### PR TITLE
Add 5 context source tools: skills, configs, audit, targets, plans (v0.12.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ user. Good moments to reach for mnemo:
 - `mnemo_sessions` — List sessions by recency, type, project, repo, work type
 - `mnemo_read_session` — Read messages from a specific session (supports prefix IDs)
 - `mnemo_memories` — Search across auto-memory files from all projects. Filters by type (user/feedback/project/reference), project. Cross-project memory search.
+- `mnemo_skills` — Search across skill files from ~/.claude/skills/. Discover available workflows and reusable procedures.
 - `mnemo_usage` — Token usage analytics: aggregated input/output/cache tokens with cost estimates. Filters by repo, model, date range. Groups by day, model, or repo.
 - `mnemo_query` — SQL SELECT/WITH or sqldeep nested syntax (FROM ... SELECT { }) against the transcript database
 - `mnemo_recent_activity` — Per-repo summary of recent session activity (counts, recency, work types, topics)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,8 @@ user. Good moments to reach for mnemo:
 - `mnemo_skills` — Search across skill files from ~/.claude/skills/. Discover available workflows and reusable procedures.
 - `mnemo_configs` — Search across CLAUDE.md project instruction files from all repos. Find build instructions, conventions, and delivery definitions.
 - `mnemo_usage` — Token usage analytics: aggregated input/output/cache tokens with cost estimates. Filters by repo, model, date range. Groups by day, model, or repo.
-- `mnemo_query` — SQL SELECT/WITH or sqldeep nested syntax (FROM ... SELECT { }) against the transcript database
+- `mnemo_audit` — Search across audit logs (docs/audit-log.md) from all repos. Filters by repo, skill (release/audit/docs). Use to check when a project was last released or find maintenance patterns.
+- `mnemo_query` — SQL SELECT/WITH or sqldeep nested syntax (FROM ... SELECT { }) against the transcript database. Tables include: audit_entries (id, repo, file_path, date, skill, version, summary, raw_text), audit_entries_fts.
 - `mnemo_recent_activity` — Per-repo summary of recent session activity (counts, recency, work types, topics)
 - `mnemo_status` — Rich status report: repos → sessions → truncated conversation excerpts with drill-down offsets
 - `mnemo_repos` — List repos with paths, session counts, last activity. Supports globs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ user. Good moments to reach for mnemo:
 - `mnemo_read_session` — Read messages from a specific session (supports prefix IDs)
 - `mnemo_memories` — Search across auto-memory files from all projects. Filters by type (user/feedback/project/reference), project. Cross-project memory search.
 - `mnemo_skills` — Search across skill files from ~/.claude/skills/. Discover available workflows and reusable procedures.
+- `mnemo_configs` — Search across CLAUDE.md project instruction files from all repos. Find build instructions, conventions, and delivery definitions.
 - `mnemo_usage` — Token usage analytics: aggregated input/output/cache tokens with cost estimates. Filters by repo, model, date range. Groups by day, model, or repo.
 - `mnemo_query` — SQL SELECT/WITH or sqldeep nested syntax (FROM ... SELECT { }) against the transcript database
 - `mnemo_recent_activity` — Per-repo summary of recent session activity (counts, recency, work types, topics)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,9 @@ user. Good moments to reach for mnemo:
 - `mnemo_configs` — Search across CLAUDE.md project instruction files from all repos. Find build instructions, conventions, and delivery definitions.
 - `mnemo_usage` — Token usage analytics: aggregated input/output/cache tokens with cost estimates. Filters by repo, model, date range. Groups by day, model, or repo.
 - `mnemo_audit` — Search across audit logs (docs/audit-log.md) from all repos. Filters by repo, skill (release/audit/docs). Use to check when a project was last released or find maintenance patterns.
-- `mnemo_query` — SQL SELECT/WITH or sqldeep nested syntax (FROM ... SELECT { }) against the transcript database. Tables include: audit_entries (id, repo, file_path, date, skill, version, summary, raw_text), audit_entries_fts.
+- `mnemo_targets` — Search across convergence targets (docs/targets.md) from all repos. Filters by repo, status. Cross-project target search.
+- `mnemo_plans` — Search across implementation plans (.planning/ directories) from all repos. Use this to find past design decisions or understand how features were planned.
+- `mnemo_query` — SQL SELECT/WITH or sqldeep nested syntax (FROM ... SELECT { }) against the transcript database. Tables include: audit_entries (id, repo, file_path, date, skill, version, summary, raw_text), audit_entries_fts; targets (id, repo, file_path, target_id, name, status, weight, description, raw_text), targets_fts; plans (id, repo, file_path, phase, content, updated_at), plans_fts.
 - `mnemo_recent_activity` — Per-repo summary of recent session activity (counts, recency, work types, topics)
 - `mnemo_status` — Rich status report: repos → sessions → truncated conversation excerpts with drill-down offsets
 - `mnemo_repos` — List repos with paths, session counts, last activity. Supports globs.

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -9,7 +9,7 @@ new product. The pre-1.0 period exists to get these surfaces right.
 
 ## Interaction surface catalogue
 
-Snapshot as of v0.11.0.
+Snapshot as of v0.12.0.
 
 ### CLI flags
 
@@ -102,6 +102,57 @@ review — first release, output format and filters may evolve.
 **Added in v0.11.0.** Returns aggregated token usage with cost estimates.
 **Stability**: Needs review — cost model and grouping options may evolve.
 
+#### mnemo_skills
+
+| Parameter | Type | Required | Description | Stability |
+|---|---|---|---|---|
+| `query` | string | no | Search query (fuzzy OR matching) | Needs review |
+| `limit` | number | no | Max results (default 20) | Stable |
+
+**Added in v0.12.0.** Searches `~/.claude/skills/*.md`. **Stability**: Needs review.
+
+#### mnemo_configs
+
+| Parameter | Type | Required | Description | Stability |
+|---|---|---|---|---|
+| `query` | string | no | Search query (fuzzy OR matching) | Needs review |
+| `repo` | string | no | Repo filter | Needs review |
+| `limit` | number | no | Max results (default 20) | Stable |
+
+**Added in v0.12.0.** Searches CLAUDE.md files from all repos. **Stability**: Needs review.
+
+#### mnemo_audit
+
+| Parameter | Type | Required | Description | Stability |
+|---|---|---|---|---|
+| `query` | string | no | Search query (fuzzy OR matching) | Needs review |
+| `repo` | string | no | Repo filter | Needs review |
+| `skill` | string | no | Skill name filter (e.g. "release") | Needs review |
+| `limit` | number | no | Max results (default 20) | Stable |
+
+**Added in v0.12.0.** Searches `docs/audit-log.md` from all repos. **Stability**: Needs review.
+
+#### mnemo_targets
+
+| Parameter | Type | Required | Description | Stability |
+|---|---|---|---|---|
+| `query` | string | no | Search query (fuzzy OR matching) | Needs review |
+| `repo` | string | no | Repo filter | Needs review |
+| `status` | string | no | Status filter: identified, converging, achieved | Needs review |
+| `limit` | number | no | Max results (default 20) | Stable |
+
+**Added in v0.12.0.** Searches `docs/targets.md` from all repos. **Stability**: Needs review.
+
+#### mnemo_plans
+
+| Parameter | Type | Required | Description | Stability |
+|---|---|---|---|---|
+| `query` | string | no | Search query (fuzzy OR matching) | Needs review |
+| `repo` | string | no | Repo filter | Needs review |
+| `limit` | number | no | Max results (default 20) | Stable |
+
+**Added in v0.12.0.** Searches `.planning/` directories from all repos. **Stability**: Needs review.
+
 #### mnemo_query
 
 | Parameter | Type | Required | Description | Stability |
@@ -150,6 +201,16 @@ stored in indexed `session_nonces` table. The mechanism may evolve.
 | `session_meta` | Per-session metadata: session_id, repo, cwd, git_branch, work_type, topic | Needs review |
 | `memories` | id, project, file_path (unique), name, description, memory_type, content, updated_at — auto-memory files from ~/.claude/projects/*/memory/*.md | Needs review |
 | `memories_fts` | FTS5 on name, description, content, project — with insert/update/delete triggers | Needs review |
+| `skills` | id, file_path (unique), name, description, content, updated_at — ~/.claude/skills/*.md | Needs review |
+| `skills_fts` | FTS5 on name, description, content | Needs review |
+| `claude_configs` | id, repo, file_path (unique), content, updated_at — CLAUDE.md from all repos | Needs review |
+| `claude_configs_fts` | FTS5 on content, repo | Needs review |
+| `audit_entries` | id, repo, file_path, date, skill, version, summary, raw_text — docs/audit-log.md | Needs review |
+| `audit_entries_fts` | FTS5 on summary, raw_text, repo | Needs review |
+| `targets` | id, repo, file_path, target_id, name, status, weight, description, raw_text — docs/targets.md | Needs review |
+| `targets_fts` | FTS5 on name, description, raw_text, repo | Needs review |
+| `plans` | id, repo, file_path (unique), phase, content, updated_at — .planning/**/*.md | Needs review |
+| `plans_fts` | FTS5 on content, repo, phase | Needs review |
 | `session_nonces` | nonce → session_id mapping for mnemo_self | Fluid |
 | `ingest_state` | path, offset | Fluid |
 
@@ -162,6 +223,10 @@ file-history-snapshot entries and FTS5 on file paths.
 v0.11.0 added `memories` table for cross-project auto-memory indexing,
 `mnemo_usage` for token analytics, and changed search to OR-by-default
 with BM25 ranking for fuzzy matching.
+v0.12.0 added five context source tables: `skills`, `claude_configs`,
+`audit_entries`, `targets`, `plans` — each with FTS5 indexes. These
+index non-transcript sources (skill files, CLAUDE.md configs, audit
+logs, convergence targets, implementation plans) from all known repos.
 This surface is still evolving. `ingest_state` and `session_nonces` are
 internal implementation details.
 

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -52,3 +52,8 @@ maintenance activities. Append-only — newest entries at the bottom.
 
 - **Commit**: `05fe3b4`
 - **Outcome**: Released v0.11.0 (darwin-arm64, linux-amd64, linux-arm64). New tools: mnemo_memories (cross-project memory search), mnemo_usage (token analytics). Fuzzy OR-by-default search. Schema v7.
+
+## 2026-04-09 — /release v0.12.0
+
+- **Commit**: `77964e2`
+- **Outcome**: Released v0.12.0 (darwin-arm64, linux-amd64, linux-arm64). Five new context source tools: mnemo_skills, mnemo_configs, mnemo_audit, mnemo_targets, mnemo_plans. Schema v8. Homebrew formula updated.

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -732,3 +732,137 @@ nested JSON queries without hand-rolling `json_group_array`/`json_object`.
 - Plain SQL continues to work unchanged.
 - sqldeep JSON helper functions registered on the SQLite connection.
 - Tool description documents the available syntax.
+
+### 🎯T17 CLAUDE.md indexing
+
+- **Value**: 8
+- **Cost**: 3
+- **Weight**: 2.7 (value 8 / cost 3)
+- **Status**: identified
+- **Discovered**: 2026-04-08
+- **Related**: 🎯T1 (memory indexing — same architecture)
+
+**Desired state:** mnemo indexes CLAUDE.md files from all repos that
+appear in session transcripts. Cross-project search for project
+instructions, conventions, build systems, and configuration.
+
+An agent in repo A can ask "which projects use sqldeep?" or "how does
+the pigeon project handle releases?" without visiting each repo.
+
+**Architecture:** Discover repo paths from `session_meta.cwd`. Scan
+each for CLAUDE.md (project root) and `~/.claude/CLAUDE.md` (global).
+Store in a `claude_configs` table (path, repo, content, updated_at)
+with FTS5 index. Watch for changes via fsnotify on the discovered
+repo directories.
+
+Also index `~/.claude/CLAUDE.md` (global instructions) as a single
+always-present entry.
+
+**Acceptance criteria:**
+- CLAUDE.md files from all known repos indexed and searchable.
+- Global `~/.claude/CLAUDE.md` indexed.
+- Realtime updates when CLAUDE.md files change.
+- Queryable via `mnemo_query` and a dedicated tool.
+
+### 🎯T18 Skills indexing
+
+- **Value**: 7
+- **Cost**: 2
+- **Weight**: 3.5 (value 7 / cost 2)
+- **Status**: identified
+- **Discovered**: 2026-04-08
+- **Related**: 🎯T1 (memory indexing — same architecture),
+  🎯T5 (pattern discovery could leverage skill knowledge)
+
+**Desired state:** mnemo indexes all skill files from
+`~/.claude/skills/` and makes them searchable. Agents can discover
+relevant skills ("is there a skill for releasing?") without the user
+invoking them. Also enables cross-referencing: "which skills have been
+used in recent sessions?" by joining skill names with transcript data.
+
+**Architecture:** Scan `~/.claude/skills/` for .md files. Parse
+frontmatter or header structure. Store in a `skills` table (name,
+file_path, description, content, updated_at) with FTS5. Watch for
+changes. ~40 skill files currently.
+
+**Acceptance criteria:**
+- All skill files indexed and searchable.
+- FTS5 on skill name + description + content.
+- Realtime updates when skills are added/modified.
+- Queryable via `mnemo_query` and a dedicated `mnemo_skills` tool.
+
+### 🎯T19 Audit log indexing
+
+- **Value**: 6
+- **Cost**: 3
+- **Weight**: 2.0 (value 6 / cost 3)
+- **Status**: identified
+- **Discovered**: 2026-04-08
+- **Related**: 🎯T17 (CLAUDE.md indexing — discovers repo paths)
+
+**Desired state:** mnemo indexes `docs/audit-log.md` files from all
+repos. Cross-project maintenance history: "when was mnemo last
+released?", "which projects haven't been audited recently?", "what
+maintenance was done across all repos this week?"
+
+**Architecture:** Discover repos from `session_meta.cwd`. Scan each
+for `docs/audit-log.md`. Parse entries (date, skill, version, outcome).
+Store in an `audit_entries` table (repo, date, skill, version, summary,
+raw_text) with FTS5 on summary + raw_text. Watch for changes.
+
+**Acceptance criteria:**
+- Audit logs from all known repos indexed and searchable.
+- Structured parsing of date, skill, and version from entries.
+- "Which projects were released this month?" answerable via query.
+- Realtime updates when audit logs change.
+
+### 🎯T20 Bullseye target indexing
+
+- **Value**: 7
+- **Cost**: 3
+- **Weight**: 2.3 (value 7 / cost 3)
+- **Status**: identified
+- **Discovered**: 2026-04-08
+- **Related**: 🎯T19 (audit logs — same repo discovery)
+
+**Desired state:** mnemo indexes bullseye `targets.yaml` files from
+all repos. Cross-project target search: "which projects have unachieved
+targets?", "find all targets related to search", "what's the highest-
+weighted unblocked target across all projects?"
+
+**Architecture:** Discover repos from `session_meta.cwd`. Scan each
+for `docs/targets.yaml` (bullseye format) and `docs/targets.md`
+(markdown format). Parse target structure (ID, name, status, weight,
+dependencies). Store in a `targets` table (repo, target_id, name,
+status, weight, description) with FTS5 on name + description.
+
+**Acceptance criteria:**
+- Targets from all known repos indexed and searchable.
+- Status, weight, and dependency data queryable.
+- "Which repos have stale targets?" answerable via query.
+- Realtime updates when target files change.
+
+### 🎯T21 Plan file indexing
+
+- **Value**: 6
+- **Cost**: 3
+- **Weight**: 2.0 (value 6 / cost 3)
+- **Status**: identified
+- **Discovered**: 2026-04-08
+- **Related**: 🎯T19 (audit logs — same repo discovery)
+
+**Desired state:** mnemo indexes `.planning/` directories from all
+repos. Plans contain architectural decisions, implementation reasoning,
+and task breakdowns that don't make it into commits or transcripts.
+Cross-project search: "what was the plan for the auth rewrite?",
+"find plans that mention database migration".
+
+**Architecture:** Discover repos from `session_meta.cwd`. Scan each
+for `.planning/**/*.md` files. Store in a `plans` table (repo,
+file_path, phase, content, updated_at) with FTS5. Watch for changes.
+
+**Acceptance criteria:**
+- Plan files from all repos indexed and searchable.
+- Phase/milestone structure parsed where possible.
+- FTS5 on plan content.
+- Realtime updates when plan files change.

--- a/internal/rpc/proxy.go
+++ b/internal/rpc/proxy.go
@@ -163,7 +163,16 @@ func (p *Proxy) SearchClaudeConfigs(query string, repo string, limit int) ([]sto
 	return results, json.Unmarshal(raw, &results)
 }
 
-
+func (p *Proxy) SearchAuditLogs(query string, repo string, skill string, limit int) ([]store.AuditEntryInfo, error) {
+	raw, err := p.client.Call("SearchAuditLogs", SearchAuditLogsParams{
+		Query: query, Repo: repo, Skill: skill, Limit: limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var results []store.AuditEntryInfo
+	return results, json.Unmarshal(raw, &results)
+}
 func (p *Proxy) ResolveNonce(nonce string) (string, error) {
 	raw, err := p.client.Call("ResolveNonce", ResolveNonceParams{Nonce: nonce})
 	if err != nil {

--- a/internal/rpc/proxy.go
+++ b/internal/rpc/proxy.go
@@ -143,6 +143,15 @@ func (p *Proxy) Usage(days int, repoFilter, model, groupBy string) (*store.Usage
 	return &result, json.Unmarshal(raw, &result)
 }
 
+func (p *Proxy) SearchSkills(query string, limit int) ([]store.SkillInfo, error) {
+	raw, err := p.client.Call("SearchSkills", SearchSkillsParams{Query: query, Limit: limit})
+	if err != nil {
+		return nil, err
+	}
+	var results []store.SkillInfo
+	return results, json.Unmarshal(raw, &results)
+}
+
 func (p *Proxy) ResolveNonce(nonce string) (string, error) {
 	raw, err := p.client.Call("ResolveNonce", ResolveNonceParams{Nonce: nonce})
 	if err != nil {

--- a/internal/rpc/proxy.go
+++ b/internal/rpc/proxy.go
@@ -152,6 +152,18 @@ func (p *Proxy) SearchSkills(query string, limit int) ([]store.SkillInfo, error)
 	return results, json.Unmarshal(raw, &results)
 }
 
+func (p *Proxy) SearchClaudeConfigs(query string, repo string, limit int) ([]store.ClaudeConfigInfo, error) {
+	raw, err := p.client.Call("SearchClaudeConfigs", SearchClaudeConfigsParams{
+		Query: query, Repo: repo, Limit: limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var results []store.ClaudeConfigInfo
+	return results, json.Unmarshal(raw, &results)
+}
+
+
 func (p *Proxy) ResolveNonce(nonce string) (string, error) {
 	raw, err := p.client.Call("ResolveNonce", ResolveNonceParams{Nonce: nonce})
 	if err != nil {

--- a/internal/rpc/proxy.go
+++ b/internal/rpc/proxy.go
@@ -173,6 +173,29 @@ func (p *Proxy) SearchAuditLogs(query string, repo string, skill string, limit i
 	var results []store.AuditEntryInfo
 	return results, json.Unmarshal(raw, &results)
 }
+
+func (p *Proxy) SearchTargets(query string, repo string, status string, limit int) ([]store.TargetInfo, error) {
+	raw, err := p.client.Call("SearchTargets", SearchTargetsParams{
+		Query: query, Repo: repo, Status: status, Limit: limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var results []store.TargetInfo
+	return results, json.Unmarshal(raw, &results)
+}
+
+func (p *Proxy) SearchPlans(query string, repo string, limit int) ([]store.PlanInfo, error) {
+	raw, err := p.client.Call("SearchPlans", SearchPlansParams{
+		Query: query, Repo: repo, Limit: limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var results []store.PlanInfo
+	return results, json.Unmarshal(raw, &results)
+}
+
 func (p *Proxy) ResolveNonce(nonce string) (string, error) {
 	raw, err := p.client.Call("ResolveNonce", ResolveNonceParams{Nonce: nonce})
 	if err != nil {

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -103,6 +103,9 @@ func extraMethods(s *store.Store) map[string]mcpbridge.MethodFunc {
 		"SearchClaudeConfigs": makeMethod(func(p SearchClaudeConfigsParams) (any, error) {
 			return s.SearchClaudeConfigs(p.Query, p.Repo, p.Limit)
 		}),
+		"SearchAuditLogs": makeMethod(func(p SearchAuditLogsParams) (any, error) {
+			return s.SearchAuditLogs(p.Query, p.Repo, p.Skill, p.Limit)
+		}),
 		"ResolveNonce": makeMethod(func(p ResolveNonceParams) (any, error) {
 			sid, err := s.ResolveNonce(p.Nonce)
 			if err != nil {
@@ -209,7 +212,13 @@ type SearchClaudeConfigsParams struct {
 	Limit int    `json:"limit"`
 }
 
-
+// SearchAuditLogsParams matches the SearchAuditLogs method signature.
+type SearchAuditLogsParams struct {
+	Query string `json:"query"`
+	Repo  string `json:"repo"`
+	Skill string `json:"skill"`
+	Limit int    `json:"limit"`
+}
 // ResolveNonceParams matches the ResolveNonce method signature.
 type ResolveNonceParams struct {
 	Nonce string `json:"nonce"`

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -100,6 +100,9 @@ func extraMethods(s *store.Store) map[string]mcpbridge.MethodFunc {
 		"SearchSkills": makeMethod(func(p SearchSkillsParams) (any, error) {
 			return s.SearchSkills(p.Query, p.Limit)
 		}),
+		"SearchClaudeConfigs": makeMethod(func(p SearchClaudeConfigsParams) (any, error) {
+			return s.SearchClaudeConfigs(p.Query, p.Repo, p.Limit)
+		}),
 		"ResolveNonce": makeMethod(func(p ResolveNonceParams) (any, error) {
 			sid, err := s.ResolveNonce(p.Nonce)
 			if err != nil {
@@ -198,6 +201,14 @@ type SearchSkillsParams struct {
 	Query string `json:"query"`
 	Limit int    `json:"limit"`
 }
+
+// SearchClaudeConfigsParams matches the SearchClaudeConfigs method signature.
+type SearchClaudeConfigsParams struct {
+	Query string `json:"query"`
+	Repo  string `json:"repo"`
+	Limit int    `json:"limit"`
+}
+
 
 // ResolveNonceParams matches the ResolveNonce method signature.
 type ResolveNonceParams struct {

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -97,6 +97,9 @@ func extraMethods(s *store.Store) map[string]mcpbridge.MethodFunc {
 		"SearchMemories": makeMethod(func(p SearchMemoriesParams) (any, error) {
 			return s.SearchMemories(p.Query, p.MemoryType, p.Project, p.Limit)
 		}),
+		"SearchSkills": makeMethod(func(p SearchSkillsParams) (any, error) {
+			return s.SearchSkills(p.Query, p.Limit)
+		}),
 		"ResolveNonce": makeMethod(func(p ResolveNonceParams) (any, error) {
 			sid, err := s.ResolveNonce(p.Nonce)
 			if err != nil {
@@ -188,6 +191,12 @@ type UsageParams struct {
 	RepoFilter string `json:"repo_filter"`
 	Model      string `json:"model"`
 	GroupBy    string `json:"group_by"`
+}
+
+// SearchSkillsParams matches the SearchSkills method signature.
+type SearchSkillsParams struct {
+	Query string `json:"query"`
+	Limit int    `json:"limit"`
 }
 
 // ResolveNonceParams matches the ResolveNonce method signature.

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -106,6 +106,12 @@ func extraMethods(s *store.Store) map[string]mcpbridge.MethodFunc {
 		"SearchAuditLogs": makeMethod(func(p SearchAuditLogsParams) (any, error) {
 			return s.SearchAuditLogs(p.Query, p.Repo, p.Skill, p.Limit)
 		}),
+		"SearchTargets": makeMethod(func(p SearchTargetsParams) (any, error) {
+			return s.SearchTargets(p.Query, p.Repo, p.Status, p.Limit)
+		}),
+		"SearchPlans": makeMethod(func(p SearchPlansParams) (any, error) {
+			return s.SearchPlans(p.Query, p.Repo, p.Limit)
+		}),
 		"ResolveNonce": makeMethod(func(p ResolveNonceParams) (any, error) {
 			sid, err := s.ResolveNonce(p.Nonce)
 			if err != nil {
@@ -219,6 +225,21 @@ type SearchAuditLogsParams struct {
 	Skill string `json:"skill"`
 	Limit int    `json:"limit"`
 }
+// SearchTargetsParams matches the SearchTargets method signature.
+type SearchTargetsParams struct {
+	Query  string `json:"query"`
+	Repo   string `json:"repo"`
+	Status string `json:"status"`
+	Limit  int    `json:"limit"`
+}
+
+// SearchPlansParams matches the SearchPlans method signature.
+type SearchPlansParams struct {
+	Query string `json:"query"`
+	Repo  string `json:"repo"`
+	Limit int    `json:"limit"`
+}
+
 // ResolveNonceParams matches the ResolveNonce method signature.
 type ResolveNonceParams struct {
 	Nonce string `json:"nonce"`

--- a/internal/store/iface.go
+++ b/internal/store/iface.go
@@ -20,4 +20,6 @@ type Backend interface {
 	SearchSkills(query string, limit int) ([]SkillInfo, error)
 	SearchClaudeConfigs(query string, repo string, limit int) ([]ClaudeConfigInfo, error)
 	SearchAuditLogs(query string, repo string, skill string, limit int) ([]AuditEntryInfo, error)
+	SearchTargets(query string, repo string, status string, limit int) ([]TargetInfo, error)
+	SearchPlans(query string, repo string, limit int) ([]PlanInfo, error)
 }

--- a/internal/store/iface.go
+++ b/internal/store/iface.go
@@ -18,4 +18,5 @@ type Backend interface {
 	Usage(days int, repoFilter, model, groupBy string) (*UsageResult, error)
 	SearchMemories(query string, memType string, project string, limit int) ([]MemoryInfo, error)
 	SearchSkills(query string, limit int) ([]SkillInfo, error)
+	SearchClaudeConfigs(query string, repo string, limit int) ([]ClaudeConfigInfo, error)
 }

--- a/internal/store/iface.go
+++ b/internal/store/iface.go
@@ -17,4 +17,5 @@ type Backend interface {
 	Status(days int, repoFilter string, maxSessions int, maxExcerpts int, truncateLen int) (*StatusResult, error)
 	Usage(days int, repoFilter, model, groupBy string) (*UsageResult, error)
 	SearchMemories(query string, memType string, project string, limit int) ([]MemoryInfo, error)
+	SearchSkills(query string, limit int) ([]SkillInfo, error)
 }

--- a/internal/store/iface.go
+++ b/internal/store/iface.go
@@ -19,4 +19,5 @@ type Backend interface {
 	SearchMemories(query string, memType string, project string, limit int) ([]MemoryInfo, error)
 	SearchSkills(query string, limit int) ([]SkillInfo, error)
 	SearchClaudeConfigs(query string, repo string, limit int) ([]ClaudeConfigInfo, error)
+	SearchAuditLogs(query string, repo string, skill string, limit int) ([]AuditEntryInfo, error)
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -391,6 +391,17 @@ func New(dbPath, projectDir string) (*Store, error) {
 			content TEXT NOT NULL,
 			updated_at TEXT NOT NULL
 		);
+		CREATE TABLE IF NOT EXISTS audit_entries (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			repo TEXT NOT NULL,
+			file_path TEXT NOT NULL,
+			date TEXT NOT NULL DEFAULT '',
+			skill TEXT NOT NULL DEFAULT '',
+			version TEXT NOT NULL DEFAULT '',
+			summary TEXT NOT NULL DEFAULT '',
+			raw_text TEXT NOT NULL,
+			UNIQUE(file_path, date, skill)
+		);
 	`)
 	if err != nil {
 		db.Close()
@@ -432,6 +443,9 @@ func New(dbPath, projectDir string) (*Store, error) {
 		CREATE INDEX IF NOT EXISTS idx_memories_type ON memories(memory_type);
 		CREATE INDEX IF NOT EXISTS idx_skills_name ON skills(name);
 		CREATE INDEX IF NOT EXISTS idx_claude_configs_repo ON claude_configs(repo);
+		CREATE INDEX IF NOT EXISTS idx_audit_entries_repo ON audit_entries(repo);
+		CREATE INDEX IF NOT EXISTS idx_audit_entries_date ON audit_entries(date);
+		CREATE INDEX IF NOT EXISTS idx_audit_entries_skill ON audit_entries(skill);
 	`)
 	if err != nil {
 		db.Close()
@@ -444,6 +458,31 @@ func New(dbPath, projectDir string) (*Store, error) {
 			content=snapshot_files,
 			content_rowid=id
 		);
+		CREATE VIRTUAL TABLE IF NOT EXISTS audit_entries_fts USING fts5(
+			summary, raw_text, repo,
+			content=audit_entries,
+			content_rowid=id
+		);
+		DROP TRIGGER IF EXISTS audit_entries_ai;
+		CREATE TRIGGER audit_entries_ai AFTER INSERT ON audit_entries
+		BEGIN
+			INSERT INTO audit_entries_fts(rowid, summary, raw_text, repo)
+			VALUES (new.id, new.summary, new.raw_text, new.repo);
+		END;
+		DROP TRIGGER IF EXISTS audit_entries_au;
+		CREATE TRIGGER audit_entries_au AFTER UPDATE ON audit_entries
+		BEGIN
+			INSERT INTO audit_entries_fts(audit_entries_fts, rowid, summary, raw_text, repo)
+			VALUES ('delete', old.id, old.summary, old.raw_text, old.repo);
+			INSERT INTO audit_entries_fts(rowid, summary, raw_text, repo)
+			VALUES (new.id, new.summary, new.raw_text, new.repo);
+		END;
+		DROP TRIGGER IF EXISTS audit_entries_ad;
+		CREATE TRIGGER audit_entries_ad AFTER DELETE ON audit_entries
+		BEGIN
+			INSERT INTO audit_entries_fts(audit_entries_fts, rowid, summary, raw_text, repo)
+			VALUES ('delete', old.id, old.summary, old.raw_text, old.repo);
+		END;
 		CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
 			name, description, content, project,
 			content=memories,
@@ -1151,6 +1190,265 @@ func (s *Store) queryClaudeConfigs(q string, args ...any) ([]ClaudeConfigInfo, e
 	return results, nil
 }
 
+
+// AuditEntryInfo holds a single audit log entry from the index.
+type AuditEntryInfo struct {
+	ID       int    `json:"id"`
+	Repo     string `json:"repo"`
+	FilePath string `json:"file_path"`
+	Date     string `json:"date"`
+	Skill    string `json:"skill"`
+	Version  string `json:"version"`
+	Summary  string `json:"summary"`
+	RawText  string `json:"raw_text"`
+}
+
+// versionPattern matches version strings like v1.2.3.
+var versionPattern = regexp.MustCompile(`v\d+\.\d+\.\d+`)
+
+// parseAuditLogEntries parses a docs/audit-log.md file into individual entries.
+// Each ## heading starts a new entry. The first word after ## is the date;
+// skill follows a — or / separator; version matches vN.N.N.
+func parseAuditLogEntries(content string) []AuditEntryInfo {
+	var entries []AuditEntryInfo
+	lines := strings.Split(content, "\n")
+
+	var current *AuditEntryInfo
+	var rawLines []string
+
+	flush := func() {
+		if current != nil {
+			current.RawText = strings.TrimSpace(strings.Join(rawLines, "\n"))
+			// Use the heading line as summary if no body lines.
+			if current.Summary == "" {
+				current.Summary = current.RawText
+			}
+			entries = append(entries, *current)
+			current = nil
+			rawLines = nil
+		}
+	}
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "## ") {
+			flush()
+			heading := strings.TrimPrefix(line, "## ")
+			entry := AuditEntryInfo{}
+
+			// Parse date: first word.
+			fields := strings.Fields(heading)
+			if len(fields) > 0 {
+				entry.Date = fields[0]
+			}
+
+			// Parse skill: look for — or / after the date.
+			// Format: "DATE — /skill vN.N.N" or "DATE — skill description"
+			rest := strings.TrimSpace(strings.TrimPrefix(heading, entry.Date))
+			rest = strings.TrimPrefix(rest, "—")
+			rest = strings.TrimSpace(rest)
+			// Strip leading slash if present (skill name indicator).
+			if strings.HasPrefix(rest, "/") {
+				rest = rest[1:]
+				// First word after / is the skill.
+				skillFields := strings.Fields(rest)
+				if len(skillFields) > 0 {
+					entry.Skill = skillFields[0]
+				}
+			} else if rest != "" {
+				// No slash — use first word as skill.
+				skillFields := strings.Fields(rest)
+				if len(skillFields) > 0 {
+					entry.Skill = skillFields[0]
+				}
+			}
+
+			// Parse version: find vN.N.N in the heading.
+			if m := versionPattern.FindString(heading); m != "" {
+				entry.Version = m
+			}
+
+			// Use the full heading (after ##) as the initial summary.
+			entry.Summary = heading
+
+			current = &entry
+			rawLines = []string{line}
+		} else if current != nil {
+			rawLines = append(rawLines, line)
+		}
+	}
+	flush()
+	return entries
+}
+
+// IngestAuditLogs scans all repo roots discovered from session_meta and
+// ingests any docs/audit-log.md files found. Audit logs change rarely so
+// startup-only ingest is sufficient; no file watcher is set up.
+func (s *Store) IngestAuditLogs() error {
+	s.rwmu.Lock()
+	defer s.rwmu.Unlock()
+
+	// Collect distinct cwd values from session metadata.
+	rows, err := s.db.Query("SELECT DISTINCT cwd FROM session_meta WHERE cwd != ''")
+	if err != nil {
+		return err
+	}
+	cwds := make([]string, 0)
+	for rows.Next() {
+		var cwd string
+		if rows.Scan(&cwd) == nil {
+			cwds = append(cwds, cwd)
+		}
+	}
+	rows.Close()
+
+	// Walk up each cwd to find the repo root (contains .git).
+	seen := make(map[string]bool)
+	count := 0
+	for _, cwd := range cwds {
+		root := findRepoRoot(cwd)
+		if root == "" || seen[root] {
+			continue
+		}
+		seen[root] = true
+
+		auditPath := filepath.Join(root, "docs", "audit-log.md")
+		if _, err := os.Stat(auditPath); os.IsNotExist(err) {
+			continue
+		}
+
+		// Derive repo name from the root path (last two path components).
+		repo := repoNameFromPath(root)
+		if err := s.ingestAuditLogFileLocked(auditPath, repo); err != nil {
+			slog.Error("ingest audit log failed", "file", auditPath, "err", err)
+			continue
+		}
+		count++
+	}
+	slog.Info("ingested audit logs", "count", count)
+	return nil
+}
+
+// repoNameFromPath returns a "org/repo" style name from a filesystem path,
+// taking the last two non-empty path components.
+func repoNameFromPath(path string) string {
+	parts := strings.Split(filepath.Clean(path), string(filepath.Separator))
+	// Remove empty segments.
+	var nonempty []string
+	for _, p := range parts {
+		if p != "" {
+			nonempty = append(nonempty, p)
+		}
+	}
+	if len(nonempty) >= 2 {
+		return nonempty[len(nonempty)-2] + "/" + nonempty[len(nonempty)-1]
+	}
+	if len(nonempty) == 1 {
+		return nonempty[0]
+	}
+	return path
+}
+
+// ingestAuditLogFile ingests a single audit log file (acquires write lock).
+func (s *Store) ingestAuditLogFile(path, repo string) error {
+	s.rwmu.Lock()
+	defer s.rwmu.Unlock()
+	return s.ingestAuditLogFileLocked(path, repo)
+}
+
+// ingestAuditLogFileLocked ingests a single audit log file (caller must hold rwmu write lock).
+func (s *Store) ingestAuditLogFileLocked(path, repo string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			_, _ = s.db.Exec("DELETE FROM audit_entries WHERE file_path = ?", path)
+			return nil
+		}
+		return err
+	}
+
+	entries := parseAuditLogEntries(string(data))
+
+	// Full replace: delete existing entries for this file, then insert fresh.
+	if _, err := s.db.Exec("DELETE FROM audit_entries WHERE file_path = ?", path); err != nil {
+		return fmt.Errorf("delete old audit entries: %w", err)
+	}
+
+	for _, e := range entries {
+		_, err := s.db.Exec(`
+			INSERT OR IGNORE INTO audit_entries (repo, file_path, date, skill, version, summary, raw_text)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+		`, repo, path, e.Date, e.Skill, e.Version, e.Summary, e.RawText)
+		if err != nil {
+			slog.Error("insert audit entry failed", "file", path, "date", e.Date, "err", err)
+		}
+	}
+	return nil
+}
+
+// SearchAuditLogs searches across all indexed audit log entries.
+func (s *Store) SearchAuditLogs(query string, repo string, skill string, limit int) ([]AuditEntryInfo, error) {
+	s.rwmu.RLock()
+	defer s.rwmu.RUnlock()
+
+	if limit <= 0 {
+		limit = 20
+	}
+
+	if query != "" {
+		ftsQuery := relaxQuery(query)
+		q := `SELECT ae.id, ae.repo, ae.file_path, ae.date, ae.skill, ae.version, ae.summary, ae.raw_text
+			FROM audit_entries ae
+			JOIN audit_entries_fts f ON f.rowid = ae.id
+			WHERE audit_entries_fts MATCH ?`
+		args := []any{ftsQuery}
+		if repo != "" {
+			q += " AND ae.repo LIKE ?"
+			args = append(args, "%"+repo+"%")
+		}
+		if skill != "" {
+			q += " AND ae.skill = ?"
+			args = append(args, skill)
+		}
+		q += " ORDER BY rank LIMIT ?"
+		args = append(args, limit)
+		return s.queryAuditEntries(q, args...)
+	}
+
+	// No query — list with optional filters.
+	where := []string{"1=1"}
+	var args []any
+	if repo != "" {
+		where = append(where, "repo LIKE ?")
+		args = append(args, "%"+repo+"%")
+	}
+	if skill != "" {
+		where = append(where, "skill = ?")
+		args = append(args, skill)
+	}
+	q := `SELECT id, repo, file_path, date, skill, version, summary, raw_text
+		FROM audit_entries WHERE ` + strings.Join(where, " AND ") + ` ORDER BY date DESC LIMIT ?`
+	args = append(args, limit)
+	return s.queryAuditEntries(q, args...)
+}
+
+func (s *Store) queryAuditEntries(q string, args ...any) ([]AuditEntryInfo, error) {
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []AuditEntryInfo
+	for rows.Next() {
+		var e AuditEntryInfo
+		if err := rows.Scan(&e.ID, &e.Repo, &e.FilePath, &e.Date, &e.Skill,
+			&e.Version, &e.Summary, &e.RawText); err != nil {
+			continue
+		}
+		results = append(results, e)
+	}
+	return results, nil
+}
 
 // parsedMessage is a single content block ready for insertion.
 type parsedMessage struct {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -376,6 +376,14 @@ func New(dbPath, projectDir string) (*Store, error) {
 			content TEXT NOT NULL,
 			updated_at TEXT NOT NULL
 		);
+		CREATE TABLE IF NOT EXISTS skills (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			file_path TEXT NOT NULL UNIQUE,
+			name TEXT NOT NULL DEFAULT '',
+			description TEXT NOT NULL DEFAULT '',
+			content TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
 	`)
 	if err != nil {
 		db.Close()
@@ -415,6 +423,7 @@ func New(dbPath, projectDir string) (*Store, error) {
 		CREATE INDEX IF NOT EXISTS idx_snapshot_files_path ON snapshot_files(file_path);
 		CREATE INDEX IF NOT EXISTS idx_memories_project ON memories(project);
 		CREATE INDEX IF NOT EXISTS idx_memories_type ON memories(memory_type);
+		CREATE INDEX IF NOT EXISTS idx_skills_name ON skills(name);
 	`)
 	if err != nil {
 		db.Close()
@@ -451,6 +460,31 @@ func New(dbPath, projectDir string) (*Store, error) {
 		BEGIN
 			INSERT INTO memories_fts(memories_fts, rowid, name, description, content, project)
 			VALUES ('delete', old.id, old.name, old.description, old.content, old.project);
+		END;
+		CREATE VIRTUAL TABLE IF NOT EXISTS skills_fts USING fts5(
+			name, description, content,
+			content=skills,
+			content_rowid=id
+		);
+		DROP TRIGGER IF EXISTS skills_ai;
+		CREATE TRIGGER skills_ai AFTER INSERT ON skills
+		BEGIN
+			INSERT INTO skills_fts(rowid, name, description, content)
+			VALUES (new.id, new.name, new.description, new.content);
+		END;
+		DROP TRIGGER IF EXISTS skills_au;
+		CREATE TRIGGER skills_au AFTER UPDATE ON skills
+		BEGIN
+			INSERT INTO skills_fts(skills_fts, rowid, name, description, content)
+			VALUES ('delete', old.id, old.name, old.description, old.content);
+			INSERT INTO skills_fts(rowid, name, description, content)
+			VALUES (new.id, new.name, new.description, new.content);
+		END;
+		DROP TRIGGER IF EXISTS skills_ad;
+		CREATE TRIGGER skills_ad AFTER DELETE ON skills
+		BEGIN
+			INSERT INTO skills_fts(skills_fts, rowid, name, description, content)
+			VALUES ('delete', old.id, old.name, old.description, old.content);
 		END;
 	`)
 	if err != nil {
@@ -773,6 +807,152 @@ func (s *Store) queryMemories(q string, args ...any) ([]MemoryInfo, error) {
 			continue
 		}
 		results = append(results, m)
+	}
+	return results, nil
+}
+
+// SkillInfo holds a single skill record from the index.
+type SkillInfo struct {
+	ID          int    `json:"id"`
+	FilePath    string `json:"file_path"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Content     string `json:"content"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+// skillsDir returns the path to ~/.claude/skills/.
+func skillsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".claude", "skills"), nil
+}
+
+// IngestSkills scans ~/.claude/skills/*.md and ingests them.
+func (s *Store) IngestSkills() error {
+	dir, err := skillsDir()
+	if err != nil {
+		return err
+	}
+
+	s.rwmu.Lock()
+	defer s.rwmu.Unlock()
+
+	files, err := filepath.Glob(filepath.Join(dir, "*.md"))
+	if err != nil {
+		return err
+	}
+
+	count := 0
+	for _, f := range files {
+		if err := s.ingestSkillFileLocked(f); err != nil {
+			slog.Error("ingest skill failed", "file", f, "err", err)
+			continue
+		}
+		count++
+	}
+	slog.Info("ingested skills", "count", count)
+	return nil
+}
+
+// ingestSkillFile ingests a single skill file (acquires write lock).
+func (s *Store) ingestSkillFile(path string) error {
+	s.rwmu.Lock()
+	defer s.rwmu.Unlock()
+	return s.ingestSkillFileLocked(path)
+}
+
+// ingestSkillFileLocked ingests a single skill file (caller must hold rwmu write lock).
+func (s *Store) ingestSkillFileLocked(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			s.db.Exec("DELETE FROM skills WHERE file_path = ?", path)
+			return nil
+		}
+		return err
+	}
+
+	content := string(data)
+	name, description, _, body := parseMemoryFrontmatter(content)
+
+	// If no frontmatter, derive name from filename and use first non-blank line as description.
+	if name == "" {
+		base := filepath.Base(path)
+		stem := strings.TrimSuffix(base, ".md")
+		name = strings.NewReplacer("-", " ", "_", " ").Replace(stem)
+	}
+	if description == "" {
+		for _, line := range strings.Split(content, "\n") {
+			line = strings.TrimSpace(line)
+			if line != "" && !strings.HasPrefix(line, "#") {
+				description = line
+				break
+			}
+		}
+	}
+	if body == "" {
+		body = content
+	}
+
+	now := time.Now().Format(time.RFC3339)
+	_, err = s.db.Exec(`
+		INSERT INTO skills (file_path, name, description, content, updated_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(file_path) DO UPDATE SET
+			name = excluded.name,
+			description = excluded.description,
+			content = excluded.content,
+			updated_at = excluded.updated_at
+	`, path, name, description, body, now)
+	return err
+}
+
+// deleteSkillFile removes a skill file from the index (acquires write lock).
+func (s *Store) deleteSkillFile(path string) {
+	s.rwmu.Lock()
+	defer s.rwmu.Unlock()
+	s.db.Exec("DELETE FROM skills WHERE file_path = ?", path)
+}
+
+// SearchSkills searches across all indexed skill files.
+func (s *Store) SearchSkills(query string, limit int) ([]SkillInfo, error) {
+	s.rwmu.RLock()
+	defer s.rwmu.RUnlock()
+
+	if limit <= 0 {
+		limit = 20
+	}
+
+	if query == "" {
+		return s.querySkills(`SELECT id, file_path, name, description, content, updated_at
+			FROM skills ORDER BY name ASC LIMIT ?`, limit)
+	}
+
+	ftsQuery := relaxQuery(query)
+	return s.querySkills(`SELECT s.id, s.file_path, s.name, s.description, s.content, s.updated_at
+		FROM skills s
+		JOIN skills_fts f ON f.rowid = s.id
+		WHERE skills_fts MATCH ?
+		ORDER BY rank LIMIT ?`, ftsQuery, limit)
+}
+
+func (s *Store) querySkills(q string, args ...any) ([]SkillInfo, error) {
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []SkillInfo
+	for rows.Next() {
+		var sk SkillInfo
+		if err := rows.Scan(&sk.ID, &sk.FilePath, &sk.Name, &sk.Description, &sk.Content, &sk.UpdatedAt); err != nil {
+			continue
+		}
+		results = append(results, sk)
 	}
 	return results, nil
 }
@@ -1164,6 +1344,13 @@ func (s *Store) Watch() error {
 		return nil
 	})
 
+	// Also watch the skills directory for .md changes.
+	if sdir, err := skillsDir(); err == nil {
+		if wErr := watcher.Add(sdir); wErr != nil {
+			slog.Warn("failed to watch skills directory", "path", sdir, "err", wErr)
+		}
+	}
+
 	slog.Info("watching for transcript changes", "dir", s.projectDir)
 
 	for {
@@ -1187,6 +1374,17 @@ func (s *Store) Watch() error {
 				}
 				if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
 					s.deleteMemoryFile(event.Name)
+				}
+			}
+			// Watch skill file changes.
+			if strings.HasSuffix(event.Name, ".md") && strings.Contains(event.Name, "/.claude/skills/") {
+				if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
+					if err := s.ingestSkillFile(event.Name); err != nil {
+						slog.Error("ingest skill failed", "file", event.Name, "err", err)
+					}
+				}
+				if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
+					s.deleteSkillFile(event.Name)
 				}
 			}
 			if event.Has(fsnotify.Create) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -384,6 +384,13 @@ func New(dbPath, projectDir string) (*Store, error) {
 			content TEXT NOT NULL,
 			updated_at TEXT NOT NULL
 		);
+		CREATE TABLE IF NOT EXISTS claude_configs (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			repo TEXT NOT NULL DEFAULT '',
+			file_path TEXT NOT NULL UNIQUE,
+			content TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
 	`)
 	if err != nil {
 		db.Close()
@@ -424,6 +431,7 @@ func New(dbPath, projectDir string) (*Store, error) {
 		CREATE INDEX IF NOT EXISTS idx_memories_project ON memories(project);
 		CREATE INDEX IF NOT EXISTS idx_memories_type ON memories(memory_type);
 		CREATE INDEX IF NOT EXISTS idx_skills_name ON skills(name);
+		CREATE INDEX IF NOT EXISTS idx_claude_configs_repo ON claude_configs(repo);
 	`)
 	if err != nil {
 		db.Close()
@@ -485,6 +493,31 @@ func New(dbPath, projectDir string) (*Store, error) {
 		BEGIN
 			INSERT INTO skills_fts(skills_fts, rowid, name, description, content)
 			VALUES ('delete', old.id, old.name, old.description, old.content);
+		END;
+		CREATE VIRTUAL TABLE IF NOT EXISTS claude_configs_fts USING fts5(
+			content, repo,
+			content=claude_configs,
+			content_rowid=id
+		);
+		DROP TRIGGER IF EXISTS claude_configs_ai;
+		CREATE TRIGGER claude_configs_ai AFTER INSERT ON claude_configs
+		BEGIN
+			INSERT INTO claude_configs_fts(rowid, content, repo)
+			VALUES (new.id, new.content, new.repo);
+		END;
+		DROP TRIGGER IF EXISTS claude_configs_au;
+		CREATE TRIGGER claude_configs_au AFTER UPDATE ON claude_configs
+		BEGIN
+			INSERT INTO claude_configs_fts(claude_configs_fts, rowid, content, repo)
+			VALUES ('delete', old.id, old.content, old.repo);
+			INSERT INTO claude_configs_fts(rowid, content, repo)
+			VALUES (new.id, new.content, new.repo);
+		END;
+		DROP TRIGGER IF EXISTS claude_configs_ad;
+		CREATE TRIGGER claude_configs_ad AFTER DELETE ON claude_configs
+		BEGIN
+			INSERT INTO claude_configs_fts(claude_configs_fts, rowid, content, repo)
+			VALUES ('delete', old.id, old.content, old.repo);
 		END;
 	`)
 	if err != nil {
@@ -957,6 +990,168 @@ func (s *Store) querySkills(q string, args ...any) ([]SkillInfo, error) {
 	return results, nil
 }
 
+// ClaudeConfigInfo holds a single CLAUDE.md record from the index.
+type ClaudeConfigInfo struct {
+	ID        int    `json:"id"`
+	Repo      string `json:"repo"`
+	FilePath  string `json:"file_path"`
+	Content   string `json:"content"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// IngestClaudeConfigs scans all repo roots discovered via session_meta and ingests CLAUDE.md files.
+// It also checks ~/.claude/CLAUDE.md and ~/CLAUDE.md.
+func (s *Store) IngestClaudeConfigs() error {
+	s.rwmu.Lock()
+	defer s.rwmu.Unlock()
+
+	// Gather unique cwd values from session_meta.
+	rows, err := s.db.Query("SELECT DISTINCT cwd FROM session_meta WHERE cwd != ''")
+	if err != nil {
+		return fmt.Errorf("query session_meta: %w", err)
+	}
+	var cwds []string
+	for rows.Next() {
+		var cwd string
+		if err := rows.Scan(&cwd); err == nil && cwd != "" {
+			cwds = append(cwds, cwd)
+		}
+	}
+	rows.Close()
+
+	// Find repo roots for each cwd by walking up to a .git directory.
+	seen := map[string]bool{}
+	for _, cwd := range cwds {
+		root := findRepoRoot(cwd)
+		if root != "" && !seen[root] {
+			seen[root] = true
+			claudePath := filepath.Join(root, "CLAUDE.md")
+			repo := extractRepo(cwd)
+			if err := s.ingestClaudeConfigFileLocked(claudePath, repo); err != nil && !os.IsNotExist(err) {
+				slog.Error("ingest claude config failed", "file", claudePath, "err", err)
+			}
+		}
+	}
+
+	// Also check ~/.claude/CLAUDE.md and ~/CLAUDE.md.
+	homeDir, err := os.UserHomeDir()
+	if err == nil {
+		for _, extra := range []struct{ path, repo string }{
+			{filepath.Join(homeDir, ".claude", "CLAUDE.md"), "global"},
+			{filepath.Join(homeDir, "CLAUDE.md"), "home"},
+		} {
+			if !seen[extra.path] {
+				seen[extra.path] = true
+				if err := s.ingestClaudeConfigFileLocked(extra.path, extra.repo); err != nil && !os.IsNotExist(err) {
+					slog.Error("ingest claude config failed", "file", extra.path, "err", err)
+				}
+			}
+		}
+	}
+
+	slog.Info("ingested claude configs", "repos", len(seen))
+	return nil
+}
+
+// findRepoRoot walks up from dir to find the nearest directory containing .git.
+// Returns "" if no .git ancestor is found.
+func findRepoRoot(dir string) string {
+	dir = filepath.Clean(dir)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return ""
+}
+
+// ingestClaudeConfigFileLocked ingests a single CLAUDE.md file (caller must hold rwmu write lock).
+func (s *Store) ingestClaudeConfigFileLocked(path, repo string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			s.db.Exec("DELETE FROM claude_configs WHERE file_path = ?", path)
+			return nil
+		}
+		return err
+	}
+
+	content := string(data)
+	now := time.Now().Format(time.RFC3339)
+
+	_, err = s.db.Exec(`
+		INSERT INTO claude_configs (repo, file_path, content, updated_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(file_path) DO UPDATE SET
+			repo = excluded.repo,
+			content = excluded.content,
+			updated_at = excluded.updated_at
+	`, repo, path, content, now)
+	return err
+}
+
+// SearchClaudeConfigs searches across all indexed CLAUDE.md files.
+func (s *Store) SearchClaudeConfigs(query string, repo string, limit int) ([]ClaudeConfigInfo, error) {
+	s.rwmu.RLock()
+	defer s.rwmu.RUnlock()
+
+	if limit <= 0 {
+		limit = 20
+	}
+
+	var q string
+	var args []any
+
+	if query != "" {
+		ftsQuery := relaxQuery(query)
+		q = `SELECT c.id, c.repo, c.file_path, c.content, c.updated_at
+			FROM claude_configs c
+			JOIN claude_configs_fts f ON f.rowid = c.id
+			WHERE claude_configs_fts MATCH ?`
+		args = []any{ftsQuery}
+		if repo != "" {
+			q += " AND c.repo LIKE ?"
+			args = append(args, "%"+repo+"%")
+		}
+		q += " ORDER BY rank LIMIT ?"
+		args = append(args, limit)
+	} else {
+		q = `SELECT id, repo, file_path, content, updated_at FROM claude_configs`
+		if repo != "" {
+			q += " WHERE repo LIKE ?"
+			args = append(args, "%"+repo+"%")
+		}
+		q += " ORDER BY updated_at DESC LIMIT ?"
+		args = append(args, limit)
+	}
+
+	return s.queryClaudeConfigs(q, args...)
+}
+
+func (s *Store) queryClaudeConfigs(q string, args ...any) ([]ClaudeConfigInfo, error) {
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []ClaudeConfigInfo
+	for rows.Next() {
+		var c ClaudeConfigInfo
+		if err := rows.Scan(&c.ID, &c.Repo, &c.FilePath, &c.Content, &c.UpdatedAt); err != nil {
+			continue
+		}
+		results = append(results, c)
+	}
+	return results, nil
+}
+
+
 // parsedMessage is a single content block ready for insertion.
 type parsedMessage struct {
 	entryIdx    int // index into parsedFile.entries
@@ -1352,6 +1547,10 @@ func (s *Store) Watch() error {
 	}
 
 	slog.Info("watching for transcript changes", "dir", s.projectDir)
+	// NOTE: Realtime watching of repo CLAUDE.md files is deferred.
+	// CLAUDE.md files live in repo roots (not under projectDir), and they change
+	// rarely enough that restart-based refresh (via IngestClaudeConfigs at startup)
+	// is acceptable for now.
 
 	for {
 		select {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -224,7 +224,7 @@ func relaxQuery(q string) string {
 
 // schemaVersion is incremented whenever the database schema changes.
 // On mismatch the database file is deleted and rebuilt from transcripts.
-const schemaVersion = 7
+const schemaVersion = 8
 
 func openDB(dbPath string) (*sql.DB, error) {
 	db, err := sql.Open("sqlite3", dbPath)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -402,6 +402,26 @@ func New(dbPath, projectDir string) (*Store, error) {
 			raw_text TEXT NOT NULL,
 			UNIQUE(file_path, date, skill)
 		);
+		CREATE TABLE IF NOT EXISTS targets (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			repo TEXT NOT NULL,
+			file_path TEXT NOT NULL,
+			target_id TEXT NOT NULL DEFAULT '',
+			name TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT '',
+			weight REAL NOT NULL DEFAULT 0,
+			description TEXT NOT NULL DEFAULT '',
+			raw_text TEXT NOT NULL,
+			UNIQUE(file_path, target_id)
+		);
+		CREATE TABLE IF NOT EXISTS plans (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			repo TEXT NOT NULL,
+			file_path TEXT NOT NULL UNIQUE,
+			phase TEXT NOT NULL DEFAULT '',
+			content TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
 	`)
 	if err != nil {
 		db.Close()
@@ -446,6 +466,11 @@ func New(dbPath, projectDir string) (*Store, error) {
 		CREATE INDEX IF NOT EXISTS idx_audit_entries_repo ON audit_entries(repo);
 		CREATE INDEX IF NOT EXISTS idx_audit_entries_date ON audit_entries(date);
 		CREATE INDEX IF NOT EXISTS idx_audit_entries_skill ON audit_entries(skill);
+		CREATE INDEX IF NOT EXISTS idx_targets_repo ON targets(repo);
+		CREATE INDEX IF NOT EXISTS idx_targets_status ON targets(status);
+		CREATE INDEX IF NOT EXISTS idx_targets_target_id ON targets(target_id);
+		CREATE INDEX IF NOT EXISTS idx_plans_repo ON plans(repo);
+		CREATE INDEX IF NOT EXISTS idx_plans_phase ON plans(phase);
 	`)
 	if err != nil {
 		db.Close()
@@ -557,6 +582,56 @@ func New(dbPath, projectDir string) (*Store, error) {
 		BEGIN
 			INSERT INTO claude_configs_fts(claude_configs_fts, rowid, content, repo)
 			VALUES ('delete', old.id, old.content, old.repo);
+		END;
+		CREATE VIRTUAL TABLE IF NOT EXISTS targets_fts USING fts5(
+			name, description, raw_text, repo,
+			content=targets,
+			content_rowid=id
+		);
+		DROP TRIGGER IF EXISTS targets_ai;
+		CREATE TRIGGER targets_ai AFTER INSERT ON targets
+		BEGIN
+			INSERT INTO targets_fts(rowid, name, description, raw_text, repo)
+			VALUES (new.id, new.name, new.description, new.raw_text, new.repo);
+		END;
+		DROP TRIGGER IF EXISTS targets_au;
+		CREATE TRIGGER targets_au AFTER UPDATE ON targets
+		BEGIN
+			INSERT INTO targets_fts(targets_fts, rowid, name, description, raw_text, repo)
+			VALUES ('delete', old.id, old.name, old.description, old.raw_text, old.repo);
+			INSERT INTO targets_fts(rowid, name, description, raw_text, repo)
+			VALUES (new.id, new.name, new.description, new.raw_text, new.repo);
+		END;
+		DROP TRIGGER IF EXISTS targets_ad;
+		CREATE TRIGGER targets_ad AFTER DELETE ON targets
+		BEGIN
+			INSERT INTO targets_fts(targets_fts, rowid, name, description, raw_text, repo)
+			VALUES ('delete', old.id, old.name, old.description, old.raw_text, old.repo);
+		END;
+		CREATE VIRTUAL TABLE IF NOT EXISTS plans_fts USING fts5(
+			content, repo, phase,
+			content=plans,
+			content_rowid=id
+		);
+		DROP TRIGGER IF EXISTS plans_ai;
+		CREATE TRIGGER plans_ai AFTER INSERT ON plans
+		BEGIN
+			INSERT INTO plans_fts(rowid, content, repo, phase)
+			VALUES (new.id, new.content, new.repo, new.phase);
+		END;
+		DROP TRIGGER IF EXISTS plans_au;
+		CREATE TRIGGER plans_au AFTER UPDATE ON plans
+		BEGIN
+			INSERT INTO plans_fts(plans_fts, rowid, content, repo, phase)
+			VALUES ('delete', old.id, old.content, old.repo, old.phase);
+			INSERT INTO plans_fts(rowid, content, repo, phase)
+			VALUES (new.id, new.content, new.repo, new.phase);
+		END;
+		DROP TRIGGER IF EXISTS plans_ad;
+		CREATE TRIGGER plans_ad AFTER DELETE ON plans
+		BEGIN
+			INSERT INTO plans_fts(plans_fts, rowid, content, repo, phase)
+			VALUES ('delete', old.id, old.content, old.repo, old.phase);
 		END;
 	`)
 	if err != nil {
@@ -1203,6 +1278,29 @@ type AuditEntryInfo struct {
 	RawText  string `json:"raw_text"`
 }
 
+// TargetInfo holds a single convergence target from a docs/targets.md file.
+type TargetInfo struct {
+	ID          int     `json:"id"`
+	Repo        string  `json:"repo"`
+	FilePath    string  `json:"file_path"`
+	TargetID    string  `json:"target_id"`
+	Name        string  `json:"name"`
+	Status      string  `json:"status"`
+	Weight      float64 `json:"weight"`
+	Description string  `json:"description"`
+	RawText     string  `json:"raw_text"`
+}
+
+// PlanInfo holds a single indexed plan file.
+type PlanInfo struct {
+	ID        int    `json:"id"`
+	Repo      string `json:"repo"`
+	FilePath  string `json:"file_path"`
+	Phase     string `json:"phase"`
+	Content   string `json:"content"`
+	UpdatedAt string `json:"updated_at"`
+}
+
 // versionPattern matches version strings like v1.2.3.
 var versionPattern = regexp.MustCompile(`v\d+\.\d+\.\d+`)
 
@@ -1446,6 +1544,402 @@ func (s *Store) queryAuditEntries(q string, args ...any) ([]AuditEntryInfo, erro
 			continue
 		}
 		results = append(results, e)
+	}
+	return results, nil
+}
+
+// targetHeading matches a ### 🎯TN or ### 🎯TN.N heading line.
+var targetHeading = regexp.MustCompile(`^### (🎯T[\d]+(?:\.[\d]+)*)\s*(.*)$`)
+
+// parseTargetsFile parses a docs/targets.md file and returns all targets found.
+func parseTargetsFile(repo, filePath string, data []byte) []TargetInfo {
+	lines := strings.Split(string(data), "\n")
+	var targets []TargetInfo
+	var cur *TargetInfo
+	var rawLines []string
+
+	flush := func() {
+		if cur == nil {
+			return
+		}
+		cur.RawText = strings.TrimSpace(strings.Join(rawLines, "\n"))
+		targets = append(targets, *cur)
+		cur = nil
+		rawLines = nil
+	}
+
+	for _, line := range lines {
+		if m := targetHeading.FindStringSubmatch(line); m != nil {
+			flush()
+			cur = &TargetInfo{
+				Repo:     repo,
+				FilePath: filePath,
+				TargetID: m[1],
+				Name:     strings.TrimSpace(m[2]),
+			}
+			rawLines = []string{line}
+			continue
+		}
+		if cur != nil {
+			// Check for next ### heading (non-target) to end the block.
+			if strings.HasPrefix(line, "### ") {
+				flush()
+				continue
+			}
+			rawLines = append(rawLines, line)
+			// Parse metadata lines.
+			if strings.HasPrefix(line, "- **Status**:") {
+				cur.Status = strings.TrimSpace(strings.TrimPrefix(line, "- **Status**:"))
+			} else if strings.HasPrefix(line, "- **Weight**:") {
+				wStr := strings.TrimSpace(strings.TrimPrefix(line, "- **Weight**:"))
+				var w float64
+				fmt.Sscanf(wStr, "%f", &w)
+				cur.Weight = w
+			}
+		}
+	}
+	flush()
+
+	// Extract description: first non-empty, non-metadata paragraph after the metadata lines.
+	for i := range targets {
+		t := &targets[i]
+		bodyLines := strings.Split(t.RawText, "\n")
+		// Skip the heading line and metadata lines.
+		inMeta := true
+		var descLines []string
+		for _, l := range bodyLines[1:] {
+			trimmed := strings.TrimSpace(l)
+			if inMeta {
+				if strings.HasPrefix(trimmed, "- **") || trimmed == "" {
+					continue
+				}
+				inMeta = false
+			}
+			if trimmed == "" && len(descLines) > 0 {
+				break
+			}
+			if trimmed != "" {
+				descLines = append(descLines, trimmed)
+			}
+		}
+		t.Description = strings.Join(descLines, " ")
+	}
+
+	return targets
+}
+
+// IngestTargets scans all repos known from session_meta and ingests their
+// docs/targets.md files. This is run at startup only; no realtime watching.
+func (s *Store) IngestTargets() error {
+	s.rwmu.Lock()
+	defer s.rwmu.Unlock()
+
+	// Collect unique cwds from session_meta.
+	rows, err := s.db.Query("SELECT DISTINCT cwd FROM session_meta WHERE cwd != ''")
+	if err != nil {
+		return fmt.Errorf("query cwds: %w", err)
+	}
+	var cwds []string
+	for rows.Next() {
+		var cwd string
+		if rows.Scan(&cwd) == nil && cwd != "" {
+			cwds = append(cwds, cwd)
+		}
+	}
+	rows.Close()
+
+	// Deduplicate repo roots.
+	seen := map[string]bool{}
+	count := 0
+	for _, cwd := range cwds {
+		root := findRepoRoot(cwd)
+		if root == "" || seen[root] {
+			continue
+		}
+		seen[root] = true
+
+		targetsPath := filepath.Join(root, "docs", "targets.md")
+		data, err := os.ReadFile(targetsPath)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				slog.Warn("cannot read targets.md", "path", targetsPath, "err", err)
+			}
+			continue
+		}
+
+		// Derive repo name from root path.
+		repo := filepath.Base(root)
+
+		parsed := parseTargetsFile(repo, targetsPath, data)
+		if len(parsed) == 0 {
+			continue
+		}
+
+		// Delete existing targets for this file and re-insert.
+		if _, err := s.db.Exec("DELETE FROM targets WHERE file_path = ?", targetsPath); err != nil {
+			slog.Warn("delete targets failed", "path", targetsPath, "err", err)
+			continue
+		}
+		for _, t := range parsed {
+			_, err := s.db.Exec(`
+				INSERT INTO targets (repo, file_path, target_id, name, status, weight, description, raw_text)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+				ON CONFLICT(file_path, target_id) DO UPDATE SET
+					repo = excluded.repo,
+					name = excluded.name,
+					status = excluded.status,
+					weight = excluded.weight,
+					description = excluded.description,
+					raw_text = excluded.raw_text
+			`, t.Repo, t.FilePath, t.TargetID, t.Name, t.Status, t.Weight, t.Description, t.RawText)
+			if err != nil {
+				slog.Warn("insert target failed", "target_id", t.TargetID, "err", err)
+				continue
+			}
+			count++
+		}
+	}
+	slog.Info("ingested targets", "count", count)
+	return nil
+}
+
+// SearchTargets searches across indexed convergence targets.
+func (s *Store) SearchTargets(query string, repo string, status string, limit int) ([]TargetInfo, error) {
+	s.rwmu.RLock()
+	defer s.rwmu.RUnlock()
+
+	if limit <= 0 {
+		limit = 20
+	}
+
+	var q string
+	var args []any
+
+	if query != "" {
+		ftsQuery := relaxQuery(query)
+		q = `SELECT t.id, t.repo, t.file_path, t.target_id, t.name, t.status, t.weight, t.description, t.raw_text
+			FROM targets t
+			JOIN targets_fts f ON f.rowid = t.id
+			WHERE targets_fts MATCH ?`
+		args = []any{ftsQuery}
+		if repo != "" {
+			q += " AND t.repo LIKE ?"
+			args = append(args, "%"+repo+"%")
+		}
+		if status != "" {
+			q += " AND t.status = ?"
+			args = append(args, status)
+		}
+		q += " ORDER BY rank LIMIT ?"
+		args = append(args, limit)
+	} else {
+		where := []string{"1=1"}
+		if repo != "" {
+			where = append(where, "repo LIKE ?")
+			args = append(args, "%"+repo+"%")
+		}
+		if status != "" {
+			where = append(where, "status = ?")
+			args = append(args, status)
+		}
+		q = `SELECT id, repo, file_path, target_id, name, status, weight, description, raw_text
+			FROM targets WHERE ` + strings.Join(where, " AND ") + ` ORDER BY weight DESC, target_id LIMIT ?`
+		args = append(args, limit)
+	}
+
+	return s.queryTargets(q, args...)
+}
+
+func (s *Store) queryTargets(q string, args ...any) ([]TargetInfo, error) {
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []TargetInfo
+	for rows.Next() {
+		var t TargetInfo
+		if err := rows.Scan(&t.ID, &t.Repo, &t.FilePath, &t.TargetID, &t.Name,
+			&t.Status, &t.Weight, &t.Description, &t.RawText); err != nil {
+			continue
+		}
+		results = append(results, t)
+	}
+	return results, nil
+}
+
+// IngestPlans scans .planning/ directories in all known repos and indexes them.
+// Plans change during active GSD work but are read-heavy, so startup-only
+// ingestion is sufficient — no realtime watch is registered.
+func (s *Store) IngestPlans() error {
+	s.rwmu.Lock()
+	defer s.rwmu.Unlock()
+
+	// Collect unique repo roots from all known cwds.
+	rows, err := s.db.Query("SELECT DISTINCT cwd FROM session_meta WHERE cwd != ''")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	seen := map[string]bool{}
+	for rows.Next() {
+		var cwd string
+		if err := rows.Scan(&cwd); err != nil {
+			continue
+		}
+		root := findRepoRoot(cwd)
+		if root != "" && !seen[root] {
+			seen[root] = true
+		}
+	}
+	rows.Close()
+
+	count := 0
+	for root := range seen {
+		planningDir := filepath.Join(root, ".planning")
+		if _, err := os.Stat(planningDir); os.IsNotExist(err) {
+			continue
+		}
+		repo := extractRepo(root)
+
+		// Walk all .md files under .planning/
+		if err := filepath.Walk(planningDir, func(path string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() {
+				return nil
+			}
+			if strings.ToLower(filepath.Ext(path)) != ".md" {
+				return nil
+			}
+			if err2 := s.ingestPlanFileLocked(path, repo, planningDir); err2 != nil {
+				slog.Error("ingest plan failed", "file", path, "err", err2)
+			} else {
+				count++
+			}
+			return nil
+		}); err != nil {
+			slog.Error("walk planning dir failed", "dir", planningDir, "err", err)
+		}
+	}
+	slog.Info("ingested plans", "count", count)
+	return nil
+}
+
+// ingestPlanFileLocked ingests a single plan file (caller must hold rwmu write lock).
+func (s *Store) ingestPlanFileLocked(path, repo, planningDir string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			s.db.Exec("DELETE FROM plans WHERE file_path = ?", path)
+			return nil
+		}
+		return err
+	}
+
+	// Derive phase from the relative path under .planning/.
+	// e.g. .planning/phase-3/PLAN.md → "3"
+	//      .planning/milestone-v2/phase-1/PLAN.md → "v2/1"
+	//      .planning/PLAN.md → ""
+	rel, err := filepath.Rel(planningDir, path)
+	if err != nil {
+		rel = ""
+	}
+	phase := extractPlanPhase(rel)
+
+	now := time.Now().Format(time.RFC3339)
+	_, err = s.db.Exec(`
+		INSERT INTO plans (repo, file_path, phase, content, updated_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(file_path) DO UPDATE SET
+			repo = excluded.repo,
+			phase = excluded.phase,
+			content = excluded.content,
+			updated_at = excluded.updated_at
+	`, repo, path, phase, string(data), now)
+	return err
+}
+
+// extractPlanPhase derives a short phase identifier from a path relative to .planning/.
+// Examples:
+//
+//	"PLAN.md"                        → ""
+//	"phase-3/PLAN.md"                → "3"
+//	"milestone-v2/phase-1/PLAN.md"   → "v2/1"
+//	"codebase/overview.md"           → "codebase"
+func extractPlanPhase(rel string) string {
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	// Drop the filename component.
+	if len(parts) <= 1 {
+		return ""
+	}
+	dirs := parts[:len(parts)-1]
+
+	var segments []string
+	for _, d := range dirs {
+		// Strip common prefixes: "phase-", "milestone-" to get the identifier.
+		lower := strings.ToLower(d)
+		for _, prefix := range []string{"phase-", "milestone-"} {
+			if strings.HasPrefix(lower, prefix) {
+				d = d[len(prefix):]
+				break
+			}
+		}
+		segments = append(segments, d)
+	}
+	return strings.Join(segments, "/")
+}
+
+// SearchPlans searches across all indexed plan files.
+func (s *Store) SearchPlans(query string, repo string, limit int) ([]PlanInfo, error) {
+	s.rwmu.RLock()
+	defer s.rwmu.RUnlock()
+
+	if limit <= 0 {
+		limit = 20
+	}
+
+	if query == "" {
+		q := `SELECT id, repo, file_path, phase, content, updated_at FROM plans`
+		var args []any
+		if repo != "" {
+			q += ` WHERE repo LIKE ?`
+			args = append(args, "%"+repo+"%")
+		}
+		q += ` ORDER BY updated_at DESC LIMIT ?`
+		args = append(args, limit)
+		return s.queryPlans(q, args...)
+	}
+
+	ftsQuery := relaxQuery(query)
+	q := `SELECT p.id, p.repo, p.file_path, p.phase, p.content, p.updated_at
+		FROM plans p
+		JOIN plans_fts f ON f.rowid = p.id
+		WHERE plans_fts MATCH ?`
+	args := []any{ftsQuery}
+	if repo != "" {
+		q += ` AND p.repo LIKE ?`
+		args = append(args, "%"+repo+"%")
+	}
+	q += ` ORDER BY rank LIMIT ?`
+	args = append(args, limit)
+	return s.queryPlans(q, args...)
+}
+
+func (s *Store) queryPlans(q string, args ...any) ([]PlanInfo, error) {
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []PlanInfo
+	for rows.Next() {
+		var p PlanInfo
+		if err := rows.Scan(&p.ID, &p.Repo, &p.FilePath, &p.Phase, &p.Content, &p.UpdatedAt); err != nil {
+			continue
+		}
+		results = append(results, p)
 	}
 	return results, nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1626,3 +1626,243 @@ Chronological record of maintenance activities.
 		t.Fatalf("expected 3 audit entries after re-ingest (no duplicates), got %v", rows[0]["cnt"])
 	}
 }
+
+func TestTargetIngest(t *testing.T) {
+	// Create a fake repo with .git and docs/targets.md.
+	repoDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoDir, "docs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	targetsContent := `# Convergence Targets
+
+### 🎯T1 All tests pass on CI
+
+- **Status**: converging
+- **Weight**: 8
+
+The CI pipeline should run all unit and integration tests and report green
+on every pull request before merge.
+
+### 🎯T2 Documentation is complete
+
+- **Status**: identified
+- **Weight**: 5
+
+All public APIs and user-facing features must have documentation.
+
+### 🎯T3 Achieved target example
+
+- **Status**: achieved
+- **Weight**: 3
+
+This target has already been completed.
+`
+	if err := os.WriteFile(filepath.Join(repoDir, "docs", "targets.md"), []byte(targetsContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a session that uses this repo as cwd.
+	projectDir := t.TempDir()
+	writeJSONL(t, projectDir, "myproject", "sess-targets", []map[string]any{
+		metaMsg("user", "working on CI", "2026-04-01T10:00:00Z", repoDir, "master"),
+		msg("assistant", "OK, I'll look at CI.", "2026-04-01T10:00:05Z"),
+	})
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.IngestTargets(); err != nil {
+		t.Fatal(err)
+	}
+
+	// List all targets.
+	results, err := s.SearchTargets("", "", "", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 targets, got %d", len(results))
+	}
+
+	// Find T1 and verify parsed fields.
+	var t1 *TargetInfo
+	for i := range results {
+		if results[i].TargetID == "🎯T1" {
+			t1 = &results[i]
+			break
+		}
+	}
+	if t1 == nil {
+		t.Fatal("expected to find 🎯T1")
+	}
+	if t1.Name != "All tests pass on CI" {
+		t.Errorf("T1 name = %q, want %q", t1.Name, "All tests pass on CI")
+	}
+	if t1.Status != "converging" {
+		t.Errorf("T1 status = %q, want %q", t1.Status, "converging")
+	}
+	if t1.Weight != 8 {
+		t.Errorf("T1 weight = %v, want 8", t1.Weight)
+	}
+	if t1.Description == "" {
+		t.Error("T1 description should not be empty")
+	}
+	if t1.RawText == "" {
+		t.Error("T1 raw_text should not be empty")
+	}
+	if t1.Repo == "" {
+		t.Error("T1 repo should not be empty")
+	}
+
+	// Filter by status.
+	results, err = s.SearchTargets("", "", "identified", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 target with status=identified, got %d", len(results))
+	}
+	if results[0].TargetID != "🎯T2" {
+		t.Errorf("expected 🎯T2, got %s", results[0].TargetID)
+	}
+
+	// Filter by status=achieved.
+	results, err = s.SearchTargets("", "", "achieved", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].TargetID != "🎯T3" {
+		t.Errorf("expected 🎯T3 with status=achieved, got %v", results)
+	}
+
+	// FTS search.
+	results, err = s.SearchTargets("documentation APIs", "", "", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected FTS results for 'documentation APIs'")
+	}
+}
+
+func TestPlanIngest(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// Create a fake repo with a .git directory to make findRepoRoot work.
+	repoRoot := filepath.Join(projectDir, "work", "github.com", "testorg", "myrepo")
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create .planning/ structure:
+	//   .planning/phase-1/PLAN.md
+	//   .planning/milestone-v2/phase-1/PLAN.md
+	//   .planning/OVERVIEW.md
+	planDir := filepath.Join(repoRoot, ".planning")
+	if err := os.MkdirAll(filepath.Join(planDir, "phase-1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(planDir, "milestone-v2", "phase-1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile := func(path, content string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile(filepath.Join(planDir, "phase-1", "PLAN.md"),
+		"# Phase 1\n\nImplement the widget factory using dependency injection.\n")
+	writeFile(filepath.Join(planDir, "milestone-v2", "phase-1", "PLAN.md"),
+		"# Milestone v2 Phase 1\n\nRefactor widget factory for performance.\n")
+	writeFile(filepath.Join(planDir, "OVERVIEW.md"),
+		"# Overview\n\nHigh-level architecture for the widget system.\n")
+
+	// Seed session_meta so IngestPlans can discover the repo root.
+	writeJSONL(t, projectDir, "testorg-myrepo", "sess-plan1", []map[string]any{
+		msg("user", "hello", "2026-04-01T10:00:00Z"),
+	})
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Manually insert a session_meta row pointing at the repo.
+	if _, err := s.db.Exec(
+		"INSERT OR IGNORE INTO session_meta (session_id, cwd) VALUES (?, ?)",
+		"sess-plan1", repoRoot,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.IngestPlans(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Search for "widget factory" — should find phase-1 PLAN.md.
+	results, err := s.SearchPlans("widget factory", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected plan search results for 'widget factory'")
+	}
+	t.Logf("found %d results", len(results))
+
+	// Verify phase parsing.
+	phaseMap := map[string]string{}
+	for _, r := range results {
+		t.Logf("  file=%q phase=%q repo=%q", r.FilePath, r.Phase, r.Repo)
+		phaseMap[r.Phase] = r.FilePath
+	}
+
+	// phase-1/PLAN.md → phase "1"
+	if _, ok := phaseMap["1"]; !ok {
+		t.Errorf("expected phase '1' in results, got: %v", phaseMap)
+	}
+
+	// List all plans (no query).
+	all, err := s.SearchPlans("", "", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) < 3 {
+		t.Errorf("expected at least 3 plans (3 files), got %d", len(all))
+	}
+
+	// Check milestone-v2/phase-1 → phase "v2/1"
+	foundMilestone := false
+	for _, r := range all {
+		if r.Phase == "v2/1" {
+			foundMilestone = true
+		}
+	}
+	if !foundMilestone {
+		t.Error("expected phase 'v2/1' for milestone-v2/phase-1/PLAN.md")
+	}
+
+	// Filter by repo.
+	filtered, err := s.SearchPlans("", "testorg/myrepo", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered) == 0 {
+		t.Error("expected results when filtering by repo 'testorg/myrepo'")
+	}
+
+	// Fuzzy OR search — "performance architecture" should match via OR.
+	fuzzy, err := s.SearchPlans("performance architecture", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fuzzy) == 0 {
+		t.Error("expected fuzzy OR results for 'performance architecture'")
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1263,3 +1263,126 @@ func TestRelaxQuery(t *testing.T) {
 		}
 	}
 }
+
+func TestSkillIngest(t *testing.T) {
+	projectDir := t.TempDir()
+	skillsDir := t.TempDir()
+
+	// Write a skill file with YAML frontmatter.
+	skillContent := `---
+name: release workflow
+description: Steps to publish a new release with CI and Homebrew tap
+---
+
+1. Bump the version constant in main.go.
+2. Run the release CI workflow via GitHub Actions.
+3. Update the Homebrew tap formula with the new sha256 checksums.
+`
+	if err := os.WriteFile(filepath.Join(skillsDir, "release.md"), []byte(skillContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a skill file without frontmatter — name derived from filename.
+	plainContent := `Use this skill to audit the codebase for code quality,
+security issues, and documentation gaps.`
+	if err := os.WriteFile(filepath.Join(skillsDir, "audit-codebase.md"), []byte(plainContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newTestStore(t, projectDir)
+
+	// Directly ingest from the temp skills dir using ingestSkillFileLocked.
+	s.rwmu.Lock()
+	for _, name := range []string{"release.md", "audit-codebase.md"} {
+		if err := s.ingestSkillFileLocked(filepath.Join(skillsDir, name)); err != nil {
+			s.rwmu.Unlock()
+			t.Fatalf("ingest skill %s: %v", name, err)
+		}
+	}
+	s.rwmu.Unlock()
+
+	// Search for "release" should find the release skill.
+	results, err := s.SearchSkills("release", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected results for 'release'")
+	}
+	found := false
+	for _, r := range results {
+		t.Logf("result: name=%q description=%.60q", r.Name, r.Description)
+		if r.Name == "release workflow" {
+			found = true
+			if r.Description != "Steps to publish a new release with CI and Homebrew tap" {
+				t.Errorf("unexpected description: %q", r.Description)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected to find skill 'release workflow'")
+	}
+
+	// Filename-derived name for the plain skill.
+	results, err = s.SearchSkills("audit codebase", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found = false
+	for _, r := range results {
+		if r.Name == "audit codebase" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected to find skill 'audit codebase'")
+	}
+
+	// List all (empty query).
+	results, err = s.SearchSkills("", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) < 2 {
+		t.Errorf("expected at least 2 skills, got %d", len(results))
+	}
+
+	// Update a skill file and re-ingest.
+	updatedContent := `---
+name: release workflow
+description: Updated release steps including signing
+---
+
+Updated content.
+`
+	if err := os.WriteFile(filepath.Join(skillsDir, "release.md"), []byte(updatedContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.rwmu.Lock()
+	if err := s.ingestSkillFileLocked(filepath.Join(skillsDir, "release.md")); err != nil {
+		s.rwmu.Unlock()
+		t.Fatal(err)
+	}
+	s.rwmu.Unlock()
+
+	results, err = s.SearchSkills("signing", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected updated skill to be searchable by new description")
+	}
+
+	// Delete the skill.
+	s.deleteSkillFile(filepath.Join(skillsDir, "release.md"))
+	results, err = s.SearchSkills("release workflow", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range results {
+		if r.Name == "release workflow" {
+			t.Error("expected deleted skill to be removed from index")
+		}
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1490,3 +1490,139 @@ Merged to master via squash PR.
 		t.Fatal("expected results for updated content 'library'")
 	}
 }
+
+func TestAuditLogIngest(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// Create a fake repo with a .git marker and docs/audit-log.md.
+	repoDir := filepath.Join(t.TempDir(), "myorg", "myrepo")
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	docsDir := filepath.Join(repoDir, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	auditContent := `# Audit Log
+
+Chronological record of maintenance activities.
+
+## 2026-04-06 — /release v0.1.0
+
+- **Commit**: ` + "`" + `abc123` + "`" + `
+- **Outcome**: Released v0.1.0 with initial features.
+
+## 2026-04-07 — /audit
+
+- Reviewed code quality and security.
+- No critical issues found.
+
+## 2026-04-08 — /release v0.2.0
+
+- **Commit**: ` + "`" + `def456` + "`" + `
+- **Outcome**: Released v0.2.0 with bug fixes.
+`
+	auditPath := filepath.Join(docsDir, "audit-log.md")
+	if err := os.WriteFile(auditPath, []byte(auditContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a session with cwd pointing to the repo so IngestAuditLogs can discover it.
+	writeJSONL(t, projectDir, "myproject", "sess-audit", []map[string]any{
+		metaMsg("user", "working on repo", "2026-04-08T10:00:00Z",
+			repoDir, "master"),
+	})
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.IngestAuditLogs(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have 3 entries.
+	rows, err := s.Query("SELECT COUNT(*) AS cnt FROM audit_entries")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cnt, ok := rows[0]["cnt"].(int64); !ok || cnt != 3 {
+		t.Fatalf("expected 3 audit entries, got %v", rows[0]["cnt"])
+	}
+
+	// Verify parsed fields for the first release entry.
+	results, err := s.SearchAuditLogs("", "", "release", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 release entries, got %d", len(results))
+	}
+	// Results are ordered by date DESC.
+	first := results[0]
+	if first.Date != "2026-04-08" {
+		t.Errorf("expected date 2026-04-08, got %q", first.Date)
+	}
+	if first.Skill != "release" {
+		t.Errorf("expected skill 'release', got %q", first.Skill)
+	}
+	if first.Version != "v0.2.0" {
+		t.Errorf("expected version v0.2.0, got %q", first.Version)
+	}
+
+	// Verify the audit entry (no version).
+	auditResults, err := s.SearchAuditLogs("", "", "audit", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(auditResults) != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", len(auditResults))
+	}
+	if auditResults[0].Version != "" {
+		t.Errorf("expected empty version for audit entry, got %q", auditResults[0].Version)
+	}
+	if auditResults[0].Date != "2026-04-07" {
+		t.Errorf("expected date 2026-04-07, got %q", auditResults[0].Date)
+	}
+
+	// FTS search.
+	ftsResults, err := s.SearchAuditLogs("bug fixes", "", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ftsResults) == 0 {
+		t.Fatal("expected FTS search to find 'bug fixes'")
+	}
+	found := false
+	for _, r := range ftsResults {
+		if r.Version == "v0.2.0" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected to find v0.2.0 entry via FTS 'bug fixes'")
+	}
+
+	// Filter by repo.
+	repoResults, err := s.SearchAuditLogs("", "myrepo", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(repoResults) != 3 {
+		t.Fatalf("expected 3 results for repo filter 'myrepo', got %d", len(repoResults))
+	}
+
+	// Re-ingest should replace all entries (not duplicate them).
+	if err := s.IngestAuditLogs(); err != nil {
+		t.Fatal(err)
+	}
+	rows, err = s.Query("SELECT COUNT(*) AS cnt FROM audit_entries")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cnt, ok := rows[0]["cnt"].(int64); !ok || cnt != 3 {
+		t.Fatalf("expected 3 audit entries after re-ingest (no duplicates), got %v", rows[0]["cnt"])
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1386,3 +1386,107 @@ Updated content.
 		}
 	}
 }
+
+func TestClaudeConfigIngest(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// Create a fake repo directory with a .git marker and CLAUDE.md.
+	repoDir := filepath.Join(t.TempDir(), "work", "github.com", "acme", "myrepo")
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	claudeContent := `# myrepo
+
+## Build & Run
+
+` + "```bash\nmake build\n```" + `
+
+## Delivery
+
+Merged to master via squash PR.
+`
+	if err := os.WriteFile(filepath.Join(repoDir, "CLAUDE.md"), []byte(claudeContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a session_meta row pointing cwd into the repo.
+	writeJSONL(t, projectDir, "myproject", "sess-cfg1", []map[string]any{
+		metaMsg("user", "let's build this", "2026-04-01T10:00:00Z",
+			filepath.Join(repoDir, "internal", "store"), "master"),
+	})
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.IngestClaudeConfigs(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Search for "squash" should find the CLAUDE.md.
+	results, err := s.SearchClaudeConfigs("squash", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected results for 'squash' in CLAUDE.md")
+	}
+	found := false
+	for _, r := range results {
+		if r.FilePath == filepath.Join(repoDir, "CLAUDE.md") {
+			found = true
+			if r.Repo == "" {
+				t.Error("expected non-empty repo in ClaudeConfigInfo")
+			}
+			t.Logf("found config: repo=%q path=%q content=%.80q", r.Repo, r.FilePath, r.Content)
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected to find config at %s", filepath.Join(repoDir, "CLAUDE.md"))
+	}
+
+	// List all (no query).
+	all, err := s.SearchClaudeConfigs("", "", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) == 0 {
+		t.Fatal("expected at least one config in list-all mode")
+	}
+
+	// Repo filter — should find by fragment.
+	filtered, err := s.SearchClaudeConfigs("", "myrepo", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered) == 0 {
+		t.Fatal("expected results for repo filter 'myrepo'")
+	}
+
+	// Repo filter — no match.
+	none, err := s.SearchClaudeConfigs("", "doesnotexist", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(none) != 0 {
+		t.Errorf("expected no results for repo filter 'doesnotexist', got %d", len(none))
+	}
+
+	// Update the CLAUDE.md and re-ingest.
+	updatedContent := claudeContent + "\n## Gates\nprofile: library\n"
+	if err := os.WriteFile(filepath.Join(repoDir, "CLAUDE.md"), []byte(updatedContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.IngestClaudeConfigs(); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err = s.SearchClaudeConfigs("library", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected results for updated content 'library'")
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -107,6 +107,9 @@ Tables:
     — auto-memory files from ~/.claude/projects/*/memory/*.md
     — memory_type: user, feedback, project, reference
   memories_fts — FTS5 on name, description, content, project
+  skills (id, file_path, name, description, content, updated_at)
+    — skill files from ~/.claude/skills/*.md
+  skills_fts — FTS5 on name, description, content
 
 Join pattern — message with its entry metadata:
   SELECT m.text, e.model, e.input_tokens FROM messages m JOIN entries e ON e.id = m.entry_id
@@ -169,6 +172,11 @@ Returns per-period breakdown and totals. Cost estimates use published Anthropic 
 			mcp.WithString("model", mcp.Description(`Filter by model prefix (e.g. "claude-opus-4", "claude-sonnet-4")`)),
 			mcp.WithString("group_by", mcp.Description(`Group results by: "day" (default), "model", or "repo"`)),
 		),
+		mcp.NewTool("mnemo_skills",
+			mcp.WithDescription(`Search across Claude Code skill files (~/.claude/skills/). Skills define reusable workflows — release processes, audit procedures, documentation generation, etc. Use this to discover relevant skills or understand what workflows are available.`),
+			mcp.WithString("query", mcp.Description("Search query (fuzzy OR matching). Omit to list all.")),
+			mcp.WithNumber("limit", mcp.Description("Max results (default 20)")),
+		),
 		mcp.NewTool("mnemo_self",
 			mcp.WithDescription(`Discover the calling session's ID. Two-phase protocol:
 
@@ -204,6 +212,8 @@ func (h *Handler) Call(name string, args map[string]any) (string, bool, error) {
 		return h.stats()
 	case "mnemo_memories":
 		return h.memories(args)
+	case "mnemo_skills":
+		return h.skills(args)
 	case "mnemo_usage":
 		return h.usage(args)
 	case "mnemo_self":
@@ -497,6 +507,28 @@ func (h *Handler) memories(args map[string]any) (string, bool, error) {
 		}
 		fmt.Fprintf(&b, "## %s [%s] (%s)\n%s\n\n%s\n\n",
 			m.Name, m.MemoryType, proj, m.Description, m.Content)
+	}
+	return b.String(), false, nil
+}
+
+func (h *Handler) skills(args map[string]any) (string, bool, error) {
+	query, _ := args["query"].(string)
+	limit := 20
+	if l, ok := args["limit"].(float64); ok && l > 0 {
+		limit = int(l)
+	}
+
+	results, err := h.mem.SearchSkills(query, limit)
+	if err != nil {
+		return fmt.Sprintf("skill search failed: %v", err), true, nil
+	}
+	if len(results) == 0 {
+		return "No skills found.", false, nil
+	}
+
+	var b strings.Builder
+	for _, sk := range results {
+		fmt.Fprintf(&b, "## %s\n%s\n\n%s\n\n", sk.Name, sk.Description, sk.Content)
 	}
 	return b.String(), false, nil
 }

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -197,6 +197,19 @@ Returns per-period breakdown and totals. Cost estimates use published Anthropic 
 			mcp.WithString("skill", mcp.Description("Filter by skill name (e.g. 'release', 'audit')")),
 			mcp.WithNumber("limit", mcp.Description("Max results (default 20)")),
 		),
+		mcp.NewTool("mnemo_targets",
+			mcp.WithDescription(`Search across convergence targets (docs/targets.md) from all repos. Targets track desired states — features to build, bugs to fix, quality gaps to close. Use this to find targets across projects, check what's active/achieved, or discover cross-project priorities.`),
+			mcp.WithString("query", mcp.Description("Search query (fuzzy OR matching). Omit to list all.")),
+			mcp.WithString("repo", mcp.Description("Filter by repo name")),
+			mcp.WithString("status", mcp.Description("Filter by status: identified, converging, achieved")),
+			mcp.WithNumber("limit", mcp.Description("Max results (default 20)")),
+		),
+		mcp.NewTool("mnemo_plans",
+			mcp.WithDescription(`Search across implementation plans (.planning/ directories) from all repos. Plans contain architectural decisions, task breakdowns, and implementation reasoning from GSD workflows. Use this to find past design decisions or understand how features were planned.`),
+			mcp.WithString("query", mcp.Description("Search query (fuzzy OR matching). Omit to list all.")),
+			mcp.WithString("repo", mcp.Description("Filter by repo name")),
+			mcp.WithNumber("limit", mcp.Description("Max results (default 20)")),
+		),
 		mcp.NewTool("mnemo_self",
 			mcp.WithDescription(`Discover the calling session's ID. Two-phase protocol:
 
@@ -240,6 +253,10 @@ func (h *Handler) Call(name string, args map[string]any) (string, bool, error) {
 		return h.configs(args)
 	case "mnemo_audit":
 		return h.auditLogs(args)
+	case "mnemo_targets":
+		return h.targets(args)
+	case "mnemo_plans":
+		return h.plans(args)
 	case "mnemo_self":
 		return h.self(args)
 	default:
@@ -627,6 +644,69 @@ func (h *Handler) auditLogs(args map[string]any) (string, bool, error) {
 		return fmt.Sprintf("marshal failed: %v", err), true, nil
 	}
 	return string(out), false, nil
+}
+
+func (h *Handler) targets(args map[string]any) (string, bool, error) {
+	query, _ := args["query"].(string)
+	repo, _ := args["repo"].(string)
+	status, _ := args["status"].(string)
+	limit := 20
+	if l, ok := args["limit"].(float64); ok && l > 0 {
+		limit = int(l)
+	}
+
+	results, err := h.mem.SearchTargets(query, repo, status, limit)
+	if err != nil {
+		return fmt.Sprintf("targets search failed: %v", err), true, nil
+	}
+	if len(results) == 0 {
+		return "No targets found.", false, nil
+	}
+
+	var b strings.Builder
+	for _, t := range results {
+		statusStr := t.Status
+		if statusStr == "" {
+			statusStr = "unknown"
+		}
+		weightStr := ""
+		if t.Weight != 0 {
+			weightStr = fmt.Sprintf(" weight=%.1f", t.Weight)
+		}
+		fmt.Fprintf(&b, "## %s %s [%s%s] (%s)\n", t.TargetID, t.Name, statusStr, weightStr, t.Repo)
+		if t.Description != "" {
+			fmt.Fprintf(&b, "%s\n", t.Description)
+		}
+		b.WriteByte('\n')
+	}
+	return b.String(), false, nil
+}
+
+func (h *Handler) plans(args map[string]any) (string, bool, error) {
+	query, _ := args["query"].(string)
+	repoFilter, _ := args["repo"].(string)
+	limit := 20
+	if l, ok := args["limit"].(float64); ok && l > 0 {
+		limit = int(l)
+	}
+
+	results, err := h.mem.SearchPlans(query, repoFilter, limit)
+	if err != nil {
+		return fmt.Sprintf("plan search failed: %v", err), true, nil
+	}
+	if len(results) == 0 {
+		return "No plans found.", false, nil
+	}
+
+	var b strings.Builder
+	for _, p := range results {
+		phase := p.Phase
+		if phase == "" {
+			phase = "(root)"
+		}
+		fmt.Fprintf(&b, "## %s [phase: %s] (%s)\n\n%s\n\n", p.FilePath, phase, p.Repo, p.Content)
+	}
+	return b.String(), false, nil
 }
 
 func (h *Handler) self(args map[string]any) (string, bool, error) {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -110,6 +110,9 @@ Tables:
   skills (id, file_path, name, description, content, updated_at)
     — skill files from ~/.claude/skills/*.md
   skills_fts — FTS5 on name, description, content
+  claude_configs (id, repo, file_path, content, updated_at)
+    — CLAUDE.md project instruction files from all repo roots
+  claude_configs_fts — FTS5 on content, repo
 
 Join pattern — message with its entry metadata:
   SELECT m.text, e.model, e.input_tokens FROM messages m JOIN entries e ON e.id = m.entry_id
@@ -177,6 +180,12 @@ Returns per-period breakdown and totals. Cost estimates use published Anthropic 
 			mcp.WithString("query", mcp.Description("Search query (fuzzy OR matching). Omit to list all.")),
 			mcp.WithNumber("limit", mcp.Description("Max results (default 20)")),
 		),
+		mcp.NewTool("mnemo_configs",
+			mcp.WithDescription(`Search across CLAUDE.md project instruction files from all repos. These files contain build instructions, conventions, delivery definitions, and project-specific agent guidance. Use this to understand how other projects are configured or to find cross-project patterns.`),
+			mcp.WithString("query", mcp.Description("Search query (fuzzy OR matching). Omit to list all.")),
+			mcp.WithString("repo", mcp.Description("Filter by repo name or path fragment")),
+			mcp.WithNumber("limit", mcp.Description("Max results (default 20)")),
+		),
 		mcp.NewTool("mnemo_self",
 			mcp.WithDescription(`Discover the calling session's ID. Two-phase protocol:
 
@@ -216,6 +225,8 @@ func (h *Handler) Call(name string, args map[string]any) (string, bool, error) {
 		return h.skills(args)
 	case "mnemo_usage":
 		return h.usage(args)
+	case "mnemo_configs":
+		return h.configs(args)
 	case "mnemo_self":
 		return h.self(args)
 	default:
@@ -532,6 +543,30 @@ func (h *Handler) skills(args map[string]any) (string, bool, error) {
 	}
 	return b.String(), false, nil
 }
+
+func (h *Handler) configs(args map[string]any) (string, bool, error) {
+	query, _ := args["query"].(string)
+	repoFilter, _ := args["repo"].(string)
+	limit := 20
+	if l, ok := args["limit"].(float64); ok && l > 0 {
+		limit = int(l)
+	}
+
+	results, err := h.mem.SearchClaudeConfigs(query, repoFilter, limit)
+	if err != nil {
+		return fmt.Sprintf("config search failed: %v", err), true, nil
+	}
+	if len(results) == 0 {
+		return "No CLAUDE.md configs found.", false, nil
+	}
+
+	var b strings.Builder
+	for _, c := range results {
+		fmt.Fprintf(&b, "## %s\n**Path:** %s\n\n%s\n\n---\n\n", c.Repo, c.FilePath, c.Content)
+	}
+	return b.String(), false, nil
+}
+
 
 func (h *Handler) usage(args map[string]any) (string, bool, error) {
 	days := 30

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -113,6 +113,10 @@ Tables:
   claude_configs (id, repo, file_path, content, updated_at)
     — CLAUDE.md project instruction files from all repo roots
   claude_configs_fts — FTS5 on content, repo
+  audit_entries (id, repo, file_path, date, skill, version, summary, raw_text)
+    — parsed entries from docs/audit-log.md in each repo
+    — skill: release, audit, docs, etc. version: vN.N.N if present
+  audit_entries_fts — FTS5 on summary, raw_text, repo
 
 Join pattern — message with its entry metadata:
   SELECT m.text, e.model, e.input_tokens FROM messages m JOIN entries e ON e.id = m.entry_id
@@ -186,6 +190,13 @@ Returns per-period breakdown and totals. Cost estimates use published Anthropic 
 			mcp.WithString("repo", mcp.Description("Filter by repo name or path fragment")),
 			mcp.WithNumber("limit", mcp.Description("Max results (default 20)")),
 		),
+		mcp.NewTool("mnemo_audit",
+			mcp.WithDescription(`Search across audit logs (docs/audit-log.md) from all repos. Audit logs record maintenance activities: releases, audits, documentation runs. Use this to check when a project was last released, find maintenance patterns across repos, or review past audit findings.`),
+			mcp.WithString("query", mcp.Description("Search query (fuzzy OR matching). Omit to list all.")),
+			mcp.WithString("repo", mcp.Description("Filter by repo name")),
+			mcp.WithString("skill", mcp.Description("Filter by skill name (e.g. 'release', 'audit')")),
+			mcp.WithNumber("limit", mcp.Description("Max results (default 20)")),
+		),
 		mcp.NewTool("mnemo_self",
 			mcp.WithDescription(`Discover the calling session's ID. Two-phase protocol:
 
@@ -227,6 +238,8 @@ func (h *Handler) Call(name string, args map[string]any) (string, bool, error) {
 		return h.usage(args)
 	case "mnemo_configs":
 		return h.configs(args)
+	case "mnemo_audit":
+		return h.auditLogs(args)
 	case "mnemo_self":
 		return h.self(args)
 	default:
@@ -586,6 +599,30 @@ func (h *Handler) usage(args map[string]any) (string, bool, error) {
 	}
 
 	out, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("marshal failed: %v", err), true, nil
+	}
+	return string(out), false, nil
+}
+
+func (h *Handler) auditLogs(args map[string]any) (string, bool, error) {
+	query, _ := args["query"].(string)
+	repo, _ := args["repo"].(string)
+	skill, _ := args["skill"].(string)
+	limit := 20
+	if l, ok := args["limit"].(float64); ok && l > 0 {
+		limit = int(l)
+	}
+
+	results, err := h.mem.SearchAuditLogs(query, repo, skill, limit)
+	if err != nil {
+		return fmt.Sprintf("audit log search failed: %v", err), true, nil
+	}
+	if len(results) == 0 {
+		return "No audit log entries found.", false, nil
+	}
+
+	out, err := json.MarshalIndent(results, "", "  ")
 	if err != nil {
 		return fmt.Sprintf("marshal failed: %v", err), true, nil
 	}

--- a/main.go
+++ b/main.go
@@ -101,6 +101,9 @@ func runServe() {
 		if err := mem.IngestSkills(); err != nil {
 			slog.Error("skill ingest failed", "err", err)
 		}
+		if err := mem.IngestClaudeConfigs(); err != nil {
+			slog.Error("claude config ingest failed", "err", err)
+		}
 		if err := mem.Watch(); err != nil {
 			slog.Error("watcher failed", "err", err)
 		}

--- a/main.go
+++ b/main.go
@@ -109,6 +109,12 @@ func runServe() {
 		if err := mem.IngestAuditLogs(); err != nil {
 			slog.Error("audit log ingest failed", "err", err)
 		}
+		if err := mem.IngestTargets(); err != nil {
+			slog.Error("target ingest failed", "err", err)
+		}
+		if err := mem.IngestPlans(); err != nil {
+			slog.Error("plan ingest failed", "err", err)
+		}
 		if err := mem.Watch(); err != nil {
 			slog.Error("watcher failed", "err", err)
 		}

--- a/main.go
+++ b/main.go
@@ -98,6 +98,9 @@ func runServe() {
 		if err := mem.IngestMemories(); err != nil {
 			slog.Error("memory ingest failed", "err", err)
 		}
+		if err := mem.IngestSkills(); err != nil {
+			slog.Error("skill ingest failed", "err", err)
+		}
 		if err := mem.Watch(); err != nil {
 			slog.Error("watcher failed", "err", err)
 		}

--- a/main.go
+++ b/main.go
@@ -104,6 +104,11 @@ func runServe() {
 		if err := mem.IngestClaudeConfigs(); err != nil {
 			slog.Error("claude config ingest failed", "err", err)
 		}
+		// Audit logs change rarely — startup-only ingest is sufficient.
+		// No file watcher needed for docs/audit-log.md files.
+		if err := mem.IngestAuditLogs(); err != nil {
+			slog.Error("audit log ingest failed", "err", err)
+		}
 		if err := mem.Watch(); err != nil {
 			slog.Error("watcher failed", "err", err)
 		}

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ import (
 //go:embed agents-guide.md
 var agentsGuide string
 
-const version = "0.11.0"
+const version = "0.12.0"
 
 func main() {
 	showVersion := flag.Bool("version", false, "print version and exit")


### PR DESCRIPTION
## Summary
- **mnemo_skills**: search ~/.claude/skills/ (🎯T18)
- **mnemo_configs**: search CLAUDE.md from all repos (🎯T17)
- **mnemo_audit**: search docs/audit-log.md from all repos (🎯T19)
- **mnemo_targets**: search docs/targets.md from all repos (🎯T20)
- **mnemo_plans**: search .planning/ from all repos (🎯T21)
- Schema v8 with 5 new tables + FTS5 indexes

## Test plan
- [x] TestSkillIngest, TestClaudeConfigIngest, TestAuditLogIngest, TestTargetIngest, TestPlanIngest
- [x] `go test -tags sqlite_fts5 ./...` passes
- [x] `go build -tags sqlite_fts5` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)