### PR TITLE
Add full-fidelity entries table for complete JSONL ingest (🎯T9.1)

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -9,7 +9,7 @@ new product. The pre-1.0 period exists to get these surfaces right.
 
 ## Interaction surface catalogue
 
-Snapshot as of v0.8.0.
+Snapshot as of v0.9.0.
 
 ### CLI flags
 
@@ -113,7 +113,9 @@ stored in indexed `session_nonces` table. The mechanism may evolve.
 
 | Table/View | Columns | Stability |
 |---|---|---|
-| `messages` | id, session_id, project, role, text, timestamp, type, is_noise, content_type, tool_name, tool_use_id, tool_input (JSONB), is_error | Needs review |
+| `entries` | id, session_id, project, type, timestamp, raw (JSONB) | Needs review |
+| `entries` (virtual) | model, stop_reason, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, agent_id, version, slug, is_sidechain, data_type, data_command, data_hook_event, top_tool_use_id, parent_tool_use_id | Needs review |
+| `messages` | id, entry_id, session_id, project, role, text, timestamp, type, is_noise, content_type, tool_name, tool_use_id, tool_input (JSONB), is_error | Needs review |
 | `messages` (virtual) | tool_file_path, tool_command, tool_pattern, tool_description, tool_skill, tool_old_string, tool_new_string, tool_content, tool_query, tool_url, tool_name_param, tool_prompt, tool_subject, tool_status, tool_task_id | Needs review |
 | `messages_fts` | FTS5 virtual table matching `messages` (excludes noise) | Stable |
 | `sessions` | View joining session_summary + session_meta: session_id, project, session_type, repo, git_branch, work_type, topic, total_msgs, substantive_msgs, first_msg, last_msg | Needs review |
@@ -122,12 +124,15 @@ stored in indexed `session_nonces` table. The mechanism may evolve.
 | `session_nonces` | nonce → session_id mapping for mnemo_self | Fluid |
 | `ingest_state` | path, offset | Fluid |
 
-**Notes**: The `messages` schema expanded significantly in v0.3.0 with
-content block columns (content_type, tool_name, tool_use_id, tool_input,
-is_error) and virtual computed columns. This surface is still evolving.
-`ingest_state` and `session_nonces` are internal implementation details.
+**Notes**: v0.9.0 added the `entries` table which stores every JSONL line
+as JSONB with 15 virtual columns for high-query fields. All entry types
+(user, assistant, progress, system, file-history-snapshot) are now ingested.
+`messages` gained `entry_id` FK linking content blocks to their source entry.
+This surface is still evolving. `ingest_state` and `session_nonces` are
+internal implementation details.
 
-Content types: `text`, `tool_use`, `tool_result`, `thinking`.
+Entry types: `user`, `assistant`, `progress`, `system`, `file-history-snapshot`.
+Content types (messages): `text`, `tool_use`, `tool_result`, `thinking`.
 
 ### Output formats
 
@@ -158,8 +163,6 @@ configurable before 1.0.
 - **Session metadata completeness**: repo, work_type, and topic are
   extracted heuristically and may be missing or inaccurate. Extraction
   quality should be audited before locking the schema.
-- **System entry indexing**: System entries (hooks, stop reasons) are
-  not yet indexed. The ingest pipeline skips non-user/assistant entries.
 
 ## Out of scope for 1.0
 

--- a/docs/convergence-report.md
+++ b/docs/convergence-report.md
@@ -1,12 +1,13 @@
 # Convergence Report
 
-Standing invariants: all green. Tests pass, CI green (v0.7.0 release succeeded).
+Standing invariants: all green. Tests pass, CI green (v0.8.0 release succeeded).
 
 ## Movement
 
-- 🎯T9: (new — added since last report, with 6 sub-targets)
-- 🎯T3: (unchanged) not started
-- 🎯T8: (unchanged) not started
+- 🎯T3: not started → **achieved** (mnemo_recent_activity tool implemented and released in v0.8.0)
+- 🎯T8: not started → **achieved** (sqldeep integration merged and released in v0.8.0)
+- 🎯T10: (new — live context compaction target added)
+- 🎯T9.1: (unchanged) not started
 - 🎯T5: (unchanged) not started
 - 🎯T7: (unchanged) not started
 - 🎯T1: (unchanged) not started
@@ -14,27 +15,27 @@ Standing invariants: all green. Tests pass, CI green (v0.7.0 release succeeded).
 
 ## Gap report
 
-### 🎯T3 Active work dashboard data  [weight 1.6]
+### 🎯T9.1 Full-fidelity ingest  [weight 1.6]
 Gap: **not started**
-No `mnemo_recent_activity` tool exists. The data needed (session recency, message counts) is available in the database via `sessions` view, but no dedicated tool exposes the structured JSON output the acceptance criteria require.
+No usage, model, stop_reason, agentId, or version fields in the store schema. Messages table stores only id, session_id, project, role, text, block_type, tool_name, tool_id, timestamp, seq. No JSONB storage. Full schema redesign and re-index required.
 
-### 🎯T8 sqldeep integration  [weight 1.2]
+### 🎯T10 Live context compaction  [weight 1.25]
 Gap: **not started**
-No sqldeep references in the codebase. `mnemo_query` accepts only plain SQL. No transpilation layer.
+No mnemo_restore tool, no summarizer spawning logic, no compaction infrastructure. References to "compaction" and "summarizer" exist only in docs/targets.md. Depends on jevon `claude.Process` / `manager.Manager` which is an external dependency.
+
+### 🎯T5 Self-improving tool discovery  [weight 1.1]
+Gap: **not started** (status only)
+No pattern discovery tool or workaround detection logic in the codebase.
 
 ### 🎯T9 Full-fidelity ingest and observability tools  [weight 1.1]
 Gap: **not started** (converging 0/6 sub-targets achieved)
 
-  [ ] 🎯T9.1 Full-fidelity ingest (weight 1.6) — not started: no usage/model/stop_reason fields in store schema
+  [ ] 🎯T9.1 Full-fidelity ingest (weight 1.6) — not started
   [ ] 🎯T9.2 Token usage analytics (weight 2.7) — not started, blocked by 🎯T9.1
   [ ] 🎯T9.3 Permission prompt analysis (weight 1.7) — not started, blocked by 🎯T9.1
   [ ] 🎯T9.4 Process attribution (weight 2.5) — not started, blocked by 🎯T9.1
   [ ] 🎯T9.5 System correlation (weight 1.0) — not started, blocked by 🎯T9.1
   [ ] 🎯T9.6 Cross-session decision recall (weight 1.6) — not started, blocked by 🎯T9.1
-
-### 🎯T5 Self-improving tool discovery  [weight 1.1]
-Gap: **not started** (status only)
-No pattern discovery tool or workaround detection logic.
 
 ### 🎯T7 Agent-defined query templates  [weight 0.9]
 Gap: **not started** (status only)
@@ -42,9 +43,12 @@ No template system. Weight < 1.0 — cost exceeds value. Consider reframing or r
 
 ### 🎯T1 Broader memory beyond transcripts  [weight 0.6]
 Gap: **not started** (status only)
-No work beyond the design philosophy note. Weight 0.6 — cost significantly exceeds value. Consider decomposition or deferral.
+No work beyond design notes. Weight 0.6 — cost significantly exceeds value. 🎯T10 subsumes the core of this target; reassess after 🎯T10 is achieved.
 
 ### 🎯T2 Smarter session classification  [weight 1.7]
+Gap: **achieved**
+
+### 🎯T3 Active work dashboard data  [weight 1.6]
 Gap: **achieved**
 
 ### 🎯T4 Individual session transcript access  [weight 1.7]
@@ -53,18 +57,34 @@ Gap: **achieved**
 ### 🎯T6 Session self-identification  [weight 1.2]
 Gap: **achieved**
 
+### 🎯T8 sqldeep integration  [weight 1.2]
+Gap: **achieved**
+
 ## Recommendation
 
-Work on: **🎯T3 Active work dashboard data**
-Reason: Highest effective weight (1.6) among non-achieved, unblocked targets. Clear acceptance criteria, moderate cost, and high value for cross-tool integration. The underlying data already exists in the sessions view — this is primarily a tool definition and structured output task. While 🎯T9.2 has higher weight (2.7), it is blocked by 🎯T9.1 which requires schema redesign and full re-index.
+Work on: **🎯T9.1 Full-fidelity ingest**
+
+Both the markdown ranking and bullseye agree: 🎯T9.1 is the highest-leverage next step. It has the highest effective weight among unblocked non-achieved targets (markdown: 1.6, bullseye: 2) and it is the critical-path gate for 5 downstream targets (🎯T9.2 through 🎯T9.6), several of which have very high weights (🎯T9.2 at 2.7, 🎯T9.4 at 2.5). Completing 🎯T9.1 unlocks the entire observability tools suite.
+
+While 🎯T10 has the highest raw value (10), it depends on an external API (jevon `claude.Process`) and has no downstream dependents to unblock. 🎯T9.1 is purely internal work with a clear path and outsized multiplier effect.
 
 ## Suggested action
 
-Add a `mnemo_recent_activity` tool to `internal/tools/tools.go` that queries the `sessions` view grouped by repo, returning per-repo JSON with last session time, message count, and key topics. Start by defining the tool schema and Backend interface method, then implement the store query. Accept a `days` parameter (default 7) for the recency window.
+Design the new schema for full-fidelity ingest. Read `internal/store/store.go` to understand the current schema, then extend the `messages` table (or add a new `entries` table) to store the full JSONB entry alongside extracted virtual columns for `model`, `stop_reason`, `usage.input_tokens`, `usage.output_tokens`, `agentId`, and `version`. Bump the schema version constant to trigger a full re-index. Start with schema changes and the ingest path — tools come in subsequent sub-targets.
+
+## Bullseye scorecard
+
+**Ranking**:        +1
+**Blocking**:       +1
+**Data quality**:   -1
+**Overall**:        0
+**Markdown rec**:   🎯T9.1 Full-fidelity ingest
+**Bullseye rec**:   🎯T9.1 Full-fidelity ingest
+**Notes**: Ranking +1: bullseye's integer weights gave a clearer separation between T9.1 (weight 2) and T10 (weight 1) than markdown's 1.6 vs 1.25. Blocking +1: bullseye correctly identified all 5 T9.x sub-targets as blocked by T9.1, matching markdown's Gates analysis. Data quality -1: fresh bootstrap — all targets imported but the T10 dependency on external jevon API is not modeled as a depends_on edge in bullseye (markdown captures it as a note). Also, bullseye weights use integer rounding which loses some fidelity (T10 and T5 both show weight 1 despite different ratios). Overall 0: equivalent recommendation this run; bullseye's blocking analysis is slightly more structured, but data was just bootstrapped so hasn't been tested over time.
 
 <!-- convergence-deps
-evaluated: 2026-04-07T12:00:00Z
-sha: ebbd6f4
+evaluated: 2026-04-07T18:00:00Z
+sha: 6a54f25
 
 🎯T2:
   gap: achieved
@@ -79,8 +99,8 @@ sha: ebbd6f4
     - internal/tools/tools.go
 
 🎯T3:
-  gap: not started
-  assessment: "No mnemo_recent_activity tool. Data exists in sessions view but no structured API."
+  gap: achieved
+  assessment: "mnemo_recent_activity implemented and released in v0.8.0."
   read:
     - internal/tools/tools.go
 
@@ -91,26 +111,31 @@ sha: ebbd6f4
     - internal/tools/tools.go
 
 🎯T8:
+  gap: achieved
+  assessment: "sqldeep integration merged. mnemo_query transparently transpiles. Released in v0.8.0."
+  read:
+    - internal/tools/tools.go
+
+🎯T9.1:
   gap: not started
-  assessment: "No sqldeep references in codebase. mnemo_query accepts plain SQL only."
+  assessment: "No usage/model/stop_reason/agentId fields in store schema. No JSONB storage. Full schema redesign needed."
+  read:
+    - internal/store/store.go
+
+🎯T10:
+  gap: not started
+  assessment: "No mnemo_restore tool, no summarizer logic, no compaction infrastructure. External dependency on jevon."
   read:
     - internal/tools/tools.go
 
 🎯T5:
   gap: not started
   assessment: "No pattern discovery tool or workaround detection logic."
-  read:
-    - internal/tools/tools.go
+  read: []
 
 🎯T9:
   gap: not started
-  assessment: "New target. No sub-targets started. 0/6 achieved."
-  read:
-    - internal/store/store.go
-
-🎯T9.1:
-  gap: not started
-  assessment: "No usage/model/stop_reason/agentId fields in store schema. No JSONB storage."
+  assessment: "0/6 sub-targets achieved."
   read:
     - internal/store/store.go
 
@@ -146,6 +171,14 @@ sha: ebbd6f4
 
 🎯T1:
   gap: not started
-  assessment: "No work beyond design notes. Weight 0.6 — consider decomposition."
+  assessment: "No work beyond design notes. Weight 0.6 — T10 subsumes core."
   read: []
+
+bullseye:
+  ranking: 1
+  blocking: 1
+  data_quality: -1
+  overall: 0
+  markdown_rec: T9.1
+  bullseye_rec: T9.1
 -->

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -193,7 +193,8 @@ stop reasons, Claude Code version, agent IDs, and more.
 - **Value**: 8
 - **Cost**: 5
 - **Weight**: 1.6 (value 8 / cost 5)
-- **Status**: identified
+- **Status**: achieved
+- **Achieved**: 2026-04-07
 - **Parent**: 🎯T9
 
 Ingest all top-level JSONL fields and message sub-fields. Key
@@ -202,6 +203,11 @@ additions: `usage` (token counts per response), `model`, `stop_reason`,
 `toolUseResult.*` (structured tool results). Store the full entry as
 JSONB where practical; add virtual columns for high-query fields.
 Requires schema version bump (full re-index).
+
+**Implementation:** New `entries` table stores every JSONL line as
+JSONB with 15 virtual columns. All entry types ingested (progress,
+system, file-history-snapshot). Messages linked via `entry_id` FK.
+Schema version 5.
 
 #### 🎯T9.2 Token usage analytics (`mnemo_usage`)
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -157,7 +157,7 @@ END`
 
 // schemaVersion is incremented whenever the database schema changes.
 // On mismatch the database file is deleted and rebuilt from transcripts.
-const schemaVersion = 4
+const schemaVersion = 5
 
 func openDB(dbPath string) (*sql.DB, error) {
 	db, err := sql.Open("sqlite3", dbPath)
@@ -209,8 +209,33 @@ func New(dbPath, projectDir string) (*Store, error) {
 
 	// Create tables.
 	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS entries (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id TEXT NOT NULL,
+			project TEXT NOT NULL,
+			type TEXT NOT NULL,
+			timestamp TEXT,
+			raw BLOB,
+			-- Virtual columns for high-query entry-level fields.
+			model TEXT GENERATED ALWAYS AS (raw->>'$.message.model'),
+			stop_reason TEXT GENERATED ALWAYS AS (raw->>'$.message.stop_reason'),
+			input_tokens INTEGER GENERATED ALWAYS AS (json_extract(raw, '$.message.usage.input_tokens')),
+			output_tokens INTEGER GENERATED ALWAYS AS (json_extract(raw, '$.message.usage.output_tokens')),
+			cache_read_tokens INTEGER GENERATED ALWAYS AS (json_extract(raw, '$.message.usage.cache_read_input_tokens')),
+			cache_creation_tokens INTEGER GENERATED ALWAYS AS (json_extract(raw, '$.message.usage.cache_creation_input_tokens')),
+			agent_id TEXT GENERATED ALWAYS AS (raw->>'$.agentId'),
+			version TEXT GENERATED ALWAYS AS (raw->>'$.version'),
+			slug TEXT GENERATED ALWAYS AS (raw->>'$.slug'),
+			is_sidechain INTEGER GENERATED ALWAYS AS (CASE WHEN json_extract(raw, '$.isSidechain') THEN 1 ELSE 0 END),
+			data_type TEXT GENERATED ALWAYS AS (raw->>'$.data.type'),
+			data_command TEXT GENERATED ALWAYS AS (raw->>'$.data.command'),
+			data_hook_event TEXT GENERATED ALWAYS AS (raw->>'$.data.hookEvent'),
+			top_tool_use_id TEXT GENERATED ALWAYS AS (raw->>'$.toolUseID'),
+			parent_tool_use_id TEXT GENERATED ALWAYS AS (raw->>'$.parentToolUseID')
+		);
 		CREATE TABLE IF NOT EXISTS messages (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			entry_id INTEGER REFERENCES entries(id),
 			session_id TEXT NOT NULL,
 			project TEXT NOT NULL,
 			role TEXT NOT NULL,
@@ -275,8 +300,19 @@ func New(dbPath, projectDir string) (*Store, error) {
 
 	// Create indexes.
 	_, err = db.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_entries_session ON entries(session_id);
+		CREATE INDEX IF NOT EXISTS idx_entries_project ON entries(project);
+		CREATE INDEX IF NOT EXISTS idx_entries_type ON entries(type);
+		CREATE INDEX IF NOT EXISTS idx_entries_timestamp ON entries(timestamp);
+		CREATE INDEX IF NOT EXISTS idx_entries_model ON entries(model) WHERE model IS NOT NULL;
+		CREATE INDEX IF NOT EXISTS idx_entries_agent_id ON entries(agent_id) WHERE agent_id IS NOT NULL;
+		CREATE INDEX IF NOT EXISTS idx_entries_data_type ON entries(data_type) WHERE data_type IS NOT NULL;
+		CREATE INDEX IF NOT EXISTS idx_entries_data_hook_event ON entries(data_hook_event) WHERE data_hook_event IS NOT NULL;
+		CREATE INDEX IF NOT EXISTS idx_entries_top_tool_use_id ON entries(top_tool_use_id) WHERE top_tool_use_id IS NOT NULL;
+		CREATE INDEX IF NOT EXISTS idx_entries_parent_tool_use_id ON entries(parent_tool_use_id) WHERE parent_tool_use_id IS NOT NULL;
 		CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id);
 		CREATE INDEX IF NOT EXISTS idx_messages_project ON messages(project);
+		CREATE INDEX IF NOT EXISTS idx_messages_entry_id ON messages(entry_id) WHERE entry_id IS NOT NULL;
 		CREATE INDEX IF NOT EXISTS idx_messages_content_type ON messages(content_type);
 		CREATE INDEX IF NOT EXISTS idx_messages_tool_name ON messages(tool_name);
 		CREATE INDEX IF NOT EXISTS idx_messages_tool_use_id ON messages(tool_use_id);
@@ -382,8 +418,9 @@ func (s *Store) Close() error {
 	return s.db.Close()
 }
 
-// parsedMessage is a single message ready for insertion.
+// parsedMessage is a single content block ready for insertion.
 type parsedMessage struct {
+	entryIdx    int // index into parsedFile.entries
 	role        string
 	text        string
 	timestamp   string
@@ -396,11 +433,19 @@ type parsedMessage struct {
 	isError     int
 }
 
+// parsedRawEntry is a raw JSONL line ready for insertion into the entries table.
+type parsedRawEntry struct {
+	entryType string
+	timestamp string
+	raw       []byte // full JSONL line
+}
+
 // parsedFile is the result of parsing a single JSONL file.
 type parsedFile struct {
 	path      string
 	sessionID string
 	project   string
+	entries   []parsedRawEntry
 	messages  []parsedMessage
 	cwd       string
 	branch    string
@@ -485,13 +530,7 @@ func (s *Store) IngestAll() error {
 	}()
 
 	// Stage 3: Writer — single goroutine, batched transactions.
-	const commitInterval = 200 * time.Millisecond
-	const insertSQL = `INSERT INTO messages
-		(session_id, project, role, text, timestamp, type, is_noise,
-		 content_type, tool_name, tool_use_id, tool_input, is_error)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, jsonb(?), ?)`
-
-	if err := s.runWriter(parsedCh, insertSQL); err != nil {
+	if err := s.runWriter(parsedCh); err != nil {
 		return err
 	}
 
@@ -504,44 +543,75 @@ func (s *Store) IngestAll() error {
 	return nil
 }
 
+const (
+	entryInsertSQL = `INSERT INTO entries
+		(session_id, project, type, timestamp, raw)
+		VALUES (?, ?, ?, ?, jsonb(?))`
+	messageInsertSQL = `INSERT INTO messages
+		(entry_id, session_id, project, role, text, timestamp, type, is_noise,
+		 content_type, tool_name, tool_use_id, tool_input, is_error)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, jsonb(?), ?)`
+)
+
+// writerState holds prepared statements for the two-table insert.
+type writerState struct {
+	tx       *sql.Tx
+	entryStmt *sql.Stmt
+	msgStmt   *sql.Stmt
+}
+
+func newWriterState(db *sql.DB) (*writerState, error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	entryStmt, err := tx.Prepare(entryInsertSQL)
+	if err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+	msgStmt, err := tx.Prepare(messageInsertSQL)
+	if err != nil {
+		entryStmt.Close()
+		tx.Rollback()
+		return nil, err
+	}
+	return &writerState{tx: tx, entryStmt: entryStmt, msgStmt: msgStmt}, nil
+}
+
+func (ws *writerState) Close() {
+	ws.entryStmt.Close()
+	ws.msgStmt.Close()
+}
+
 // runWriter is the single-goroutine writer for the parallel ingest pipeline.
 // It consumes parsed files from the channel and inserts them in batched
 // transactions, yielding the write lock every 200ms for readers.
-func (s *Store) runWriter(parsedCh <-chan parsedFile, insertSQL string) error {
+func (s *Store) runWriter(parsedCh <-chan parsedFile) error {
 	const commitInterval = 200 * time.Millisecond
 
 	s.rwmu.Lock()
 	defer s.rwmu.Unlock()
 
-	tx, err := s.db.Begin()
+	ws, err := newWriterState(s.db)
 	if err != nil {
 		return err
 	}
-	defer func() { tx.Rollback() }()
-
-	stmt, err := tx.Prepare(insertSQL)
-	if err != nil {
-		return err
-	}
-	defer func() { stmt.Close() }()
+	defer func() { ws.tx.Rollback() }()
+	defer ws.Close()
 
 	lastCommit := time.Now()
 
 	commitBatch := func() error {
-		stmt.Close()
-		if err := tx.Commit(); err != nil {
+		ws.Close()
+		if err := ws.tx.Commit(); err != nil {
 			return err
 		}
 		// Yield write lock for readers.
 		s.rwmu.Unlock()
 		s.rwmu.Lock()
-		tx, err = s.db.Begin()
+		ws, err = newWriterState(s.db)
 		if err != nil {
-			return err
-		}
-		stmt, err = tx.Prepare(insertSQL)
-		if err != nil {
-			tx.Rollback()
 			return err
 		}
 		lastCommit = time.Now()
@@ -549,17 +619,32 @@ func (s *Store) runWriter(parsedCh <-chan parsedFile, insertSQL string) error {
 	}
 
 	for pf := range parsedCh {
+		// Insert all raw entries and build entryIdx→entryID map.
+		entryIDs := make(map[int]int64, len(pf.entries))
+		for i, e := range pf.entries {
+			result, err := ws.entryStmt.Exec(pf.sessionID, pf.project, e.entryType, e.timestamp, string(e.raw))
+			if err != nil {
+				slog.Warn("entry insert failed", "session", pf.sessionID, "err", err)
+				continue
+			}
+			if id, err := result.LastInsertId(); err == nil {
+				entryIDs[i] = id
+			}
+		}
+
+		// Insert content block messages linked to their entries.
 		for _, m := range pf.messages {
 			var toolInput any
 			if m.toolInput != nil {
 				toolInput = string(m.toolInput)
 			}
-			stmt.Exec(pf.sessionID, pf.project, m.role, m.text, m.timestamp, m.typ, m.isNoise,
+			entryID := entryIDs[m.entryIdx]
+			ws.msgStmt.Exec(entryID, pf.sessionID, pf.project, m.role, m.text, m.timestamp, m.typ, m.isNoise,
 				m.contentType, m.toolName, m.toolUseID, toolInput, m.isError)
 
 			// Detect self-identification nonces.
 			if m.contentType == "text" && strings.HasPrefix(m.text, NoncePrefix) {
-				tx.Exec("INSERT OR IGNORE INTO session_nonces (nonce, session_id) VALUES (?, ?)",
+				ws.tx.Exec("INSERT OR IGNORE INTO session_nonces (nonce, session_id) VALUES (?, ?)",
 					strings.TrimSpace(m.text), pf.sessionID)
 			}
 		}
@@ -568,7 +653,7 @@ func (s *Store) runWriter(parsedCh <-chan parsedFile, insertSQL string) error {
 		if pf.cwd != "" || pf.branch != "" || pf.topic != "" {
 			repo := extractRepo(pf.cwd)
 			workType := classifyWorkType(pf.branch)
-			tx.Exec(`INSERT INTO session_meta (session_id, repo, cwd, git_branch, work_type, topic)
+			ws.tx.Exec(`INSERT INTO session_meta (session_id, repo, cwd, git_branch, work_type, topic)
 				VALUES (?, ?, ?, ?, ?, ?)
 				ON CONFLICT(session_id) DO UPDATE SET
 					repo = CASE WHEN excluded.repo != '' THEN excluded.repo ELSE session_meta.repo END,
@@ -580,7 +665,7 @@ func (s *Store) runWriter(parsedCh <-chan parsedFile, insertSQL string) error {
 		}
 
 		// Update ingest offset.
-		tx.Exec("INSERT OR REPLACE INTO ingest_state (path, offset) VALUES (?, ?)", pf.path, pf.newOffset)
+		ws.tx.Exec("INSERT OR REPLACE INTO ingest_state (path, offset) VALUES (?, ?)", pf.path, pf.newOffset)
 		s.mu.Lock()
 		s.offsets[pf.path] = pf.newOffset
 		s.mu.Unlock()
@@ -594,8 +679,8 @@ func (s *Store) runWriter(parsedCh <-chan parsedFile, insertSQL string) error {
 	}
 
 	// Final commit.
-	stmt.Close()
-	return tx.Commit()
+	ws.Close()
+	return ws.tx.Commit()
 }
 
 // parseFile reads and parses a JSONL transcript file, returning all
@@ -641,6 +726,22 @@ func parseFile(path string, offset int64) (parsedFile, error) {
 			pf.branch = entry.GitBranch
 		}
 
+		ts := entry.Timestamp
+		if ts == "" {
+			ts = time.Now().Format(time.RFC3339)
+		}
+
+		// Store every JSONL line in the entries table.
+		rawCopy := make([]byte, len(line))
+		copy(rawCopy, line)
+		entryIdx := len(pf.entries)
+		pf.entries = append(pf.entries, parsedRawEntry{
+			entryType: entry.Type,
+			timestamp: ts,
+			raw:       rawCopy,
+		})
+
+		// Only extract content blocks for user/assistant messages.
 		if entry.Type != "user" && entry.Type != "assistant" {
 			continue
 		}
@@ -648,11 +749,6 @@ func parseFile(path string, offset int64) (parsedFile, error) {
 		blocks := extractBlocks(entry.Message)
 		if len(blocks) == 0 {
 			continue
-		}
-
-		ts := entry.Timestamp
-		if ts == "" {
-			ts = time.Now().Format(time.RFC3339)
 		}
 
 		for _, b := range blocks {
@@ -673,6 +769,7 @@ func parseFile(path string, offset int64) (parsedFile, error) {
 			}
 
 			pf.messages = append(pf.messages, parsedMessage{
+				entryIdx:    entryIdx,
 				role:        entry.Type,
 				text:        b.Text,
 				timestamp:   ts,
@@ -1745,21 +1842,12 @@ func (s *Store) ingestFile(path string) error {
 	s.rwmu.Lock()
 	defer s.rwmu.Unlock()
 
-	tx, err := s.db.Begin()
+	ws, err := newWriterState(s.db)
 	if err != nil {
 		return err
 	}
-	defer func() { tx.Rollback() }()
-
-	const insertSQL = `INSERT INTO messages
-		(session_id, project, role, text, timestamp, type, is_noise,
-		 content_type, tool_name, tool_use_id, tool_input, is_error)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, jsonb(?), ?)`
-	stmt, err := tx.Prepare(insertSQL)
-	if err != nil {
-		return err
-	}
-	defer func() { stmt.Close() }()
+	defer func() { ws.tx.Rollback() }()
+	defer ws.Close()
 
 	lockAcquired := time.Now()
 	linesSinceLockCheck := 0
@@ -1783,56 +1871,62 @@ func (s *Store) ingestFile(path string) error {
 			metaBranch = entry.GitBranch
 		}
 
-		if entry.Type != "user" && entry.Type != "assistant" {
-			// TODO: index system entries in a future pass.
-			continue
-		}
-
-		blocks := extractBlocks(entry.Message)
-		if len(blocks) == 0 {
-			continue
-		}
-
 		ts := entry.Timestamp
 		if ts == "" {
 			ts = time.Now().Format(time.RFC3339)
 		}
 
-		for _, b := range blocks {
-			noise := 0
-			if b.ContentType == "text" && isNoise(b.Text) {
-				noise = 1
-			}
-			// Capture first substantive user text message as topic.
-			if metaTopic == "" && entry.Type == "user" && b.ContentType == "text" && noise == 0 && len(b.Text) >= 10 && !isBoilerplate(b.Text) {
-				metaTopic = b.Text
-				if len(metaTopic) > 200 {
-					metaTopic = metaTopic[:197] + "..."
+		// Insert every JSONL line into entries table.
+		var entryID int64
+		result, entryErr := ws.entryStmt.Exec(sessionID, project, entry.Type, ts, string(line))
+		if entryErr == nil {
+			entryID, _ = result.LastInsertId()
+		}
+
+		// Only extract content blocks for user/assistant messages.
+		if entry.Type != "user" && entry.Type != "assistant" {
+			goto yieldCheck
+		}
+
+		{
+			blocks := extractBlocks(entry.Message)
+			for _, b := range blocks {
+				noise := 0
+				if b.ContentType == "text" && isNoise(b.Text) {
+					noise = 1
 				}
-			}
+				// Capture first substantive user text message as topic.
+				if metaTopic == "" && entry.Type == "user" && b.ContentType == "text" && noise == 0 && len(b.Text) >= 10 && !isBoilerplate(b.Text) {
+					metaTopic = b.Text
+					if len(metaTopic) > 200 {
+						metaTopic = metaTopic[:197] + "..."
+					}
+				}
 
-			// tool_input: pass raw JSON or nil.
-			var toolInput any
-			if b.ToolInput != nil {
-				toolInput = string(b.ToolInput)
-			}
+				// tool_input: pass raw JSON or nil.
+				var toolInput any
+				if b.ToolInput != nil {
+					toolInput = string(b.ToolInput)
+				}
 
-			isErr := 0
-			if b.IsError {
-				isErr = 1
-			}
+				isErr := 0
+				if b.IsError {
+					isErr = 1
+				}
 
-			stmt.Exec(sessionID, project, entry.Type, b.Text, ts, entry.Type, noise,
-				b.ContentType, b.ToolName, b.ToolUseID, toolInput, isErr)
-			count++
+				ws.msgStmt.Exec(entryID, sessionID, project, entry.Type, b.Text, ts, entry.Type, noise,
+					b.ContentType, b.ToolName, b.ToolUseID, toolInput, isErr)
+				count++
 
-			// Detect self-identification nonces.
-			if b.ContentType == "text" && strings.HasPrefix(b.Text, NoncePrefix) {
-				nonce := strings.TrimSpace(b.Text)
-				tx.Exec("INSERT OR IGNORE INTO session_nonces (nonce, session_id) VALUES (?, ?)", nonce, sessionID)
+				// Detect self-identification nonces.
+				if b.ContentType == "text" && strings.HasPrefix(b.Text, NoncePrefix) {
+					nonce := strings.TrimSpace(b.Text)
+					ws.tx.Exec("INSERT OR IGNORE INTO session_nonces (nonce, session_id) VALUES (?, ?)", nonce, sessionID)
+				}
 			}
 		}
 
+	yieldCheck:
 		// Periodically yield the write lock so readers aren't starved.
 		linesSinceLockCheck++
 		if linesSinceLockCheck >= lineCheckInterval {
@@ -1840,10 +1934,10 @@ func (s *Store) ingestFile(path string) error {
 			if time.Since(lockAcquired) >= yieldInterval {
 				// Commit current transaction with offset update.
 				curOffset, _ := f.Seek(0, 1)
-				tx.Exec("INSERT OR REPLACE INTO ingest_state (path, offset) VALUES (?, ?)", path, curOffset)
+				ws.tx.Exec("INSERT OR REPLACE INTO ingest_state (path, offset) VALUES (?, ?)", path, curOffset)
 
-				stmt.Close()
-				if err := tx.Commit(); err != nil {
+				ws.Close()
+				if err := ws.tx.Commit(); err != nil {
 					return err
 				}
 
@@ -1857,11 +1951,7 @@ func (s *Store) ingestFile(path string) error {
 				lockAcquired = time.Now()
 
 				// Start a new transaction.
-				tx, err = s.db.Begin()
-				if err != nil {
-					return err
-				}
-				stmt, err = tx.Prepare(insertSQL)
+				ws, err = newWriterState(s.db)
 				if err != nil {
 					return err
 				}
@@ -1873,7 +1963,7 @@ func (s *Store) ingestFile(path string) error {
 	if metaCwd != "" || metaBranch != "" || metaTopic != "" {
 		repo := extractRepo(metaCwd)
 		workType := classifyWorkType(metaBranch)
-		tx.Exec(`INSERT INTO session_meta (session_id, repo, cwd, git_branch, work_type, topic)
+		ws.tx.Exec(`INSERT INTO session_meta (session_id, repo, cwd, git_branch, work_type, topic)
 			VALUES (?, ?, ?, ?, ?, ?)
 			ON CONFLICT(session_id) DO UPDATE SET
 				repo = CASE WHEN excluded.repo != '' THEN excluded.repo ELSE session_meta.repo END,
@@ -1885,9 +1975,10 @@ func (s *Store) ingestFile(path string) error {
 	}
 
 	newOffset, _ := f.Seek(0, 1)
-	tx.Exec("INSERT OR REPLACE INTO ingest_state (path, offset) VALUES (?, ?)", path, newOffset)
+	ws.tx.Exec("INSERT OR REPLACE INTO ingest_state (path, offset) VALUES (?, ?)", path, newOffset)
 
-	if err := tx.Commit(); err != nil {
+	ws.Close()
+	if err := ws.tx.Commit(); err != nil {
 		return err
 	}
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -691,6 +691,217 @@ func TestToolUseIngest(t *testing.T) {
 	}
 }
 
+func TestEntriesTable(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// Build a transcript with multiple entry types: user, assistant (with model/usage),
+	// progress, and system.
+	writeJSONL(t, projectDir, "myproject", "sess-entries", []map[string]any{
+		// System entry (gitStatus).
+		{
+			"type":      "system",
+			"timestamp": "2026-04-01T10:00:00Z",
+			"cwd":       "/Users/dev/work/github.com/acme/webapp",
+			"gitBranch": "feature/entries",
+			"version":   "2.1.81",
+			"message":   map[string]any{"content": "system init"},
+		},
+		// User message.
+		{
+			"type":      "user",
+			"timestamp": "2026-04-01T10:00:01Z",
+			"cwd":       "/Users/dev/work/github.com/acme/webapp",
+			"gitBranch": "feature/entries",
+			"version":   "2.1.81",
+			"message":   map[string]any{"content": "Build the new feature"},
+		},
+		// Assistant with model and usage.
+		{
+			"type":      "assistant",
+			"timestamp": "2026-04-01T10:00:05Z",
+			"cwd":       "/Users/dev/work/github.com/acme/webapp",
+			"gitBranch": "feature/entries",
+			"version":   "2.1.81",
+			"slug":      "myproject-sess-entries",
+			"message": map[string]any{
+				"role": "assistant",
+				"content": []any{
+					map[string]any{
+						"type": "text",
+						"text": "I'll build the feature now.",
+					},
+				},
+				"model":       "claude-opus-4-6",
+				"stop_reason": "end_turn",
+				"usage": map[string]any{
+					"input_tokens":                50000,
+					"output_tokens":               500,
+					"cache_read_input_tokens":      45000,
+					"cache_creation_input_tokens":  1000,
+				},
+			},
+		},
+		// Progress event (bash).
+		{
+			"type":            "progress",
+			"timestamp":       "2026-04-01T10:00:10Z",
+			"parentToolUseID": "toolu_abc123",
+			"agentId":         "agent-xyz",
+			"data": map[string]any{
+				"type":    "bash_progress",
+				"command": "make build",
+				"output":  "Building...",
+			},
+		},
+		// Progress event (hook).
+		{
+			"type":            "progress",
+			"timestamp":       "2026-04-01T10:00:15Z",
+			"parentToolUseID": "toolu_abc123",
+			"data": map[string]any{
+				"type":      "hook_progress",
+				"hookEvent": "PostToolUse",
+				"command":   "python3 hook.py",
+			},
+		},
+	})
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	// All 5 JSONL lines should be in entries.
+	rows, err := s.Query("SELECT COUNT(*) AS cnt FROM entries")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cnt, ok := rows[0]["cnt"].(int64); !ok || cnt != 5 {
+		t.Fatalf("expected 5 entries, got %v", rows[0]["cnt"])
+	}
+
+	// Verify entry types.
+	rows, err = s.Query("SELECT type, COUNT(*) AS cnt FROM entries GROUP BY type ORDER BY type")
+	if err != nil {
+		t.Fatal(err)
+	}
+	typeCounts := map[string]int64{}
+	for _, r := range rows {
+		typeCounts[r["type"].(string)] = r["cnt"].(int64)
+	}
+	if typeCounts["assistant"] != 1 {
+		t.Errorf("expected 1 assistant entry, got %d", typeCounts["assistant"])
+	}
+	if typeCounts["progress"] != 2 {
+		t.Errorf("expected 2 progress entries, got %d", typeCounts["progress"])
+	}
+	if typeCounts["system"] != 1 {
+		t.Errorf("expected 1 system entry, got %d", typeCounts["system"])
+	}
+
+	// Verify virtual columns on assistant entry.
+	rows, err = s.Query("SELECT model, stop_reason, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, version, slug FROM entries WHERE type = 'assistant'")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 assistant entry, got %d", len(rows))
+	}
+	r := rows[0]
+	if r["model"] != "claude-opus-4-6" {
+		t.Errorf("expected model claude-opus-4-6, got %v", r["model"])
+	}
+	if r["stop_reason"] != "end_turn" {
+		t.Errorf("expected stop_reason end_turn, got %v", r["stop_reason"])
+	}
+	if r["input_tokens"] != int64(50000) {
+		t.Errorf("expected input_tokens 50000, got %v", r["input_tokens"])
+	}
+	if r["output_tokens"] != int64(500) {
+		t.Errorf("expected output_tokens 500, got %v", r["output_tokens"])
+	}
+	if r["cache_read_tokens"] != int64(45000) {
+		t.Errorf("expected cache_read_tokens 45000, got %v", r["cache_read_tokens"])
+	}
+	if r["cache_creation_tokens"] != int64(1000) {
+		t.Errorf("expected cache_creation_tokens 1000, got %v", r["cache_creation_tokens"])
+	}
+	if r["version"] != "2.1.81" {
+		t.Errorf("expected version 2.1.81, got %v", r["version"])
+	}
+	if r["slug"] != "myproject-sess-entries" {
+		t.Errorf("expected slug myproject-sess-entries, got %v", r["slug"])
+	}
+
+	// Verify progress event virtual columns.
+	rows, err = s.Query("SELECT data_type, agent_id, parent_tool_use_id FROM entries WHERE type = 'progress' AND data_type = 'bash_progress'")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 bash_progress entry, got %d", len(rows))
+	}
+	if rows[0]["agent_id"] != "agent-xyz" {
+		t.Errorf("expected agent_id agent-xyz, got %v", rows[0]["agent_id"])
+	}
+	if rows[0]["parent_tool_use_id"] != "toolu_abc123" {
+		t.Errorf("expected parent_tool_use_id toolu_abc123, got %v", rows[0]["parent_tool_use_id"])
+	}
+
+	// Verify hook progress.
+	rows, err = s.Query("SELECT data_type, data_hook_event, data_command FROM entries WHERE data_type = 'hook_progress'")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 hook_progress entry, got %d", len(rows))
+	}
+	if rows[0]["data_hook_event"] != "PostToolUse" {
+		t.Errorf("expected hookEvent PostToolUse, got %v", rows[0]["data_hook_event"])
+	}
+	if rows[0]["data_command"] != "python3 hook.py" {
+		t.Errorf("expected command 'python3 hook.py', got %v", rows[0]["data_command"])
+	}
+
+	// Only user/assistant should produce messages (2 entries → content blocks).
+	rows, err = s.Query("SELECT COUNT(*) AS cnt FROM messages")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cnt, ok := rows[0]["cnt"].(int64); !ok || cnt != 2 {
+		t.Fatalf("expected 2 messages (user+assistant), got %v", rows[0]["cnt"])
+	}
+
+	// Messages should be linked to entries via entry_id.
+	rows, err = s.Query(`
+		SELECT m.text, e.model, e.version
+		FROM messages m
+		JOIN entries e ON e.id = m.entry_id
+		WHERE m.role = 'assistant'
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 joined row, got %d", len(rows))
+	}
+	if rows[0]["model"] != "claude-opus-4-6" {
+		t.Errorf("expected model from join, got %v", rows[0]["model"])
+	}
+
+	// Verify raw JSON access via json_extract.
+	rows, err = s.Query("SELECT json_extract(raw, '$.data.output') AS output FROM entries WHERE data_type = 'bash_progress'")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row for raw json_extract, got %d", len(rows))
+	}
+	if rows[0]["output"] != "Building..." {
+		t.Errorf("expected raw output 'Building...', got %v", rows[0]["output"])
+	}
+}
+
 func TestSchemaVersionRebuild(t *testing.T) {
 	projectDir := t.TempDir()
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -74,12 +74,29 @@ sqldeep example — repos with their recent sessions:
   GROUP BY sm.repo
 
 Tables:
-  messages (id, session_id, project, role, text, timestamp, type, is_noise)
+  entries (id, session_id, project, type, timestamp, raw)
+    — every JSONL line stored as JSONB in 'raw'. Virtual columns:
+      model, stop_reason, input_tokens, output_tokens,
+      cache_read_tokens, cache_creation_tokens, agent_id, version,
+      slug, is_sidechain, data_type, data_command, data_hook_event,
+      top_tool_use_id, parent_tool_use_id
+    — entry types: user, assistant, progress, system, file-history-snapshot
+    — use json_extract(raw, '$.path') for fields without virtual columns
+  messages (id, entry_id, session_id, project, role, text, timestamp, type, is_noise)
+    — content blocks from user/assistant entries. entry_id links to entries.
+    — tool_use fields: tool_name, tool_use_id, tool_input (JSONB), content_type
+    — virtual columns from tool_input: tool_file_path, tool_command, etc.
   messages_fts — FTS5 virtual table (excludes noise). Use: WHERE messages_fts MATCH 'terms'
   sessions — view: session_id, project, session_type, total_msgs, substantive_msgs, first_msg, last_msg
   session_meta (session_id, repo, cwd, git_branch, work_type, topic)
   session_summary (session_id, project, session_type, total_msgs, substantive_msgs, first_msg, last_msg)
-  ingest_state (path, offset)
+
+Join pattern — message with its entry metadata:
+  SELECT m.text, e.model, e.input_tokens FROM messages m JOIN entries e ON e.id = m.entry_id
+
+Token usage query:
+  SELECT date(timestamp) AS day, SUM(input_tokens) AS input, SUM(output_tokens) AS output
+  FROM entries WHERE type = 'assistant' GROUP BY day ORDER BY day DESC
 
 Session types (derived from project path): interactive, subagent, worktree, ephemeral.
 is_noise = 1 for interrupts, compaction summaries, tool-loaded markers, slash command markup.

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ import (
 //go:embed agents-guide.md
 var agentsGuide string
 
-const version = "0.8.0"
+const version = "0.9.0"
 
 func main() {
 	showVersion := flag.Bool("version", false, "print version and exit")

--- a/targets.yaml
+++ b/targets.yaml
@@ -1,0 +1,224 @@
+targets:
+  T1:
+    name: Broader memory beyond transcripts
+    status: identified
+    value: 8.0
+    cost: 13.0
+    acceptance:
+    - Data model extends beyond raw transcript messages
+    - Decisions, preferences, and project context tracked across sessions
+    - Summarisation layer distills sessions into key facts
+    context: mnemo evolves from transcript search into a general memory system. T10 (live context compaction) addresses the core. Once T10 achieved, reassess residual scope.
+    origin: targets.md bootstrap
+    discovered: 2026-04-07
+  T10:
+    name: Live context compaction
+    status: identified
+    value: 10.0
+    cost: 8.0
+    acceptance:
+    - Summarizer spawns automatically for active sessions (not for its own sessions)
+    - Compacted context available within 2s of mnemo_restore call
+    - Compaction survives /clear boundaries within a session
+    - Idle reaping cleans up summarizer instances
+    - mnemo_restore in fresh post-clear segment returns useful context
+    - Token cost of summarizer < 10% of the session it tracks
+    context: mnemo maintains a live compacted context for each active session. When a session /clears, the compacted context is available instantly via mnemo_restore. Depends on jevon claude.Process / manager.Manager for Claude instance lifecycle.
+    origin: targets.md bootstrap
+    discovered: 2026-04-07
+  T2:
+    name: Smarter session classification
+    status: achieved
+    value: 5.0
+    cost: 3.0
+    acceptance:
+    - Sessions tagged with repo(s) they operated on
+    - Sessions tagged with work type (feature, bugfix, review, etc.)
+    - Key topics extracted and searchable
+    - mnemo_sessions supports filtering by repo and work type
+    context: Session classification goes beyond path-based heuristics to understand content and purpose.
+    origin: targets.md bootstrap
+    discovered: 2026-04-07
+    achieved: 2026-04-07
+  T3:
+    name: Active work dashboard data
+    status: achieved
+    value: 8.0
+    cost: 5.0
+    acceptance:
+    - mnemo_recent_activity tool returns per-repo summary of recent session activity
+    - Output is structured JSON for consumers
+    - 'Configurable recency window (default: 7 days)'
+    context: mnemo exposes API for cross-referencing recent transcript sessions with external signals to produce unified view of active work.
+    origin: targets.md bootstrap
+    discovered: 2026-04-07
+    achieved: 2026-04-07
+  T4:
+    name: Individual session transcript access
+    status: achieved
+    value: 5.0
+    cost: 3.0
+    acceptance:
+    - mnemo_read_session returns messages from a specific session ID
+    - Supports filtering by role, offset, limit
+    - Works on raw JSONL files, not just indexed database
+    - No mutation of transcript files
+    context: mnemo can read and search within individual session transcripts. Absorbs jevon transcript_read functionality.
+    origin: targets.md bootstrap
+    discovered: 2026-04-07
+    achieved: 2026-04-07
+  T5:
+    name: Self-improving tool discovery
+    status: identified
+    value: 9.0
+    cost: 8.0
+    acceptance:
+    - mnemo_discover_patterns tool identifies workaround sessions
+    - Detects direct JSONL reads, grep over transcript dirs, repeated query shapes
+    - 'Output: candidate features with evidence'
+    - Integrates with template system (T7)
+    context: mnemo mines its own transcript index to discover patterns suggesting missing features. Feeds the feedback loop.
+    origin: targets.md bootstrap
+    discovered: 2026-04-07
+  T6:
+    name: Session self-identification
+    status: achieved
+    value: 6.0
+    cost: 5.0
+    acceptance:
+    - Agent can retrieve own session messages in a single tool call without knowing session ID
+    - Works reliably (not a fragile heuristic)
+    context: A session can discover its own transcript and query it via nonce protocol.
+    origin: targets.md bootstrap
+    discovered: 2026-04-07
+    achieved: 2026-04-07
+  T7:
+    name: Agent-defined query templates
+    status: identified
+    value: 7.0
+    cost: 8.0
+    acceptance:
+    - mnemo_define stores named parameterised query template
+    - mnemo_evaluate executes template by name with parameters
+    - mnemo_list_templates shows available templates
+    - Templates persist in SQLite across sessions
+    - mnemo_query nudges agents to define templates for complex queries
+    context: Agents can define reusable parameterised query templates that persist across sessions.
+    origin: targets.md bootstrap
+    discovered: 2026-04-07
+  T8:
+    name: sqldeep integration
+    status: achieved
+    value: 6.0
+    cost: 5.0
+    acceptance:
+    - mnemo_query transparently transpiles sqldeep syntax to SQL
+    - Plain SQL continues to work unchanged
+    - sqldeep JSON helper functions registered on SQLite connection
+    - Tool description documents available syntax
+    context: mnemo_query accepts sqldeep syntax in addition to plain SQL.
+    origin: targets.md bootstrap
+    discovered: 2026-04-07
+    achieved: 2026-04-07
+  T9:
+    name: Full-fidelity ingest and observability tools
+    status: identified
+    value: 9.0
+    cost: 8.0
+    acceptance:
+    - Field census shows 0 unindexed high-frequency fields (> 1% of entries)
+    - mnemo_usage returns daily token breakdown with cost estimates
+    - mnemo_permissions suggests concrete allowedTools rules
+    - mnemo_who_ran returns session + repo + timestamp
+    - mnemo_whatsup correlates system load with session activity
+    - mnemo_decisions returns proposal + confirmation with session context
+    context: mnemo ingests all JSONL fields (not just user/assistant message content) and exposes observability tools built on the full data. Currently discards ~70% of JSONL data.
+    origin: targets.md bootstrap
+    discovered: 2026-04-07
+  T9.1:
+    name: Full-fidelity ingest
+    status: identified
+    value: 8.0
+    cost: 5.0
+    acceptance:
+    - All top-level JSONL fields and message sub-fields ingested
+    - usage, model, stop_reason, version, slug, agentId stored
+    - Full entry stored as JSONB where practical
+    - Virtual columns for high-query fields
+    - Schema version bump with full re-index
+    context: Ingest all top-level JSONL fields and message sub-fields. Currently ~70% of data is discarded.
+    parent: T9
+    origin: targets.md bootstrap
+    discovered: 2026-04-07
+  T9.2:
+    name: Token usage analytics (mnemo_usage)
+    status: identified
+    value: 8.0
+    cost: 3.0
+    acceptance:
+    - mnemo_usage returns daily token breakdown with cost estimates
+    - Supports daily totals, per-repo breakdown, per-model breakdown
+    - Hourly rate detection
+    context: Report token consumption by day, repo, session, model with cost estimates. Data comes from message.usage fields. Gates on T9.1 (full-fidelity ingest).
+    parent: T9
+    depends_on:
+    - T9.1
+    origin: targets.md bootstrap
+    discovered: 2026-04-07
+  T9.3:
+    name: Permission prompt analysis (mnemo_permissions)
+    status: identified
+    value: 5.0
+    cost: 3.0
+    acceptance:
+    - Identifies most-used tools and frequent approval patterns
+    - Suggests concrete allowedTools rules for settings.json
+    context: Identify tool approval patterns from tool_use/tool_result pairs. Suggest allowedTools rules. Gates on T9.1.
+    parent: T9
+    depends_on:
+    - T9.1
+    origin: targets.md bootstrap
+    discovered: 2026-04-07
+  T9.4:
+    name: Process attribution (mnemo_who_ran)
+    status: identified
+    value: 5.0
+    cost: 2.0
+    acceptance:
+    - mnemo_who_ran returns session + repo + timestamp for a command pattern
+    - Matches against tool_command in recent Bash tool_use entries
+    context: Given a command pattern, find which session(s) ran it recently. Gates on T9.1.
+    parent: T9
+    depends_on:
+    - T9.1
+    origin: targets.md bootstrap
+    discovered: 2026-04-07
+  T9.5:
+    name: System correlation (mnemo_whatsup)
+    status: identified
+    value: 5.0
+    cost: 5.0
+    acceptance:
+    - Correlates current system state with active mnemo sessions
+    - Cross-references PIDs and command patterns against recent session activity
+    context: Correlate system load (CPU, disk I/O) with active sessions. Gates on T9.1.
+    parent: T9
+    depends_on:
+    - T9.1
+    origin: targets.md bootstrap
+    discovered: 2026-04-07
+  T9.6:
+    name: Cross-session decision recall (mnemo_decisions)
+    status: identified
+    value: 8.0
+    cost: 5.0
+    acceptance:
+    - mnemo_decisions searches decisions table by keyword
+    - Decision detection heuristic identifies proposal + user confirmation pairs
+    - Decisions stored in dedicated FTS5 table
+    context: Surface past decisions across all sessions. Detect decision patterns during ingest. Gates on T9.1.
+    parent: T9
+    depends_on:
+    - T9.1
+    origin: targets.md bootstrap
+    discovered: 2026-04-07

--- a/targets.yaml
+++ b/targets.yaml
@@ -137,7 +137,7 @@ targets:
     discovered: 2026-04-07
   T9.1:
     name: Full-fidelity ingest
-    status: identified
+    status: achieved
     value: 8.0
     cost: 5.0
     acceptance:
@@ -150,6 +150,7 @@ targets:
     parent: T9
     origin: targets.md bootstrap
     discovered: 2026-04-07
+    achieved: 2026-04-07
   T9.2:
     name: Token usage analytics (mnemo_usage)
     status: identified


### PR DESCRIPTION
## Summary

- New `entries` table stores every JSONL transcript line as JSONB with 15 virtual columns for high-query fields (model, stop_reason, token usage, agent_id, version, slug, etc.)
- All entry types now ingested — progress events, system entries, file-history-snapshots (previously ~70% of transcript data was discarded)
- `messages` table gains `entry_id` FK linking content blocks to their source entry
- Schema version bumped to 5 (triggers full re-index)
- `mnemo_query` tool description updated to document the new schema
- STABILITY.md updated for v0.9.0
- Version bumped to 0.9.0

## Test plan

- [x] `TestEntriesTable` — verifies all entry types stored, virtual columns extracted correctly, messages linked via entry_id, raw JSON access works
- [x] All existing tests pass (TestIngestAndSearch, TestListSessions, TestReadSession, TestStats, TestQuery, TestSessionMetadata, TestSessionTypeFiltering, TestIncrementalIngest, TestToolUseIngest, TestSchemaVersionRebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)