### PR TITLE
Release v0.20.0

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -9,7 +9,16 @@ new product. The pre-1.0 period exists to get these surfaces right.
 
 ## Interaction surface catalogue
 
-Snapshot as of v0.19.0.
+Snapshot as of v0.20.0.
+
+**v0.20.0 note (🎯T27)**: mnemo collapsed from two binaries (stdio proxy +
+serve daemon coupled by a custom UDS JSON-RPC protocol) to a single HTTP
+MCP daemon. Registration is now
+`claude mcp add --scope user --transport http mnemo http://localhost:19419/mcp`.
+The `Mcp-Session-Id` HTTP header replaces the UDS connection ID for
+session-binding, compaction anchoring, and chain detection. Stale
+stdio registrations get an actionable migration hint on launch
+instead of failing silently.
 
 ### CLI flags
 
@@ -631,6 +640,14 @@ configurable before 1.0.
 - Authentication / access control on the HTTP endpoint
 - Transcript modification or deletion tools
 - Integration with non-Claude-Code transcript formats
+**Delivered in v0.20.0** (🎯T27):
+
+- Single HTTP MCP daemon — no more stdio proxy, no more UDS
+  custom-protocol. mark3labs/mcp-go StreamableHTTP serves directly.
+  `internal/rpc/` and `internal/bridge/` deleted. connection_id
+  sourced from Mcp-Session-Id header. Stale stdio registrations get
+  a migration hint on launch.
+
 **Delivered in v0.18.0** (removed from the 1.0 out-of-scope list):
 
 - Live context compaction (🎯T10) — per-connection background

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -105,3 +105,16 @@ maintenance activities. Append-only — newest entries at the bottom.
   ingest: each changed file logs session ID, entry/message counts;
   periodic progress summary every 100 files with rate and ETA. Only
   files that grew since last ingest are logged. Homebrew formula updated.
+
+## 2026-04-18 — /release v0.20.0
+
+- **Commit**: pending
+- **Outcome**: Released v0.20.0. Architectural collapse (🎯T27): mnemo
+  is now a single HTTP MCP daemon. Stdio proxy and custom UDS
+  JSON-RPC protocol removed; mark3labs/mcp-go StreamableHTTP handles
+  clients directly (−2,231 lines net). connection_id sourced from
+  Mcp-Session-Id header; compactor / mnemo_restore / chain detection
+  continue to work. Stale stdio registrations get a migration hint on
+  launch. Registration command changes to
+  `claude mcp add --scope user --transport http mnemo http://localhost:19419/mcp`.
+  Homebrew formula updated.

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ Then restart this Claude Code session.`
 var agentsGuide string
 
 const (
-	version     = "0.19.0"
+	version     = "0.20.0"
 	defaultAddr = ":19419"
 )
 


### PR DESCRIPTION
## Summary

- Bump version to 0.20.0
- Update STABILITY.md with 🎯T27 architectural notes
- Add audit log entry

## Release notes

### Changed

- **Architectural collapse (🎯T27)**: mnemo is now a single HTTP MCP daemon. The stdio proxy and custom UDS JSON-RPC protocol are gone; mark3labs/mcp-go's StreamableHTTP server handles clients directly. Net internal/ reduction: −2,231 lines.
- Registration command is now `claude mcp add --scope user --transport http mnemo http://localhost:19419/mcp`.
- `connection_id` now sources from the `Mcp-Session-Id` HTTP header. Compactor, `mnemo_restore`, and chain detection continue to work.

### Added

- Upgrade hint for users with stale v0.19.0 stdio registrations: launching mnemo as stdio with the daemon port held prints a migration message and exits 1.

### Migration

Required: `claude mcp remove mnemo && claude mcp add --scope user --transport http mnemo http://localhost:19419/mcp`, then restart your Claude Code session.

## Test plan

- [x] `go test -tags "sqlite_fts5" ./...` passes
- [x] End-to-end HTTP MCP smoke test: initialize, tools/list, tools/call
- [x] Migration hint path verified (stdio launch + port conflict → migration message)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
