### PR TITLE
Prep release v0.16.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ user. Good moments to reach for mnemo:
 - `mnemo_status` — Rich status report: repos → sessions → truncated conversation excerpts with drill-down offsets
 - `mnemo_repos` — List repos with paths, session counts, last activity. Supports globs.
 - `mnemo_stats` — Index statistics
+- `mnemo_chain` — Retrieve the full /clear-bounded session chain for any session ID. Returns ordered chain from oldest to newest with per-session summaries and gap/confidence annotations.
 - `mnemo_self` — Session self-identification via nonce protocol
 
 ## Code Structure

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -9,7 +9,7 @@ new product. The pre-1.0 period exists to get these surfaces right.
 
 ## Interaction surface catalogue
 
-Snapshot as of v0.15.0.
+Snapshot as of v0.16.0.
 
 ### CLI flags
 
@@ -45,7 +45,9 @@ Snapshot as of v0.15.0.
 | `work_type` | string | no | Work type filter | Needs review |
 
 **Notes**: `min_messages` default of 6 may need tuning. `work_type`
-values are heuristically extracted and the set may evolve.
+values are heuristically extracted and the set may evolve. As of v0.16.0,
+live sessions (detected via `lsof` with a 5-second cache) are annotated
+with `[LIVE pid=NNNNN]` in the output.
 
 #### mnemo_read_session
 
@@ -207,7 +209,8 @@ activity. Filter matching uses SQL LIKE with `*` mapped to `%`.
 
 #### mnemo_stats
 
-No parameters. Returns session/message counts by type. **Stability**: Stable.
+No parameters. Returns session/message counts by type, including a Streams
+table showing per-stream ingest state (added in v0.16.0). **Stability**: Stable.
 
 #### mnemo_chain
 
@@ -225,6 +228,23 @@ No parameters. Returns session/message counts by type. **Stability**: Stable.
 
 **Notes**: Two-phase nonce protocol. Nonces detected during ingest and
 stored in indexed `session_nonces` table. The mechanism may evolve.
+
+### Store / Backend interface methods
+
+These methods are part of the `Backend` interface used by both the local `Store`
+and the RPC proxy. Breaking changes here would require a protocol version bump.
+
+| Method | Signature | Added | Stability |
+|---|---|---|---|
+| `LiveSessions` | `() map[string]int` | v0.16.0 | Needs review |
+| `Predecessor` | `(sessionID string) (string, error)` | v0.16.0 | Needs review |
+| `Successor` | `(sessionID string) (string, error)` | v0.16.0 | Needs review |
+| `Chain` | `(sessionID string) ([]ChainLink, error)` | v0.16.0 | Needs review |
+
+**Notes**: `LiveSessions` uses `lsof` to detect active Claude Code processes
+and maps session IDs to PIDs, with a 5-second in-process cache. The lsof
+dependency and cache TTL are implementation details and may change.
+`Predecessor`/`Successor`/`Chain` traverse the `session_chains` table.
 
 ### Database schema (exposed via mnemo_query)
 

--- a/agents-guide.md
+++ b/agents-guide.md
@@ -125,6 +125,8 @@ List sessions sorted by recency. Filter by `project`, `repo`
 (org/name substring), or `work_type` (development, feature, bugfix,
 refactor, chore, docs, test, ci, release, review, branch-work).
 Defaults to interactive sessions with at least 6 substantive messages.
+Live sessions (with an active Claude Code process) are annotated with
+`[LIVE pid=NNNNN]` in the output.
 
 ### mnemo_read_session
 
@@ -188,6 +190,7 @@ Key tables and columns:
 | `plans_fts` | FTS5 on content, repo, phase |
 | `ci_runs` | id, repo, run_id, workflow, branch, commit_sha, status, conclusion, started_at, completed_at, log_summary, url |
 | `ci_runs_fts` | FTS5 on repo, workflow, branch, log_summary, conclusion |
+| `session_chains` | successor_id (PK), predecessor_id, boundary, gap_ms, confidence, mechanism, detected_at |
 
 Content types in `content_type`: `text`, `tool_use`, `tool_result`, `thinking`.
 
@@ -355,6 +358,25 @@ Parameters:
 - `days` — recency window (default 30)
 - `limit` — max results (default 20)
 
+### mnemo_chain
+
+Retrieve the full `/clear`-bounded session chain for any session ID.
+When a user types `/clear` in Claude Code, the current JSONL transcript
+ends and a new one begins within ~300ms. mnemo detects these rollovers
+and links successive sessions into chains.
+
+Given any session ID in a chain, returns the complete ordered chain from
+oldest to newest, with per-session summaries (topic, timestamps, repo)
+and the gap/confidence for each link. Single-element result if no chain
+is found.
+
+Parameters:
+- `session_id` (required) — any session ID in the chain (or a prefix)
+
+Use this when you need to understand a work span that crossed `/clear`
+boundaries — e.g., to reconstruct the full context of a multi-session
+task.
+
 ### mnemo_self
 
 Discover the calling session's ID. Two-phase nonce protocol:
@@ -419,4 +441,6 @@ an empty source and is surfaced, not hidden.
 - **What files were edited**: `mnemo_query` with `SELECT DISTINCT tool_file_path FROM messages WHERE tool_name = 'Edit'`
 - **What commands were run**: `mnemo_query` with `SELECT tool_command FROM messages WHERE tool_name = 'Bash'`
 - **Search within a repo**: `mnemo_search` with `repo: "mnemo"` and a query term
+- **Trace a work span across /clear**: `mnemo_chain` with any session ID — returns the full chain of linked sessions
+- **Which sessions are live?**: `mnemo_sessions` — live sessions are annotated with `[LIVE pid=NNNNN]`
 - **Custom analytics**: `mnemo_query` with SQL — e.g., message volume by day, most active projects

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -72,3 +72,8 @@ maintenance activities. Append-only — newest entries at the bottom.
 
 - **Commit**: `3112ab2`
 - **Outcome**: Released v0.15.0 (darwin-arm64, linux-amd64, linux-arm64). Self-healing repo-level ingest (🎯T17): workspace-root filesystem walk discovers repos independently of session metadata. New ~/.mnemo/config.json with workspace_roots. Per-stream backfill status in mnemo_status/mnemo_stats. Schema v10. 15 new tests. Homebrew formula updated.
+
+## 2026-04-13 — /release v0.16.0
+
+- **Commit**: pending
+- **Outcome**: Released v0.16.0 (darwin-arm64, linux-amd64, linux-arm64). Session chains (🎯T16): new session_chains table and mnemo_chain tool link /clear-bounded transcripts into work spans via time-gap heuristic. Session liveness (🎯T9.5.1): mnemo_sessions annotates live sessions with [LIVE pid=NNNNN] via lsof detection. Stats streams rendering in mnemo_stats text output. Schema v11. 15 new tests. Homebrew formula updated.

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ import (
 //go:embed agents-guide.md
 var agentsGuide string
 
-const version = "0.15.0"
+const version = "0.16.0"
 
 func main() {
 	showVersion := flag.Bool("version", false, "print version and exit")


### PR DESCRIPTION
## Summary

- Bump version to 0.16.0
- Update STABILITY.md with new session chains and liveness detection features
- Update agents-guide.md and CLAUDE.md with mnemo_chain tool and liveness annotations
- Add audit log entry (commit hash pending merge)

## Test plan

- [ ] CI green on all platforms
- [ ] `mnemo --version` reports 0.16.0
- [ ] `mnemo_chain` tool works with real session data
- [ ] `mnemo_sessions` shows `[LIVE pid=...]` for active sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
