### PR TITLE
Release v0.22.0 — Windows double-click installer (🎯T32 groundwork)

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -9,7 +9,19 @@ new product. The pre-1.0 period exists to get these surfaces right.
 
 ## Interaction surface catalogue
 
-Snapshot as of v0.21.0.
+Snapshot as of v0.22.0.
+
+**v0.22.0 note (🎯T32 groundwork)**: Windows-native install pathway
+— mnemo ships as a double-click `.exe` installer produced by Inno
+Setup in CI. The binary gains a Windows Service mode (auto-start on
+boot, restart-on-failure, Event Log source) via
+`golang.org/x/sys/windows/svc`, plus four cross-platform subcommands:
+`register-mcp`, `unregister-mcp`, `install-service`,
+`uninstall-service`. The installer is not yet code-signed, so
+SmartScreen will warn on first run until an EV cert is added.
+Default bare-invocation behaviour (`mnemo` → serve HTTP on :19419)
+is unchanged — existing macOS / Linux / brew-managed setups are
+untouched.
 
 **v0.21.0 note (🎯T22)**: mnemo now builds and runs natively on Windows
 (amd64 and arm64 in addition to darwin-arm64, linux-amd64, linux-arm64).
@@ -33,6 +45,20 @@ instead of failing silently.
 | `--addr` | string | `:19419` | Stable |
 | `--version` | bool | false | Stable |
 | `--help-agent` | bool | false | Stable |
+
+### CLI subcommands
+
+| Subcommand | Flags | Platform | Description | Stability |
+|---|---|---|---|---|
+| `register-mcp` | `--url`, `--config` | all | Add mnemo entry to `~/.claude.json` (idempotent) | Needs review |
+| `unregister-mcp` | `--config` | all | Remove mnemo entry from `~/.claude.json` (idempotent) | Needs review |
+| `install-service` | `--exe` | Windows | Register mnemo as a Windows Service with auto-start + restart-on-failure | Needs review |
+| `uninstall-service` | — | Windows | Stop and remove the Windows Service and its Event Log source | Needs review |
+
+Subcommands are new in v0.22.0 — API shape and flag set may evolve
+before 1.0 as end-user feedback arrives. Non-Windows invocations of
+the `*-service` subcommands return a helpful error pointing at brew
+services / systemd instead.
 
 ### MCP tools
 

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -130,3 +130,23 @@ maintenance activities. Append-only — newest entries at the bottom.
   four new data-mined introspection targets (🎯T28–🎯T31) and
   decomposed 🎯T15 (federated queries) into five leaf sub-targets
   (🎯T15.1–🎯T15.5). Homebrew formula updated.
+
+## 2026-04-20 — /release v0.22.0
+
+- **Commit**: `pending`
+- **Outcome**: Released v0.22.0. Windows double-click installer
+  (🎯T32 groundwork): Inno Setup `.exe` produced in CI on every
+  release, bundling mnemo.exe plus a native Windows Service mode
+  (auto-start, restart-on-failure, Event Log source) via
+  `golang.org/x/sys/windows/svc`. Four new cross-platform subcommands
+  (`register-mcp`, `unregister-mcp`, `install-service`,
+  `uninstall-service`) let the installer patch `%USERPROFILE%\.claude.json`
+  and register the service without the user opening a terminal.
+  `runServe` now takes a context and shuts down gracefully via HTTP
+  Shutdown on SCM Stop. New `internal/mcpconfig/` package with full
+  unit coverage handles atomic config patching (preserves other keys
+  and MCP entries). Decomposed 🎯T32 into T32.1 (service), T32.2
+  (registration subcommand), T32.3 (installer + CI). Code signing
+  deliberately deferred to a follow-up target — SmartScreen will
+  warn on first run until an EV cert is added. Homebrew formula
+  updated.

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ Then restart this Claude Code session.`
 var agentsGuide string
 
 const (
-	version     = "0.21.0"
+	version     = "0.22.0"
 	defaultAddr = ":19419"
 	// serviceName is the Windows Service identifier used by
 	// install-service / uninstall-service and by the service control


### PR DESCRIPTION
Non-technical Windows users can now install mnemo by double-clicking
a single .exe. Bumps version to 0.22.0, updates STABILITY.md with
the new subcommand surface, appends an audit-log entry.

- main.go: bump version constant to 0.22.0.
- STABILITY.md: v0.22.0 note covering the installer + service +
  register-mcp subcommands; new "CLI subcommands" catalogue
  section flagged "Needs review" until end-user feedback lands.
- docs/audit-log.md: append v0.22.0 entry (Commit: pending, to be
  patched by a follow-up PR per the audit-log convention).
