### PR TITLE
Add file-history-snapshot indexing and new data source targets (🎯T14)

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -9,7 +9,7 @@ new product. The pre-1.0 period exists to get these surfaces right.
 
 ## Interaction surface catalogue
 
-Snapshot as of v0.9.0.
+Snapshot as of v0.10.0.
 
 ### CLI flags
 
@@ -118,6 +118,8 @@ stored in indexed `session_nonces` table. The mechanism may evolve.
 | `messages` | id, entry_id, session_id, project, role, text, timestamp, type, is_noise, content_type, tool_name, tool_use_id, tool_input (JSONB), is_error | Needs review |
 | `messages` (virtual) | tool_file_path, tool_command, tool_pattern, tool_description, tool_skill, tool_old_string, tool_new_string, tool_content, tool_query, tool_url, tool_name_param, tool_prompt, tool_subject, tool_status, tool_task_id | Needs review |
 | `messages_fts` | FTS5 virtual table matching `messages` (excludes noise) | Stable |
+| `snapshot_files` | id, entry_id, session_id, file_path, backup_time — auto-extracted via trigger from file-history-snapshot entries | Needs review |
+| `snapshot_files_fts` | FTS5 on file_path | Needs review |
 | `sessions` | View joining session_summary + session_meta: session_id, project, session_type, repo, git_branch, work_type, topic, total_msgs, substantive_msgs, first_msg, last_msg | Needs review |
 | `session_summary` | Trigger-maintained materialised table: session_id, project, session_type, total_msgs, substantive_msgs, first_msg, last_msg | Needs review |
 | `session_meta` | Per-session metadata: session_id, repo, cwd, git_branch, work_type, topic | Needs review |
@@ -128,6 +130,8 @@ stored in indexed `session_nonces` table. The mechanism may evolve.
 as JSONB with 15 virtual columns for high-query fields. All entry types
 (user, assistant, progress, system, file-history-snapshot) are now ingested.
 `messages` gained `entry_id` FK linking content blocks to their source entry.
+v0.10.0 added `snapshot_files` with trigger-based extraction from
+file-history-snapshot entries and FTS5 on file paths.
 This surface is still evolving. `ingest_state` and `session_nonces` are
 internal implementation details.
 

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -42,3 +42,8 @@ maintenance activities. Append-only — newest entries at the bottom.
 
 - **Commit**: `a593481`
 - **Outcome**: Released v0.9.0 (darwin-arm64, linux-amd64, linux-arm64). Full-fidelity ingest (🎯T9.1): new entries table stores every JSONL line as JSONB with 15 virtual columns. All entry types ingested (progress, system, file-history-snapshot). Messages linked via entry_id FK. Schema version 5 (triggers re-index). Unblocks 🎯T9.2–T9.6.
+
+## 2026-04-07 — /release v0.10.0
+
+- **Commit**: `736594c`
+- **Outcome**: Released v0.10.0 (darwin-arm64, linux-amd64, linux-arm64). File-history-snapshot indexing (🎯T14): snapshot_files table with FTS5 auto-extracted via SQL trigger. Schema version 6. New targets: 🎯T11 git history, 🎯T12 GitHub activity, 🎯T13 CI/CD history.

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -344,6 +344,126 @@ table for per-file change tracking.
 - Commit data queryable via `mnemo_query` (joins with sessions/entries).
 - Incremental — only fetches new commits since last ingest.
 
+### 🎯T12 GitHub activity indexing
+
+- **Value**: 8
+- **Cost**: 5
+- **Weight**: 1.6 (value 8 / cost 5)
+- **Status**: identified
+- **Discovered**: 2026-04-07
+- **Related**: 🎯T11 (git history), 🎯T9.6 (decision recall)
+
+**Desired state:** mnemo indexes GitHub activity (PRs, issues, reviews,
+comments) from repos that appear in session transcripts. Agents can
+search across the full corpus — "which PRs across all my repos are
+stale?", "what did the reviewer say about the auth approach?", "find
+all issues mentioning performance regression."
+
+The `gh` CLI queries one repo at a time and returns ephemeral results.
+mnemo's value is corpus-level FTS search and cross-referencing with
+session context and git history.
+
+**Architecture sketch:**
+
+The daemon periodically polls GitHub via `gh api` for repos discovered
+from `session_meta`. Ingests PRs (title, body, state, author, reviewers,
+merge status), PR reviews and comments, and issues into dedicated tables.
+FTS5 on PR/issue bodies and comments.
+
+**Tools:**
+
+- `mnemo_prs` — cross-repo PR search with filters (repo glob, state,
+  author, reviewer, date range, body/title FTS). Returns PR metadata
+  with correlated session IDs and commit hashes.
+- `mnemo_issues` — cross-repo issue search with similar filters.
+
+**Acceptance criteria:**
+- PRs and issues from repos in `session_meta` indexed automatically.
+- `mnemo_prs` supports cross-repo queries with FTS on title/body.
+- PR reviews and comments indexed and searchable.
+- Correlated with sessions (by repo + time overlap) and commits (by merge SHA).
+- Queryable via `mnemo_query` (joins with sessions/entries/commits).
+- Incremental — only fetches activity since last poll.
+
+### 🎯T13 CI/CD history and statistics
+
+- **Value**: 8
+- **Cost**: 3
+- **Weight**: 2.7 (value 8 / cost 3)
+- **Status**: identified
+- **Discovered**: 2026-04-07
+- **Related**: 🎯T12 (GitHub activity), 🎯T11 (git history)
+
+**Desired state:** mnemo indexes CI/CD run history (GitHub Actions)
+and exposes cross-repo queries over build outcomes. Agents can ask
+"has this test failed before? what fixed it?", "which repos have been
+red this week?", "what's my CI success rate by repo?"
+
+GitHub Actions logs are ephemeral (90-day retention) and per-repo.
+mnemo preserves them permanently and makes them searchable across the
+full corpus, correlated with the sessions and commits that triggered
+them.
+
+**Architecture sketch:**
+
+The daemon polls `gh api` for workflow runs from repos in `session_meta`.
+Stores run metadata (workflow name, status, conclusion, duration, trigger
+event, head SHA, branch) in a `ci_runs` table. For failed runs, fetches
+and stores the failed job log summary. FTS5 on failure messages.
+
+**Tools:**
+
+- `mnemo_ci` — cross-repo CI query with filters (repo glob, workflow,
+  conclusion, date range, branch). Returns run metadata with correlated
+  sessions and commits.
+- Failure pattern detection: "this test has failed 3 times this week
+  in 2 different repos."
+
+**Acceptance criteria:**
+- CI runs from repos in `session_meta` indexed automatically.
+- `mnemo_ci` supports cross-repo queries with status/conclusion filters.
+- Failed run logs indexed with FTS for "has this failed before?" queries.
+- Correlated with commits (by head SHA) and sessions (by repo + time).
+- Queryable via `mnemo_query`.
+- Incremental polling with configurable interval.
+
+### 🎯T14 File-history-snapshot surfacing
+
+- **Value**: 5
+- **Cost**: 2
+- **Weight**: 2.5 (value 5 / cost 2)
+- **Status**: identified
+- **Discovered**: 2026-04-07
+- **Related**: 🎯T9.1 (full-fidelity ingest — snapshots already stored)
+
+**Desired state:** The `file-history-snapshot` entries already stored
+in the `entries` table (26k+ entries) are surfaced as a queryable tool.
+Agents can track which files existed at session boundaries and how the
+working tree evolved across sessions, without running per-file git
+queries.
+
+This is low-cost because the data is already ingested — it just needs
+extraction logic and a dedicated tool or view.
+
+**Architecture sketch:**
+
+Extract file lists from `entries.raw` where `type = 'file-history-snapshot'`
+into a `file_snapshots` table (session_id, timestamp, file_path, status).
+Or expose via a view/virtual columns on the existing entries table if
+the JSON structure is simple enough.
+
+**Tools:**
+
+- `mnemo_files` — query file presence/modification across sessions.
+  "Which sessions touched store.go?", "What files were in the working
+  tree during session X?"
+
+**Acceptance criteria:**
+- File-history-snapshot data queryable via dedicated tool or view.
+- Cross-session file tracking: "which sessions touched this file?"
+- Queryable via `mnemo_query`.
+- No additional ingest needed — data already in `entries` table.
+
 ### 🎯T10 Live context compaction
 
 - **Value**: 10

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -298,6 +298,49 @@ later if keyword search proves insufficient.
 - `mnemo_decisions "relay protocol"` returns the proposal + confirmation
   with session context.
 
+### 🎯T11 Git history indexing
+
+- **Value**: 8
+- **Cost**: 5
+- **Weight**: 1.6 (value 8 / cost 5)
+- **Status**: identified
+- **Discovered**: 2026-04-07
+- **Related**: 🎯T3 (dashboard data), 🎯T9.6 (decision recall)
+
+**Desired state:** mnemo indexes Git commit history from repos that
+appear in session transcripts and cross-references commits with session
+activity. Agents can ask "what changed in this repo recently?", "which
+session produced this commit?", or "what was the reasoning behind
+changes to this file?" — all without leaving the mnemo query interface.
+
+**Architecture sketch:**
+
+The daemon discovers repos from `session_meta.cwd` paths and
+periodically runs `git log` to ingest commit metadata into a `commits`
+table. Cross-referencing uses timestamp overlap, branch name matching,
+and cwd correlation — a commit on branch `fix/auth-bug` at 10:05 likely
+came from the session on the same branch that was active at 10:05.
+
+Key fields: hash, repo, author, timestamp, branch, message, files
+changed, insertions, deletions. Stored alongside a `commit_files`
+table for per-file change tracking.
+
+**Tools:**
+
+- `mnemo_commits` — search/list commits with filters (repo, author,
+  date range, file path, message pattern). Returns commit metadata
+  with links to correlated sessions.
+- `mnemo_blame` — given a file path, show recent commits touching it
+  with session context. Answers "why was this changed?" by surfacing
+  the session discussion alongside the diff.
+
+**Acceptance criteria:**
+- Commits from repos in `session_meta` are indexed automatically.
+- `mnemo_commits` returns commits with correlated session IDs.
+- `mnemo_blame <file>` returns recent commits with session context.
+- Commit data queryable via `mnemo_query` (joins with sessions/entries).
+- Incremental — only fetches new commits since last ingest.
+
 ### 🎯T10 Live context compaction
 
 - **Value**: 10

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -307,11 +307,16 @@ later if keyword search proves insufficient.
 - **Discovered**: 2026-04-07
 - **Related**: 🎯T3 (dashboard data), 🎯T9.6 (decision recall)
 
-**Desired state:** mnemo indexes Git commit history from repos that
-appear in session transcripts and cross-references commits with session
-activity. Agents can ask "what changed in this repo recently?", "which
-session produced this commit?", or "what was the reasoning behind
-changes to this file?" — all without leaving the mnemo query interface.
+**Desired state:** mnemo indexes Git commit history from all repos
+that appear in session transcripts and exposes cross-repo, corpus-level
+queries. Single-repo git operations (log, blame, diff) are already
+well-served by Claude Code's built-in tools — mnemo's value is in
+indexed search across the entire corpus and session-commit correlation.
+
+Agents can ask "which repos had auth-related commits this week?",
+"show all commits across all projects by this author", or "what was
+the session context when this change was made?" — queries that span
+repos and join code history with conversation history.
 
 **Architecture sketch:**
 
@@ -327,17 +332,15 @@ table for per-file change tracking.
 
 **Tools:**
 
-- `mnemo_commits` — search/list commits with filters (repo, author,
-  date range, file path, message pattern). Returns commit metadata
-  with links to correlated sessions.
-- `mnemo_blame` — given a file path, show recent commits touching it
-  with session context. Answers "why was this changed?" by surfacing
-  the session discussion alongside the diff.
+- `mnemo_commits` — cross-repo commit search with filters (repo glob,
+  author, date range, file path pattern, message FTS). Returns commit
+  metadata with correlated session IDs. The cross-repo and FTS
+  capabilities are the differentiators vs built-in `git log`.
 
 **Acceptance criteria:**
 - Commits from repos in `session_meta` are indexed automatically.
-- `mnemo_commits` returns commits with correlated session IDs.
-- `mnemo_blame <file>` returns recent commits with session context.
+- `mnemo_commits` supports cross-repo queries (repo glob, date range).
+- FTS5 index on commit messages enables keyword search across corpus.
 - Commit data queryable via `mnemo_query` (joins with sessions/entries).
 - Incremental — only fetches new commits since last ingest.
 

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -432,8 +432,9 @@ and stores the failed job log summary. FTS5 on failure messages.
 - **Value**: 5
 - **Cost**: 2
 - **Weight**: 2.5 (value 5 / cost 2)
-- **Status**: identified
+- **Status**: achieved
 - **Discovered**: 2026-04-07
+- **Achieved**: 2026-04-07
 - **Related**: 🎯T9.1 (full-fidelity ingest — snapshots already stored)
 
 **Desired state:** The `file-history-snapshot` entries already stored

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -157,7 +157,7 @@ END`
 
 // schemaVersion is incremented whenever the database schema changes.
 // On mismatch the database file is deleted and rebuilt from transcripts.
-const schemaVersion = 5
+const schemaVersion = 6
 
 func openDB(dbPath string) (*sql.DB, error) {
 	db, err := sql.Open("sqlite3", dbPath)
@@ -292,6 +292,13 @@ func New(dbPath, projectDir string) (*Store, error) {
 			last_msg TEXT NOT NULL DEFAULT ''
 		);
 		CREATE INDEX IF NOT EXISTS idx_session_summary_type ON session_summary(session_type);
+		CREATE TABLE IF NOT EXISTS snapshot_files (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			entry_id INTEGER NOT NULL REFERENCES entries(id),
+			session_id TEXT NOT NULL,
+			file_path TEXT NOT NULL,
+			backup_time TEXT
+		);
 	`)
 	if err != nil {
 		db.Close()
@@ -326,10 +333,25 @@ func New(dbPath, projectDir string) (*Store, error) {
 		CREATE INDEX IF NOT EXISTS idx_messages_tool_url ON messages(tool_url) WHERE tool_url IS NOT NULL;
 		CREATE INDEX IF NOT EXISTS idx_messages_tool_task_id ON messages(tool_task_id) WHERE tool_task_id IS NOT NULL;
 		CREATE INDEX IF NOT EXISTS idx_messages_is_error ON messages(is_error) WHERE is_error = 1;
+		CREATE INDEX IF NOT EXISTS idx_snapshot_files_session ON snapshot_files(session_id);
+		CREATE INDEX IF NOT EXISTS idx_snapshot_files_entry ON snapshot_files(entry_id);
+		CREATE INDEX IF NOT EXISTS idx_snapshot_files_path ON snapshot_files(file_path);
 	`)
 	if err != nil {
 		db.Close()
 		return nil, fmt.Errorf("create indexes: %w", err)
+	}
+
+	_, err = db.Exec(`
+		CREATE VIRTUAL TABLE IF NOT EXISTS snapshot_files_fts USING fts5(
+			file_path,
+			content=snapshot_files,
+			content_rowid=id
+		);
+	`)
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("create snapshot_files FTS: %w", err)
 	}
 
 	_, err = db.Exec(`
@@ -361,6 +383,29 @@ func New(dbPath, projectDir string) (*Store, error) {
 	if err != nil {
 		db.Close()
 		return nil, fmt.Errorf("create FTS: %w", err)
+	}
+
+	// Trigger to extract file paths from file-history-snapshot entries
+	// and populate snapshot_files + its FTS index.
+	_, err = db.Exec(`
+		DROP TRIGGER IF EXISTS entries_file_snapshot;
+		CREATE TRIGGER entries_file_snapshot AFTER INSERT ON entries
+		WHEN new.type = 'file-history-snapshot'
+		BEGIN
+			INSERT INTO snapshot_files (entry_id, session_id, file_path, backup_time)
+			SELECT new.id, new.session_id, f.key, f.value->>'backupTime'
+			FROM json_each(new.raw, '$.snapshot.trackedFileBackups') f
+			WHERE f.key != '';
+
+			INSERT INTO snapshot_files_fts(rowid, file_path)
+			SELECT sf.id, sf.file_path
+			FROM snapshot_files sf
+			WHERE sf.entry_id = new.id;
+		END;
+	`)
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("create snapshot trigger: %w", err)
 	}
 
 	_, err = db.Exec(`

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -691,6 +691,103 @@ func TestToolUseIngest(t *testing.T) {
 	}
 }
 
+func TestSnapshotFiles(t *testing.T) {
+	projectDir := t.TempDir()
+
+	writeJSONL(t, projectDir, "myproject", "sess-snap", []map[string]any{
+		msg("user", "working on files", "2026-04-01T10:00:00Z"),
+		{
+			"type": "file-history-snapshot",
+			"snapshot": map[string]any{
+				"messageId": "msg-123",
+				"trackedFileBackups": map[string]any{
+					"internal/store/store.go": map[string]any{
+						"backupFileName": "abc123@v1",
+						"version":        1,
+						"backupTime":     "2026-04-01T10:00:05Z",
+					},
+					"main.go": map[string]any{
+						"backupFileName": "def456@v1",
+						"version":        1,
+						"backupTime":     "2026-04-01T10:00:06Z",
+					},
+				},
+				"timestamp": "2026-04-01T10:00:05Z",
+			},
+			"isSnapshotUpdate": false,
+		},
+		// Empty snapshot (no tracked files).
+		{
+			"type": "file-history-snapshot",
+			"snapshot": map[string]any{
+				"messageId":          "msg-456",
+				"trackedFileBackups": map[string]any{},
+				"timestamp":          "2026-04-01T10:01:00Z",
+			},
+		},
+	})
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Two files should be extracted from the first snapshot.
+	rows, err := s.Query("SELECT COUNT(*) AS cnt FROM snapshot_files")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cnt, ok := rows[0]["cnt"].(int64); !ok || cnt != 2 {
+		t.Fatalf("expected 2 snapshot_files, got %v", rows[0]["cnt"])
+	}
+
+	// Check file paths.
+	rows, err = s.Query("SELECT file_path, backup_time FROM snapshot_files ORDER BY file_path")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	if rows[0]["file_path"] != "internal/store/store.go" {
+		t.Errorf("expected internal/store/store.go, got %v", rows[0]["file_path"])
+	}
+	if rows[1]["file_path"] != "main.go" {
+		t.Errorf("expected main.go, got %v", rows[1]["file_path"])
+	}
+	if rows[0]["backup_time"] != "2026-04-01T10:00:05Z" {
+		t.Errorf("expected backup_time, got %v", rows[0]["backup_time"])
+	}
+
+	// FTS search for store.go.
+	rows, err = s.Query("SELECT file_path FROM snapshot_files WHERE id IN (SELECT rowid FROM snapshot_files_fts WHERE snapshot_files_fts MATCH 'store')")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 FTS match, got %d", len(rows))
+	}
+	if rows[0]["file_path"] != "internal/store/store.go" {
+		t.Errorf("expected store.go from FTS, got %v", rows[0]["file_path"])
+	}
+
+	// Join with session_meta.
+	rows, err = s.Query(`
+		SELECT sf.file_path, sf.session_id
+		FROM snapshot_files sf
+		WHERE sf.file_path LIKE '%main.go'
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row for main.go, got %d", len(rows))
+	}
+	if rows[0]["session_id"] != "sess-snap" {
+		t.Errorf("expected session sess-snap, got %v", rows[0]["session_id"])
+	}
+}
+
 func TestEntriesTable(t *testing.T) {
 	projectDir := t.TempDir()
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -87,6 +87,9 @@ Tables:
     — tool_use fields: tool_name, tool_use_id, tool_input (JSONB), content_type
     — virtual columns from tool_input: tool_file_path, tool_command, etc.
   messages_fts — FTS5 virtual table (excludes noise). Use: WHERE messages_fts MATCH 'terms'
+  snapshot_files (id, entry_id, session_id, file_path, backup_time)
+    — auto-extracted from file-history-snapshot entries via trigger
+  snapshot_files_fts — FTS5 on file_path. Use: WHERE snapshot_files_fts MATCH 'pattern'
   sessions — view: session_id, project, session_type, total_msgs, substantive_msgs, first_msg, last_msg
   session_meta (session_id, repo, cwd, git_branch, work_type, topic)
   session_summary (session_id, project, session_type, total_msgs, substantive_msgs, first_msg, last_msg)
@@ -97,6 +100,11 @@ Join pattern — message with its entry metadata:
 Token usage query:
   SELECT date(timestamp) AS day, SUM(input_tokens) AS input, SUM(output_tokens) AS output
   FROM entries WHERE type = 'assistant' GROUP BY day ORDER BY day DESC
+
+File history — which sessions touched a file:
+  SELECT sf.session_id, sf.backup_time, sm.repo
+  FROM snapshot_files sf JOIN session_meta sm ON sm.session_id = sf.session_id
+  WHERE sf.file_path LIKE '%store.go'
 
 Session types (derived from project path): interactive, subagent, worktree, ephemeral.
 is_noise = 1 for interrupts, compaction summaries, tool-loaded markers, slash command markup.

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ import (
 //go:embed agents-guide.md
 var agentsGuide string
 
-const version = "0.9.0"
+const version = "0.10.0"
 
 func main() {
 	showVersion := flag.Bool("version", false, "print version and exit")

--- a/targets.yaml
+++ b/targets.yaml
@@ -27,14 +27,14 @@ targets:
     origin: targets.md bootstrap
     discovered: 2026-04-07
   T11:
-    name: Git history indexed and cross-referenced with session activity
+    name: Git history indexed cross-repo with FTS and session correlation
     status: identified
     value: 8.0
     cost: 5.0
     acceptance:
-    - Commits from repos in session_meta are indexed automatically
-    - mnemo_commits returns commits with correlated session IDs
-    - mnemo_blame <file> returns recent commits with session context
+    - Commits from repos in session_meta indexed automatically
+    - mnemo_commits supports cross-repo queries (repo glob, date range)
+    - FTS5 index on commit messages enables keyword search across corpus
     - Commit data queryable via mnemo_query (joins with sessions/entries)
     - Incremental — only fetches new commits since last ingest
     context: mnemo knows what was discussed; git history knows what changed. Cross-referencing the two lets agents answer 'why was this changed?' and 'which session produced this commit?' without leaving mnemo.

--- a/targets.yaml
+++ b/targets.yaml
@@ -43,6 +43,59 @@ targets:
     - observability
     origin: user suggestion
     discovered: 2026-04-07
+  T12:
+    name: GitHub activity (PRs, issues, reviews) indexed cross-repo with FTS and session correlation
+    status: identified
+    value: 8.0
+    cost: 5.0
+    acceptance:
+    - PRs and issues from repos in session_meta indexed automatically
+    - mnemo_prs supports cross-repo queries with FTS on title/body
+    - PR reviews and comments indexed and searchable
+    - Correlated with sessions and commits
+    - Queryable via mnemo_query
+    - Incremental polling
+    context: gh CLI queries one repo at a time. mnemo adds corpus-level FTS search over PRs/issues/reviews and cross-references with session context and git history.
+    tags:
+    - ingest
+    - observability
+    - github
+    origin: user suggestion
+    discovered: 2026-04-07
+  T13:
+    name: CI/CD run history indexed cross-repo with failure pattern detection
+    status: identified
+    value: 8.0
+    cost: 3.0
+    acceptance:
+    - CI runs from repos in session_meta indexed automatically
+    - mnemo_ci supports cross-repo queries with status/conclusion filters
+    - Failed run logs indexed with FTS
+    - Correlated with commits and sessions
+    - Queryable via mnemo_query
+    - Incremental polling
+    context: GitHub Actions logs are ephemeral (90-day retention) and per-repo. mnemo preserves them permanently and makes them searchable across the full corpus. Would have been useful today for diagnosing CI patterns.
+    tags:
+    - ingest
+    - observability
+    - ci
+    origin: user suggestion
+    discovered: 2026-04-07
+  T14:
+    name: File-history-snapshots surfaced as queryable tool
+    status: identified
+    value: 5.0
+    cost: 2.0
+    acceptance:
+    - File-history-snapshot data queryable via dedicated tool or view
+    - 'Cross-session file tracking: which sessions touched this file?'
+    - Queryable via mnemo_query
+    - No additional ingest needed — data already in entries table
+    context: 26k+ file-history-snapshot entries already stored in entries table after T9.1. Just needs extraction logic and a tool/view. Low cost, high leverage.
+    tags:
+    - observability
+    origin: user suggestion
+    discovered: 2026-04-07
   T2:
     name: Smarter session classification
     status: achieved

--- a/targets.yaml
+++ b/targets.yaml
@@ -83,7 +83,7 @@ targets:
     discovered: 2026-04-07
   T14:
     name: File-history-snapshots surfaced as queryable tool
-    status: identified
+    status: achieved
     value: 5.0
     cost: 2.0
     acceptance:
@@ -96,6 +96,7 @@ targets:
     - observability
     origin: user suggestion
     discovered: 2026-04-07
+    achieved: 2026-04-07
   T2:
     name: Smarter session classification
     status: achieved

--- a/targets.yaml
+++ b/targets.yaml
@@ -26,6 +26,23 @@ targets:
     context: mnemo maintains a live compacted context for each active session. When a session /clears, the compacted context is available instantly via mnemo_restore. Depends on jevon claude.Process / manager.Manager for Claude instance lifecycle.
     origin: targets.md bootstrap
     discovered: 2026-04-07
+  T11:
+    name: Git history indexed and cross-referenced with session activity
+    status: identified
+    value: 8.0
+    cost: 5.0
+    acceptance:
+    - Commits from repos in session_meta are indexed automatically
+    - mnemo_commits returns commits with correlated session IDs
+    - mnemo_blame <file> returns recent commits with session context
+    - Commit data queryable via mnemo_query (joins with sessions/entries)
+    - Incremental — only fetches new commits since last ingest
+    context: mnemo knows what was discussed; git history knows what changed. Cross-referencing the two lets agents answer 'why was this changed?' and 'which session produced this commit?' without leaving mnemo.
+    tags:
+    - ingest
+    - observability
+    origin: user suggestion
+    discovered: 2026-04-07
   T2:
     name: Smarter session classification
     status: achieved


### PR DESCRIPTION
## Summary

- `snapshot_files` table with FTS5, auto-populated via SQL trigger on file-history-snapshot entries — zero Go ingest code changes
- New convergence targets: 🎯T11 (Git history), 🎯T12 (GitHub activity), 🎯T13 (CI/CD history)
- Schema version bumped to 6
- Version bumped to 0.10.0

## Test plan

- [x] `TestSnapshotFiles` — verifies trigger extraction, FTS5 search, empty snapshot handling
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)