### PR TITLE
Fix Windows installer build: disable MSYS path conversion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,11 @@ jobs:
         if: matrix.goos == 'windows'
         working-directory: mnemo
         shell: bash
+        env:
+          # MSYS path-conversion mangles ISCC's slash-prefixed flags
+          # (/DAppVersion=..., /O.) into Windows paths before exec,
+          # causing ISCC to treat them as extra script filenames.
+          MSYS_NO_PATHCONV: "1"
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           mkdir -p dist


### PR DESCRIPTION
iscc.exe's slash-prefixed flags (/DAppVersion, /DSourceDir, /O.)
were being mangled into Windows paths by MSYS/Git-Bash before exec,
causing iscc to treat each flag as an extra script filename and bail
with 'You may not specify more than one script filename.'

Set MSYS_NO_PATHCONV=1 on the Build Windows installer step so the
flags are passed through verbatim.
