### PR TITLE
Update audit log commit hash for v0.16.0

### DIFF
--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -75,5 +75,5 @@ maintenance activities. Append-only — newest entries at the bottom.
 
 ## 2026-04-13 — /release v0.16.0
 
-- **Commit**: pending
+- **Commit**: `b7a15b4`
 - **Outcome**: Released v0.16.0 (darwin-arm64, linux-amd64, linux-arm64). Session chains (🎯T16): new session_chains table and mnemo_chain tool link /clear-bounded transcripts into work spans via time-gap heuristic. Session liveness (🎯T9.5.1): mnemo_sessions annotates live sessions with [LIVE pid=NNNNN] via lsof detection. Stats streams rendering in mnemo_stats text output. Schema v11. 15 new tests. Homebrew formula updated.


### PR DESCRIPTION
Docs-only: replace `pending` with merge commit hash `b7a15b4` from PR #7.