### PR TITLE
Update audit log commit hash for v0.21.0 (#19)

### DIFF
--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -121,7 +121,7 @@ maintenance activities. Append-only — newest entries at the bottom.
 
 ## 2026-04-19 — /release v0.21.0
 
-- **Commit**: `pending`
+- **Commit**: `8a777d1`
 - **Outcome**: Released v0.21.0. Windows native support (🎯T22): mnemo
   daemon builds and runs on Windows amd64 and arm64 alongside the
   existing darwin-arm64, linux-amd64, linux-arm64 targets. Platform-


### PR DESCRIPTION
Rewrites the v0.21.0 audit-log entry's `Commit: pending` placeholder to the real merge-commit hash `8a777d1` (from PR #19). Docs-only; no code changes.