### PR TITLE
Windows double-click installer (🎯T32 groundwork)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,25 @@ jobs:
               ;;
           esac
 
+      - name: Build Windows installer
+        if: matrix.goos == 'windows'
+        working-directory: mnemo
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          mkdir -p dist
+          cp "mnemo.exe" dist/
+          cp LICENSE dist/LICENSE.txt
+          # Inno Setup 6 is preinstalled on windows-latest runners.
+          ISCC="/c/Program Files (x86)/Inno Setup 6/iscc.exe"
+          "$ISCC" "/DAppVersion=${VERSION}" \
+            "/DSourceDir=dist" \
+            "/O." \
+            installer/windows/mnemo.iss
+          # Output is named mnemo-${VERSION}-windows-amd64-setup.exe per
+          # OutputBaseFilename in the .iss file.
+          ls -la "mnemo-${VERSION}-windows-amd64-setup.exe"
+
       - name: Upload release artifact
         env:
           GH_TOKEN: ${{ github.token }}
@@ -92,6 +111,16 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           gh release upload "$GITHUB_REF_NAME" \
             "mnemo-${VERSION}-${{ matrix.goos }}-${{ matrix.goarch }}.${{ matrix.archive }}"
+
+      - name: Upload Windows installer
+        if: matrix.goos == 'windows'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        working-directory: mnemo
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          gh release upload "$GITHUB_REF_NAME" \
+            "mnemo-${VERSION}-windows-amd64-setup.exe"
 
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -73,11 +73,30 @@ available in every session from that point on.
 
 ## Install
 
+### macOS / Linux
+
 ```bash
 brew install marcelocantos/tap/mnemo
 ```
 
-Or build from source (requires Go and CGo for SQLite):
+### Windows
+
+Download `mnemo-<version>-windows-amd64-setup.exe` from the
+[releases page](https://github.com/marcelocantos/mnemo/releases/latest)
+and double-click it. The installer:
+
+- copies `mnemo.exe` to `C:\Program Files\mnemo\`,
+- registers mnemo as a Windows Service (auto-start on boot,
+  restart-on-failure),
+- patches `%USERPROFILE%\.claude.json` so Claude Code picks up mnemo
+  on its next session,
+- shows up in **Add/Remove Programs** as `mnemo` for a clean uninstall.
+
+No terminal required. Restart your Claude Code session after install.
+
+### Build from source
+
+Requires Go and CGo for SQLite:
 
 ```bash
 go build -tags "sqlite_fts5" -o bin/mnemo .
@@ -96,10 +115,15 @@ on Windows; transcript indexing and all query tools work identically.
 **As a service** (recommended — survives reboots):
 
 ```bash
-brew services start mnemo       # macOS
+brew services start mnemo       # macOS / Linuxbrew
 ```
 
-Logs: `$(brew --prefix)/var/log/mnemo.log`
+On Windows the installer already registers mnemo as a Windows Service
+(`sc query mnemo` to inspect, Services.msc to manage). Service logs:
+`%ProgramData%\mnemo\logs\mnemo.log` plus the Windows Event Log
+(Application source: `mnemo`).
+
+Logs on macOS: `$(brew --prefix)/var/log/mnemo.log`.
 
 **Manually**:
 

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -852,6 +852,71 @@ targets:
     context: 'Data-mined from 180 days of Claude session transcripts (2026-04-19). Observed post-mnemo pattern: Python loops over session JSONL files grepping for specific UUIDs to answer which session contains entry X or to trace parent-UUID chains. No current mnemo tool does this directly; bash grep over JSONL files is the only path. Common use cases include debugging session chaining, tracking tool_use_ids through retries, and resolving cross-session references.'
     origin: doit data-mining 2026-04-19
     discovered: 2026-04-19
+  T32:
+    name: Non-technical Windows users install mnemo via a double-click installer, with no terminal required
+    status: identified
+    value: 0.0
+    cost: 0.0
+    observable: true
+    acceptance:
+    - A non-technical Windows user downloads one .exe from the release page, double-clicks it, clicks Next through a standard Windows installer, and mnemo is running as a Windows Service with MCP registered in Claude Code's config — zero terminal commands required.
+    - Uninstalling via Add/Remove Programs cleanly removes the service, binary, and MCP registration.
+    - The installer is built in CI on every release and attached to the GitHub release as mnemo-<version>-windows-amd64-setup.exe.
+    - README documents the Windows install path alongside the brew path.
+    context: v0.21.0 shipped Windows-compatible binaries (🎯T22), but the install pathway still assumes developer tooling (manual zip extraction, PATH setup, claude mcp add via terminal). For the project to reach non-technical Windows users, the install flow must be a single signed .exe that handles binary placement, Windows Service registration, MCP config patching, and uninstallation — all without the user opening a terminal. This is the remaining gap between "runs on Windows" and "ships to Windows end users".
+    depends_on:
+    - T32.1
+    - T32.2
+    - T32.3
+    origin: manual
+    discovered: 2026-04-19
+  T32.1:
+    name: mnemo runs as a native Windows Service (auto-start on boot, restart on failure, logs to Windows Event Log)
+    status: identified
+    value: 0.0
+    cost: 0.0
+    observable: true
+    acceptance:
+    - mnemo.exe install-service registers mnemo as a Windows Service named "mnemo" with auto-start and restart-on-failure configured.
+    - mnemo.exe uninstall-service stops and removes the service.
+    - When running as a service, mnemo reports status to the SCM and handles stop/shutdown events cleanly.
+    - Non-Windows builds still compile; service_other.go returns a clear error if the install-service subcommand is invoked.
+    - Service logs route to the Windows Event Log (or at minimum a file under %ProgramData%\\mnemo\\logs\\).
+    context: The installer needs to register mnemo as a Windows Service so it survives reboots and runs without a logged-in user. Implemented using golang.org/x/sys/windows/svc (native, no nssm/WinSW wrapper). Per the established repo pattern (store_windows.go, ocr_darwin.go), platform-specific code lives in file-suffixed files rather than build-tag ifdefs scattered through main.go.
+    origin: manual
+    discovered: 2026-04-19
+  T32.2:
+    name: mnemo has a subcommand that registers/unregisters itself as an MCP server in Claude Code's config
+    status: identified
+    value: 0.0
+    cost: 0.0
+    observable: true
+    acceptance:
+    - mnemo.exe register-mcp adds/updates the mnemo entry in ~/.claude.json, preserving all other top-level keys and other mcpServers entries.
+    - mnemo.exe unregister-mcp removes the mnemo entry (and removes mcpServers if it becomes empty).
+    - Both subcommands are idempotent and exit 0 if the target state already holds.
+    - If ~/.claude.json does not exist, register-mcp creates a minimal file with just the mcpServers key.
+    context: 'Non-technical users can''t be expected to run claude mcp add from a terminal. mnemo itself can patch %USERPROFILE%\\.claude.json (shape is known: {\"mcpServers\": {\"mnemo\": {\"type\": \"http\", \"url\": \"http://localhost:19419/mcp\"}}}). Subcommand is cross-platform (same code path on macOS/Linux/Windows) and is invoked by the Windows installer post-install but is also useful to anyone wanting a one-shot registration.'
+    origin: manual
+    discovered: 2026-04-19
+  T32.3:
+    name: Inno Setup installer packages mnemo.exe, registers the service, invokes register-mcp, and is built in CI on every release
+    status: identified
+    value: 0.0
+    cost: 0.0
+    observable: true
+    acceptance:
+    - A .iss file in the repo builds into mnemo-<version>-windows-amd64-setup.exe when compiled with iscc.exe on a windows-latest runner.
+    - 'The installer: elevates to admin, copies mnemo.exe to %ProgramFiles%\\mnemo\\, runs install-service, runs register-mcp as the invoking user (so ~/.claude.json is the user''s, not SYSTEM''s), and creates a Start Menu uninstall entry.'
+    - 'The uninstaller: runs unregister-mcp, runs uninstall-service, deletes %ProgramFiles%\\mnemo\\, and removes %ProgramData%\\mnemo\\ (logs).'
+    - release.yml builds the installer after the Windows zip and attaches it to the GitHub release.
+    - README documents the Windows install path.
+    context: Inno Setup is the standard choice for non-Microsoft Windows installers — free, well-supported, produces a single .exe. Can run post-install commands, create uninstall entries, handle elevation. Runs in CI on windows-latest (Inno Setup is preinstalled on the GitHub runner image). No code-signing in this target (separate follow-up — requires a cert purchase).
+    depends_on:
+    - T32.1
+    - T32.2
+    origin: manual
+    discovered: 2026-04-19
   T4:
     name: Individual session transcript access
     status: achieved

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/marcelocantos/sqldeep/go/sqldeep v0.19.0
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sys v0.43.0
 )
 
 replace github.com/marcelocantos/sqldeep/go/sqldeep => ../sqldeep/go/sqldeep

--- a/installer/windows/mnemo.iss
+++ b/installer/windows/mnemo.iss
@@ -1,0 +1,118 @@
+; Inno Setup script for mnemo.
+;
+; Produces a double-click .exe installer that drops mnemo.exe into
+; Program Files, registers it as a Windows Service (auto-start,
+; restart-on-failure), and patches the invoking user's ~/.claude.json
+; so Claude Code picks up mnemo on next session restart.
+;
+; Build:
+;   iscc /DAppVersion=0.21.0 /DSourceDir=..\..\dist mnemo.iss
+;
+; AppVersion  — version string shown in Add/Remove Programs
+;               and in the installer window title.
+; SourceDir   — directory containing the freshly-built mnemo.exe
+;               (the CI uses the same dir it extracts the zip into).
+;
+; The installer:
+;   - Requires admin elevation (mandatory for service install +
+;     writes to Program Files).
+;   - Copies mnemo.exe into {app} (default C:\Program Files\mnemo).
+;   - Runs `mnemo.exe install-service`  (elevated).
+;   - Runs `mnemo.exe register-mcp`     (as original user, so the
+;     right ~/.claude.json is patched — not the admin account's).
+;   - Starts the service so the user doesn't have to reboot.
+;
+; The uninstaller:
+;   - Runs `mnemo.exe unregister-mcp`   (as original user).
+;   - Runs `mnemo.exe uninstall-service` (elevated).
+;   - Removes {app} and the %ProgramData%\mnemo tree.
+
+#ifndef AppVersion
+  #define AppVersion "0.0.0"
+#endif
+#ifndef SourceDir
+  #define SourceDir "."
+#endif
+
+[Setup]
+AppId={{C7F3B2A1-8E4D-4B5C-9A2F-1D6E8C7B9A0F}
+AppName=mnemo
+AppVersion={#AppVersion}
+AppVerName=mnemo {#AppVersion}
+AppPublisher=Marcelo Cantos
+AppPublisherURL=https://github.com/marcelocantos/mnemo
+AppSupportURL=https://github.com/marcelocantos/mnemo/issues
+AppUpdatesURL=https://github.com/marcelocantos/mnemo/releases
+DefaultDirName={autopf}\mnemo
+DefaultGroupName=mnemo
+DisableProgramGroupPage=yes
+OutputBaseFilename=mnemo-{#AppVersion}-windows-amd64-setup
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+PrivilegesRequired=admin
+ArchitecturesInstallIn64BitMode=x64compatible
+ArchitecturesAllowed=x64compatible
+; Allow `uninstall-service` and `unregister-mcp` to find mnemo.exe via
+; full path even if PATH is not updated.
+UninstallDisplayIcon={app}\mnemo.exe
+UninstallDisplayName=mnemo {#AppVersion}
+LicenseFile={#SourceDir}\LICENSE.txt
+
+[Files]
+Source: "{#SourceDir}\mnemo.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#SourceDir}\LICENSE.txt"; DestDir: "{app}"; Flags: ignoreversion
+
+[Run]
+; Service install (elevated — this is the installer's default
+; context). Must run before register-mcp because register-mcp's
+; `--url` default assumes the service is up on :19419 and Claude Code
+; will connect shortly after.
+Filename: "{app}\mnemo.exe"; Parameters: "install-service"; \
+  StatusMsg: "Installing mnemo Windows Service..."; \
+  Flags: runhidden waituntilterminated
+
+; Start the service immediately so the user doesn't have to reboot.
+; `net start` is used instead of sc.exe for universal availability;
+; tolerate failure (service may already be running on upgrade).
+Filename: "{sys}\net.exe"; Parameters: "start mnemo"; \
+  StatusMsg: "Starting mnemo service..."; \
+  Flags: runhidden waituntilterminated; \
+  Check: ServiceShouldStart
+
+; MCP registration (as the original user, so the right
+; ~/.claude.json is patched). runasoriginaluser is critical: without
+; it, the installer's elevated SYSTEM/Administrator context would
+; patch a different user's profile — leaving the actual user with
+; mnemo unregistered.
+Filename: "{app}\mnemo.exe"; Parameters: "register-mcp"; \
+  StatusMsg: "Registering mnemo with Claude Code..."; \
+  Flags: runhidden waituntilterminated runasoriginaluser
+
+[UninstallRun]
+; Reverse order: unregister MCP first (as original user), then stop
+; and remove the service. This order means Claude Code never sees a
+; broken registration pointing at a stopped service.
+Filename: "{app}\mnemo.exe"; Parameters: "unregister-mcp"; \
+  Flags: runhidden waituntilterminated runasoriginaluser; \
+  RunOnceId: "MnemoUnregisterMCP"
+
+Filename: "{app}\mnemo.exe"; Parameters: "uninstall-service"; \
+  Flags: runhidden waituntilterminated; \
+  RunOnceId: "MnemoUninstallService"
+
+[UninstallDelete]
+; Drop the %ProgramData%\mnemo\ tree (logs, runtime state). The user's
+; home-directory state (~/.mnemo/mnemo.db, ~/.claude/projects/) is
+; deliberately preserved so reinstalling does not destroy the index.
+Type: filesandordirs; Name: "{commonappdata}\mnemo"
+
+[Code]
+// ServiceShouldStart is a Check function for the `net start` line.
+// We only try to start the service if the install-service step
+// succeeded (the Filename: above runs before this; if it failed,
+// Inno Setup would have already aborted the installer).
+function ServiceShouldStart(): Boolean;
+begin
+  Result := True;
+end;

--- a/internal/mcpconfig/mcpconfig.go
+++ b/internal/mcpconfig/mcpconfig.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+// Package mcpconfig patches a Claude Code user config file
+// (~/.claude.json) to register or unregister mnemo as an MCP server.
+//
+// The Windows installer uses this to avoid forcing non-technical users
+// to run `claude mcp add` from a terminal. It is cross-platform and
+// also useful to anyone wanting a one-shot registration.
+//
+// The file is read, parsed as generic JSON, mutated in place, and
+// written back via a temp-file rename so a crashed write cannot leave
+// a corrupt config. All top-level keys and all other mcpServers
+// entries are preserved verbatim — we only touch the "mnemo" key.
+package mcpconfig
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// DefaultURL is the HTTP MCP endpoint used by the brew-managed and
+// Windows-Service-managed daemons. Must stay aligned with defaultAddr
+// in main.go.
+const DefaultURL = "http://localhost:19419/mcp"
+
+// ConfigPath returns the Claude Code user config file path.
+// On every supported platform this is ~/.claude.json.
+func ConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	return filepath.Join(home, ".claude.json"), nil
+}
+
+// Register adds or updates the "mnemo" entry under mcpServers in the
+// given config file, pointing at url. Other keys are preserved. If
+// the file does not exist it is created with a minimal
+// {"mcpServers": {"mnemo": ...}} shape. The operation is idempotent.
+// Returns true if the file was changed.
+func Register(path, url string) (bool, error) {
+	raw, err := readOrEmpty(path)
+	if err != nil {
+		return false, err
+	}
+
+	root := map[string]any{}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &root); err != nil {
+			return false, fmt.Errorf("parse %s: %w", path, err)
+		}
+	}
+
+	servers, _ := root["mcpServers"].(map[string]any)
+	if servers == nil {
+		servers = map[string]any{}
+	}
+
+	want := map[string]any{"type": "http", "url": url}
+	if existing, ok := servers["mnemo"].(map[string]any); ok && mapsEqual(existing, want) {
+		return false, nil
+	}
+	servers["mnemo"] = want
+	root["mcpServers"] = servers
+
+	return true, writeAtomic(path, root)
+}
+
+// Unregister removes the "mnemo" entry under mcpServers. If mcpServers
+// becomes empty it is removed too. Idempotent. Returns true if the
+// file was changed. A missing file is not an error.
+func Unregister(path string) (bool, error) {
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	root := map[string]any{}
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return false, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	servers, ok := root["mcpServers"].(map[string]any)
+	if !ok {
+		return false, nil
+	}
+	if _, present := servers["mnemo"]; !present {
+		return false, nil
+	}
+	delete(servers, "mnemo")
+	if len(servers) == 0 {
+		delete(root, "mcpServers")
+	} else {
+		root["mcpServers"] = servers
+	}
+
+	return true, writeAtomic(path, root)
+}
+
+func readOrEmpty(path string) ([]byte, error) {
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	return raw, nil
+}
+
+// writeAtomic marshals root with two-space indentation (matching the
+// format Claude Code uses) and replaces path atomically via a temp
+// file in the same directory. File permissions default to 0600 since
+// ~/.claude.json may contain OAuth tokens; existing permissions are
+// preserved if the file is already there.
+func writeAtomic(path string, root map[string]any) error {
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	out = append(out, '\n')
+
+	mode := os.FileMode(0o600)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".claude-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+	if _, err := tmp.Write(out); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("rename into place: %w", err)
+	}
+	return nil
+}
+
+func mapsEqual(a, b map[string]any) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bv, ok := b[k]; !ok || bv != v {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/mcpconfig/mcpconfig_test.go
+++ b/internal/mcpconfig/mcpconfig_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package mcpconfig
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRegisterCreatesFileWhenMissing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".claude.json")
+
+	changed, err := Register(path, DefaultURL)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true on fresh create")
+	}
+
+	root := readJSON(t, path)
+	servers, _ := root["mcpServers"].(map[string]any)
+	mnemo, _ := servers["mnemo"].(map[string]any)
+	if mnemo["url"] != DefaultURL || mnemo["type"] != "http" {
+		t.Fatalf("unexpected entry: %#v", mnemo)
+	}
+}
+
+func TestRegisterPreservesOtherKeys(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".claude.json")
+	initial := map[string]any{
+		"theme": "dark",
+		"mcpServers": map[string]any{
+			"other": map[string]any{"type": "stdio", "command": "/bin/other"},
+		},
+		"projects": map[string]any{"foo": map[string]any{"bar": 1.0}},
+	}
+	writeJSON(t, path, initial)
+
+	if _, err := Register(path, DefaultURL); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	root := readJSON(t, path)
+	if root["theme"] != "dark" {
+		t.Errorf("theme not preserved: %v", root["theme"])
+	}
+	if _, ok := root["projects"].(map[string]any); !ok {
+		t.Errorf("projects not preserved")
+	}
+	servers := root["mcpServers"].(map[string]any)
+	if _, ok := servers["other"]; !ok {
+		t.Errorf("other MCP server dropped")
+	}
+	if _, ok := servers["mnemo"]; !ok {
+		t.Errorf("mnemo MCP server not added")
+	}
+}
+
+func TestRegisterIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".claude.json")
+	if _, err := Register(path, DefaultURL); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	changed, err := Register(path, DefaultURL)
+	if err != nil {
+		t.Fatalf("second Register: %v", err)
+	}
+	if changed {
+		t.Fatal("expected changed=false on second call with same URL")
+	}
+}
+
+func TestRegisterUpdatesURL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".claude.json")
+	if _, err := Register(path, "http://localhost:19419/mcp"); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	changed, err := Register(path, "http://localhost:8080/mcp")
+	if err != nil {
+		t.Fatalf("Register update: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true when URL differs")
+	}
+	root := readJSON(t, path)
+	servers := root["mcpServers"].(map[string]any)
+	if servers["mnemo"].(map[string]any)["url"] != "http://localhost:8080/mcp" {
+		t.Errorf("URL not updated")
+	}
+}
+
+func TestUnregisterRemovesEntryAndEmptyMap(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".claude.json")
+	if _, err := Register(path, DefaultURL); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	changed, err := Unregister(path)
+	if err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	root := readJSON(t, path)
+	if _, ok := root["mcpServers"]; ok {
+		t.Errorf("expected empty mcpServers to be removed, got %v", root["mcpServers"])
+	}
+}
+
+func TestUnregisterPreservesOtherServers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".claude.json")
+	writeJSON(t, path, map[string]any{
+		"mcpServers": map[string]any{
+			"other": map[string]any{"type": "stdio", "command": "/bin/other"},
+			"mnemo": map[string]any{"type": "http", "url": DefaultURL},
+		},
+	})
+	if _, err := Unregister(path); err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+	root := readJSON(t, path)
+	servers := root["mcpServers"].(map[string]any)
+	if _, ok := servers["mnemo"]; ok {
+		t.Errorf("mnemo not removed")
+	}
+	if _, ok := servers["other"]; !ok {
+		t.Errorf("other server removed")
+	}
+}
+
+func TestUnregisterMissingFileIsNoOp(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".claude.json")
+	changed, err := Unregister(path)
+	if err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+	if changed {
+		t.Fatal("expected changed=false for missing file")
+	}
+}
+
+func TestUnregisterWhenAbsentIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".claude.json")
+	writeJSON(t, path, map[string]any{
+		"mcpServers": map[string]any{
+			"other": map[string]any{"type": "stdio", "command": "/bin/other"},
+		},
+	})
+	changed, err := Unregister(path)
+	if err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+	if changed {
+		t.Fatal("expected changed=false when mnemo entry absent")
+	}
+}
+
+func readJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(raw, &root); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return root
+}
+
+func writeJSON(t *testing.T, path string, root map[string]any) {
+	t.Helper()
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -7,8 +7,12 @@
 //
 // mnemo runs as a single HTTP MCP daemon:
 //
-//	mnemo              # run the HTTP MCP daemon (default :19419)
-//	mnemo --addr :8080 # custom listen address
+//	mnemo                       # run the HTTP MCP daemon (default :19419)
+//	mnemo --addr :8080          # custom listen address
+//	mnemo register-mcp          # add mnemo to ~/.claude.json
+//	mnemo unregister-mcp        # remove mnemo from ~/.claude.json
+//	mnemo install-service       # (Windows) install mnemo as a service
+//	mnemo uninstall-service     # (Windows) remove the mnemo service
 //	claude mcp add --scope user --transport http mnemo http://localhost:19419/mcp
 package main
 
@@ -26,6 +30,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/marcelocantos/mnemo/internal/compact"
+	"github.com/marcelocantos/mnemo/internal/mcpconfig"
 	"github.com/marcelocantos/mnemo/internal/store"
 	"github.com/marcelocantos/mnemo/internal/tools"
 )
@@ -53,9 +58,34 @@ var agentsGuide string
 const (
 	version     = "0.21.0"
 	defaultAddr = ":19419"
+	// serviceName is the Windows Service identifier used by
+	// install-service / uninstall-service and by the service control
+	// dispatcher when mnemo is launched by the SCM.
+	serviceName = "mnemo"
 )
 
 func main() {
+	// Subcommands are dispatched before flag.Parse so their own flags
+	// don't collide with the global ones (--addr, --version). The
+	// default (no subcommand) path keeps the v0.21.0 behaviour: parse
+	// global flags and serve HTTP.
+	if len(os.Args) >= 2 {
+		switch os.Args[1] {
+		case "register-mcp":
+			cmdRegisterMCP(os.Args[2:])
+			return
+		case "unregister-mcp":
+			cmdUnregisterMCP(os.Args[2:])
+			return
+		case "install-service":
+			cmdInstallService(os.Args[2:])
+			return
+		case "uninstall-service":
+			cmdUninstallService(os.Args[2:])
+			return
+		}
+	}
+
 	showVersion := flag.Bool("version", false, "print version and exit")
 	helpAgent := flag.Bool("help-agent", false, "print agent guide and exit")
 	addr := flag.String("addr", defaultAddr, "HTTP listen address")
@@ -74,6 +104,17 @@ func main() {
 		return
 	}
 
+	// On Windows, if the SCM launched this process (no interactive
+	// session), hand off to the service control dispatcher, which
+	// calls runServe with a cancellable context driven by SCM events.
+	if handled, err := runAsServiceIfUnderSCM(*addr); handled {
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "service run failed: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	// Detect a stale stdio MCP registration before opening the store.
 	// If our stdin looks piped and the target port is already bound,
 	// the caller is almost certainly Claude Code invoking this binary
@@ -85,7 +126,74 @@ func main() {
 		os.Exit(1)
 	}
 
-	runServe(*addr)
+	if err := runServe(context.Background(), *addr); err != nil {
+		os.Exit(1)
+	}
+}
+
+func cmdRegisterMCP(args []string) {
+	fs := flag.NewFlagSet("register-mcp", flag.ExitOnError)
+	url := fs.String("url", mcpconfig.DefaultURL, "MCP endpoint URL to register")
+	configPath := fs.String("config", "", "Claude Code config path (default ~/.claude.json)")
+	_ = fs.Parse(args)
+	path := *configPath
+	if path == "" {
+		p, err := mcpconfig.ConfigPath()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		path = p
+	}
+	changed, err := mcpconfig.Register(path, *url)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "register-mcp: %v\n", err)
+		os.Exit(1)
+	}
+	if changed {
+		fmt.Printf("mnemo MCP registered in %s\n", path)
+	} else {
+		fmt.Printf("mnemo MCP already registered in %s\n", path)
+	}
+}
+
+func cmdUnregisterMCP(args []string) {
+	fs := flag.NewFlagSet("unregister-mcp", flag.ExitOnError)
+	configPath := fs.String("config", "", "Claude Code config path (default ~/.claude.json)")
+	_ = fs.Parse(args)
+	path := *configPath
+	if path == "" {
+		p, err := mcpconfig.ConfigPath()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		path = p
+	}
+	changed, err := mcpconfig.Unregister(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unregister-mcp: %v\n", err)
+		os.Exit(1)
+	}
+	if changed {
+		fmt.Printf("mnemo MCP removed from %s\n", path)
+	} else {
+		fmt.Printf("mnemo MCP was not registered in %s\n", path)
+	}
+}
+
+func cmdInstallService(args []string) {
+	if err := installService(args); err != nil {
+		fmt.Fprintf(os.Stderr, "install-service: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func cmdUninstallService(args []string) {
+	if err := uninstallService(args); err != nil {
+		fmt.Fprintf(os.Stderr, "uninstall-service: %v\n", err)
+		os.Exit(1)
+	}
 }
 
 // stdinPiped reports whether stdin is a pipe or file (i.e. not a tty),
@@ -112,8 +220,10 @@ func portInUse(addr string) bool {
 }
 
 // runServe opens the store, starts ingest and background workers, and
-// serves the MCP protocol over HTTP.
-func runServe(addr string) {
+// serves the MCP protocol over HTTP until ctx is cancelled or the
+// server fails. Used by both the foreground launcher and the Windows
+// Service handler.
+func runServe(ctx context.Context, addr string) error {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	})))
@@ -121,7 +231,7 @@ func runServe(addr string) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cannot determine home directory: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	projectDir := filepath.Join(homeDir, ".claude", "projects")
@@ -129,13 +239,13 @@ func runServe(addr string) {
 
 	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
 		fmt.Fprintf(os.Stderr, "cannot create db directory: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	mem, err := store.New(dbPath, projectDir)
 	if err != nil {
 		slog.Error("failed to open store", "err", err)
-		os.Exit(1)
+		return err
 	}
 	defer mem.Close()
 
@@ -205,18 +315,23 @@ func runServe(addr string) {
 		caller := compact.NewClaudiaCaller(mnemoRepoDir, "sonnet")
 		compactor := compact.New(mem, caller, compact.Config{})
 		watcher := compact.NewWatcher(mem, compactor, compact.WatcherConfig{}, mnemoRepoDir)
-		ctx := context.Background()
 		slog.Info("compact: watcher starting")
 		watcher.Run(ctx)
 	}()
 
 	// Poll CI runs periodically (every 5 minutes).
 	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
 		for {
 			if err := mem.PollCI(); err != nil {
 				slog.Warn("CI poll failed", "err", err)
 			}
-			time.Sleep(5 * time.Minute)
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
 		}
 	}()
 
@@ -231,13 +346,29 @@ func runServe(addr string) {
 	)
 	tools.NewHandler(mem).RegisterTools(mcp)
 
-	http := server.NewStreamableHTTPServer(mcp,
+	httpSrv := server.NewStreamableHTTPServer(mcp,
 		server.WithStateful(true),
 	)
 
 	slog.Info("mnemo serve starting", "version", version, "addr", addr)
-	if err := http.Start(addr); err != nil {
+
+	// Run the HTTP server in a goroutine so we can react to ctx
+	// cancellation (triggered by the Windows Service handler on SCM
+	// Stop, or never triggered in the foreground case).
+	errCh := make(chan error, 1)
+	go func() { errCh <- httpSrv.Start(addr) }()
+
+	select {
+	case err := <-errCh:
 		slog.Error("HTTP MCP server failed", "err", err)
-		os.Exit(1)
+		return err
+	case <-ctx.Done():
+		slog.Info("mnemo serve shutting down")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := httpSrv.Shutdown(shutdownCtx); err != nil {
+			slog.Warn("HTTP shutdown error", "err", err)
+		}
+		return nil
 	}
 }

--- a/service_other.go
+++ b/service_other.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+// Non-Windows stubs for the Windows Service hooks declared in
+// service_windows.go. The corresponding subcommands error out with a
+// clear message so non-technical users who accidentally run
+// `mnemo install-service` on macOS or Linux get a useful hint
+// (brew services on macOS, systemd on Linux, rather than SCM).
+package main
+
+import "fmt"
+
+func runAsServiceIfUnderSCM(string) (bool, error) { return false, nil }
+
+func installService([]string) error {
+	return fmt.Errorf("install-service is only supported on Windows " +
+		"(use `brew services start mnemo` on macOS)")
+}
+
+func uninstallService([]string) error {
+	return fmt.Errorf("uninstall-service is only supported on Windows " +
+		"(use `brew services stop mnemo` on macOS)")
+}

--- a/service_windows.go
+++ b/service_windows.go
@@ -1,0 +1,288 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+// Windows Service support for mnemo.
+//
+// There are three entry points, each wired up from main.go:
+//
+//   - runAsServiceIfUnderSCM: called on every foreground launch.
+//     Detects whether the Service Control Manager started the
+//     process (svc.IsWindowsService) and, if so, hands off to the
+//     service dispatcher. Returns (false, nil) on interactive
+//     launches so main.go continues its normal path.
+//
+//   - installService: creates the "mnemo" service, configures
+//     auto-start and restart-on-failure, and registers an Event Log
+//     source. Called by `mnemo install-service` from the installer.
+//
+//   - uninstallService: stops and deletes the service and its Event
+//     Log source. Called by `mnemo uninstall-service` from the
+//     uninstaller.
+//
+// Service logs are written via the Windows Event Log (visible in
+// Event Viewer under Windows Logs → Application with source "mnemo"),
+// and stderr from runServe is also redirected to
+// %ProgramData%\mnemo\logs\mnemo.log so operators have a readable
+// file for deep debugging.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/eventlog"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+// runAsServiceIfUnderSCM checks whether the current process was
+// started by the Service Control Manager. If so, it runs the service
+// dispatcher (which calls serviceMain and ultimately runServe). If
+// not, it returns (false, nil) so the caller can continue with its
+// interactive/foreground path.
+func runAsServiceIfUnderSCM(addr string) (bool, error) {
+	underSCM, err := svc.IsWindowsService()
+	if err != nil {
+		return false, fmt.Errorf("detect windows service: %w", err)
+	}
+	if !underSCM {
+		return false, nil
+	}
+
+	// Redirect stderr (where slog writes) to a log file under
+	// %ProgramData%\mnemo\logs. This survives service restarts and
+	// gives operators a file they can open without Event Viewer.
+	if logFile, err := openServiceLogFile(); err == nil {
+		os.Stderr = logFile
+	}
+
+	return true, svc.Run(serviceName, &mnemoService{addr: addr})
+}
+
+// mnemoService implements svc.Handler.
+type mnemoService struct {
+	addr string
+}
+
+func (m *mnemoService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
+	const accepts = svc.AcceptStop | svc.AcceptShutdown
+
+	changes <- svc.Status{State: svc.StartPending}
+
+	elog, err := eventlog.Open(serviceName)
+	if err == nil {
+		defer func() { _ = elog.Close() }()
+		_ = elog.Info(1, fmt.Sprintf("mnemo %s service starting on %s", version, m.addr))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- runServe(ctx, m.addr) }()
+
+	changes <- svc.Status{State: svc.Running, Accepts: accepts}
+
+loop:
+	for {
+		select {
+		case c := <-r:
+			switch c.Cmd {
+			case svc.Interrogate:
+				changes <- c.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				if elog != nil {
+					_ = elog.Info(1, "mnemo service stopping")
+				}
+				changes <- svc.Status{State: svc.StopPending}
+				cancel()
+				select {
+				case <-done:
+				case <-time.After(10 * time.Second):
+					if elog != nil {
+						_ = elog.Warning(1, "runServe did not exit within 10s; forcing stop")
+					}
+				}
+				break loop
+			default:
+				if elog != nil {
+					_ = elog.Warning(1, fmt.Sprintf("unexpected SCM request: %d", c.Cmd))
+				}
+			}
+		case err := <-done:
+			if err != nil && elog != nil {
+				_ = elog.Error(1, fmt.Sprintf("runServe exited with error: %v", err))
+			}
+			break loop
+		}
+	}
+
+	changes <- svc.Status{State: svc.Stopped}
+	return false, 0
+}
+
+// openServiceLogFile opens (or creates) the service log file under
+// %ProgramData%\mnemo\logs\mnemo.log in append mode. Returns an error
+// if the directory cannot be created or the file cannot be opened;
+// callers treat that as non-fatal (stderr just stays as the SCM's
+// default, which is the null device).
+func openServiceLogFile() (*os.File, error) {
+	base := os.Getenv("ProgramData")
+	if base == "" {
+		base = `C:\ProgramData`
+	}
+	logDir := filepath.Join(base, "mnemo", "logs")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return nil, err
+	}
+	return os.OpenFile(filepath.Join(logDir, "mnemo.log"),
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+}
+
+// installService creates the mnemo Windows Service pointing at the
+// running executable. It configures auto-start-on-boot and
+// restart-on-failure, and registers an Event Log source named
+// "mnemo". Idempotent: succeeds without error if the service already
+// exists.
+func installService(args []string) error {
+	fs := flag.NewFlagSet("install-service", flag.ExitOnError)
+	exePath := fs.String("exe", "", "path to mnemo.exe (default: current executable)")
+	_ = fs.Parse(args)
+
+	path, err := resolveExe(*exePath)
+	if err != nil {
+		return err
+	}
+
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("connect SCM: %w (this command must run as Administrator)", err)
+	}
+	defer func() { _ = m.Disconnect() }()
+
+	s, err := m.OpenService(serviceName)
+	if err == nil {
+		// Already installed. Update the exe path in case the user
+		// reinstalled into a different location.
+		defer func() { _ = s.Close() }()
+		cfg, err := s.Config()
+		if err != nil {
+			return fmt.Errorf("read existing service config: %w", err)
+		}
+		cfg.BinaryPathName = path
+		cfg.StartType = mgr.StartAutomatic
+		if err := s.UpdateConfig(cfg); err != nil {
+			return fmt.Errorf("update service config: %w", err)
+		}
+		fmt.Printf("service %q updated (exe=%s)\n", serviceName, path)
+		return nil
+	}
+
+	s, err = m.CreateService(serviceName, path, mgr.Config{
+		DisplayName: "mnemo MCP server",
+		Description: "Searchable memory across Claude Code session transcripts.",
+		StartType:   mgr.StartAutomatic,
+	})
+	if err != nil {
+		return fmt.Errorf("create service: %w", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	// Configure automatic restart on unexpected exit: restart after
+	// 10 seconds, reset failure counter after an hour of clean run.
+	recovery := []mgr.RecoveryAction{
+		{Type: mgr.ServiceRestart, Delay: 10 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 30 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 60 * time.Second},
+	}
+	if err := s.SetRecoveryActions(recovery, 3600); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not set recovery actions: %v\n", err)
+	}
+
+	if err := eventlog.InstallAsEventCreate(serviceName,
+		eventlog.Error|eventlog.Warning|eventlog.Info); err != nil {
+		// Already-registered sources return an error we don't care
+		// about; tolerate.
+		fmt.Fprintf(os.Stderr, "warning: event log install: %v\n", err)
+	}
+
+	fmt.Printf("service %q installed (exe=%s)\n", serviceName, path)
+	return nil
+}
+
+// uninstallService stops (if running) and deletes the mnemo service
+// and its Event Log source. Idempotent: returns no error if the
+// service is already gone.
+func uninstallService(args []string) error {
+	_ = args
+
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("connect SCM: %w (this command must run as Administrator)", err)
+	}
+	defer func() { _ = m.Disconnect() }()
+
+	s, err := m.OpenService(serviceName)
+	if err != nil {
+		// Already gone — still try to drop the event log source.
+		_ = eventlog.Remove(serviceName)
+		fmt.Printf("service %q not installed\n", serviceName)
+		return nil
+	}
+	defer func() { _ = s.Close() }()
+
+	status, err := s.Query()
+	if err == nil && status.State != svc.Stopped && status.State != svc.StopPending {
+		if _, err := s.Control(svc.Stop); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not send stop: %v\n", err)
+		}
+		// Wait up to 15 seconds for the service to stop before
+		// deleting it. Delete will still be queued if it hasn't
+		// stopped, but this gives the handler a chance to drain.
+		deadline := time.Now().Add(15 * time.Second)
+		for time.Now().Before(deadline) {
+			status, err = s.Query()
+			if err != nil || status.State == svc.Stopped {
+				break
+			}
+			time.Sleep(250 * time.Millisecond)
+		}
+	}
+
+	if err := s.Delete(); err != nil {
+		// ERROR_SERVICE_MARKED_FOR_DELETE is fine — it means a prior
+		// delete is still pending.
+		if err != windows.ERROR_SERVICE_MARKED_FOR_DELETE {
+			return fmt.Errorf("delete service: %w", err)
+		}
+	}
+	if err := eventlog.Remove(serviceName); err != nil {
+		// Non-fatal.
+		fmt.Fprintf(os.Stderr, "warning: event log remove: %v\n", err)
+	}
+	fmt.Printf("service %q uninstalled\n", serviceName)
+	return nil
+}
+
+func resolveExe(override string) (string, error) {
+	if override != "" {
+		abs, err := filepath.Abs(override)
+		if err != nil {
+			return "", fmt.Errorf("resolve --exe: %w", err)
+		}
+		return abs, nil
+	}
+	path, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("resolve current executable: %w", err)
+	}
+	return path, nil
+}
+


### PR DESCRIPTION
Adds the non-technical Windows install path: a signed-ready Inno
Setup .exe that drops mnemo.exe into Program Files, registers it as
a Windows Service, and patches the user's ~/.claude.json so Claude
Code picks mnemo up on next session — all with zero terminal use.

- internal/mcpconfig: cross-platform helper to add/remove mnemo from
  ~/.claude.json. Atomic write preserves existing keys and other MCP
  entries; idempotent; creates file if missing. Full unit coverage.
- main.go: subcommand dispatch (register-mcp / unregister-mcp /
  install-service / uninstall-service) before flag.Parse so their
  flags don't collide with the global ones. runServe now takes a
  context and shuts down gracefully via HTTP Shutdown when cancelled.
- service_windows.go: Windows Service handler via
  golang.org/x/sys/windows/svc. Detects SCM-launched processes,
  redirects stderr to %ProgramData%\mnemo\logs\mnemo.log, reports
  status to SCM, and handles Stop/Shutdown cleanly. installService
  configures auto-start + restart-on-failure and registers an Event
  Log source. uninstallService stops (with 15s drain) then deletes.
- service_other.go: non-Windows stubs that error with a helpful
  pointer at brew services.
- installer/windows/mnemo.iss: Inno Setup script. Uses
  runasoriginaluser for register-mcp so the right user's
  ~/.claude.json is patched, not the elevated admin account's.
- .github/workflows/release.yml: builds mnemo-$VERSION-windows-amd64-
  setup.exe via iscc.exe (preinstalled on windows-latest) and uploads
  it alongside the existing zip.
- README: documents the Windows install path alongside brew.

Decomposes 🎯T32 into T32.1 (service), T32.2 (MCP registration
subcommand), T32.3 (installer + CI). Code signing is deliberately
not in scope — it requires a separate cert purchase and can ship
as a follow-up without blocking the base installer.
