### PR TITLE
Fix installer build: stage dist next to .iss file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,9 +95,13 @@ jobs:
           MSYS_NO_PATHCONV: "1"
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          mkdir -p dist
-          cp "mnemo.exe" dist/
-          cp LICENSE dist/LICENSE.txt
+          # Stage alongside the .iss file so Inno Setup's relative
+          # Source: paths (resolved from the .iss file's directory)
+          # find LICENSE.txt and mnemo.exe.
+          STAGE=installer/windows/dist
+          mkdir -p "$STAGE"
+          cp "mnemo.exe" "$STAGE/"
+          cp LICENSE "$STAGE/LICENSE.txt"
           # Inno Setup 6 is preinstalled on windows-latest runners.
           ISCC="/c/Program Files (x86)/Inno Setup 6/iscc.exe"
           "$ISCC" "/DAppVersion=${VERSION}" \


### PR DESCRIPTION
Inno Setup resolves relative Source: paths from the .iss file's
directory, not iscc's cwd. Previous staging at mnemo/dist/ caused
Inno to look for mnemo/installer/windows/dist/LICENSE.txt and fail.
Move staging to installer/windows/dist/ so SourceDir=dist resolves
correctly from the .iss file's location.
