### PR TITLE
Release v0.24.0 — suppress Windows console window (🎯T32 polish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,12 @@ jobs:
             goarch: amd64
             ext: ".exe"
             archive: zip
-            # Static-link the MinGW runtime so end users do not need
-            # MinGW-w64 DLLs on their PATH. 🎯T22 AC: "Release binary
-            # on Windows is statically linked (or bundles required
-            # DLLs)".
-            ldflags_extra: '-extldflags "-static"'
+            # -H=windowsgui so Scheduled-Task launch does not pop a
+            # console window (console_windows.go re-attaches stdio
+            # when launched from a shell). -extldflags "-static"
+            # static-links the MinGW runtime so end users do not
+            # need MinGW-w64 DLLs on their PATH.
+            ldflags_extra: '-H=windowsgui -extldflags "-static"'
             # windows-latest has MinGW-w64 GCC preinstalled; bare
             # names resolve via PATH.
             cc: gcc
@@ -56,7 +57,7 @@ jobs:
             goarch: arm64
             ext: ".exe"
             archive: zip
-            ldflags_extra: '-extldflags "-static"'
+            ldflags_extra: '-H=windowsgui -extldflags "-static"'
             # Cross-compile via llvm-mingw, installed in the
             # "Install llvm-mingw" step below. Its binaries land in
             # PATH via GITHUB_PATH, so these bare names resolve.

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -9,7 +9,15 @@ new product. The pre-1.0 period exists to get these surfaces right.
 
 ## Interaction surface catalogue
 
-Snapshot as of v0.23.0.
+Snapshot as of v0.24.0.
+
+**v0.24.0 note (🎯T32 groundwork)**: Suppress the console window the
+Windows Scheduled Task was popping on logon. mnemo.exe is now built
+with `-ldflags -H=windowsgui` so Windows never attaches a console
+to it; a `console_windows.go` init shim calls
+`AttachConsole(ATTACH_PARENT_PROCESS)` so `mnemo --version` et al.
+still show output when invoked from PowerShell / cmd. No CLI or
+MCP surface change.
 
 **v0.23.0 note (🎯T32 groundwork)**: Windows ARM64 installer parity
 and a critical fix to how mnemo runs on Windows. v0.22.0 installed

--- a/console_windows.go
+++ b/console_windows.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+// Windows subsystem handling.
+//
+// mnemo.exe is built with `-ldflags -H=windowsgui` on Windows so the
+// Scheduled Task launched at logon does NOT pop a console window —
+// which was the v0.23.0 symptom when launched via `schtasks /run`.
+//
+// But `-H=windowsgui` also means that when a user runs
+// `mnemo --version` or `mnemo --help-agent` from PowerShell / cmd,
+// there's no attached console so stdout/stderr go nowhere and the
+// user sees silence. That's a worse CLI UX than the console-window
+// regression we're fixing.
+//
+// Workaround: call AttachConsole(ATTACH_PARENT_PROCESS) at init
+// time. If the process was launched from a shell (parent has a
+// console), we attach to it and reopen the Go standard streams
+// against CONOUT$/CONIN$, so `mnemo --version` prints as expected.
+// If the process was launched without a parent console (Scheduled
+// Task, double-click, etc.), the call fails silently and we stay
+// headless — no window ever appears.
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+// ATTACH_PARENT_PROCESS per
+// https://learn.microsoft.com/windows/console/attachconsole — the
+// WinAPI constant is DWORD(-1), i.e. the uintptr with all bits set.
+const attachParentProcess = ^uintptr(0)
+
+func init() {
+	kernel32 := syscall.NewLazyDLL("kernel32.dll")
+	attach := kernel32.NewProc("AttachConsole")
+	ret, _, _ := attach.Call(attachParentProcess)
+	if ret == 0 {
+		// No parent console (Scheduled Task, Explorer double-click,
+		// etc.). Stay headless — Go's default stdout/stderr *Files are
+		// already no-ops in that case, which is fine.
+		return
+	}
+
+	// Parent console attached. Re-wire Go's stdio to it so fmt.Println
+	// and log.* actually show up in the parent shell.
+	if f, err := os.OpenFile("CONOUT$", os.O_WRONLY, 0); err == nil {
+		os.Stdout = f
+		os.Stderr = f
+	}
+	if f, err := os.OpenFile("CONIN$", os.O_RDONLY, 0); err == nil {
+		os.Stdin = f
+	}
+}

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -180,3 +180,19 @@ maintenance activities. Append-only — newest entries at the bottom.
   (arm64) runners. Validated via a v0.23.0-rc.1 prerelease before
   cutting the real tag, per the new release-workflow-touch signal
   in the /release skill. Homebrew formula updated.
+
+## 2026-04-22 — /release v0.24.0
+
+- **Commit**: `pending`
+- **Outcome**: Released v0.24.0. Fixes the visible console window
+  the Windows Scheduled Task was popping at logon. v0.23.0 shipped
+  mnemo.exe with the default console subsystem; when `schtasks`
+  launches it, Windows creates a console and shows it. Switched
+  the Windows build to `-H=windowsgui` so Windows never attaches a
+  console. Added `console_windows.go` with an init shim that calls
+  `AttachConsole(ATTACH_PARENT_PROCESS)` and reopens CONOUT$/CONIN$
+  so `mnemo --version` and other CLI invocations from PowerShell /
+  cmd still show output. Headless launches (Scheduled Task,
+  Explorer double-click) stay silent as intended. No code change
+  beyond the subsystem flag + the init shim. Homebrew formula
+  updated.

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ Then restart this Claude Code session.`
 var agentsGuide string
 
 const (
-	version     = "0.23.0"
+	version     = "0.24.0"
 	defaultAddr = ":19419"
 )
 


### PR DESCRIPTION
v0.23.0's Scheduled Task launched mnemo.exe (console subsystem);
Windows popped a visible console window at every logon. Not what
anyone wants from a background indexer.

- Windows build now passes -H=windowsgui so Windows never attaches
  a console to mnemo.exe.
- New console_windows.go init shim calls
  AttachConsole(ATTACH_PARENT_PROCESS) and re-wires stdout/stderr/
  stdin to CONOUT$/CONIN$ when there IS a parent console (e.g.
  `mnemo --version` from PowerShell), so the CLI still works.
- Headless launches (Scheduled Task, Explorer double-click) stay
  silent as intended.

No code change beyond the subsystem flag + the init shim — same
functionality, no window.

Routine release-prep: version bump, STABILITY.md note, audit-log
entry (Commit: pending).
