### PR TITLE
Release v0.27.0 — trim mnemo_status defaults

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -9,7 +9,17 @@ new product. The pre-1.0 period exists to get these surfaces right.
 
 ## Interaction surface catalogue
 
-Snapshot as of v0.26.0.
+Snapshot as of v0.27.0.
+
+**v0.27.0 note**: Trim `mnemo_status` defaults so a routine call no
+longer blows past Claude Code's 25KB inline tool-result threshold.
+Defaults: `max_sessions` 3 → 2, `max_excerpts` 20 → 6, `truncate_len`
+200 → 160. Also: truncation now applies to **every** excerpt rather
+than just assistant ones, so user pastes (logs, command output)
+stop dominating response size. A typical 30-day call against a
+moderately busy machine drops from ~74 KB to ~6 KB. Behaviour is
+configurable per call — pass larger explicit values to recover the
+old verbosity. No CLI or MCP surface change.
 
 **v0.26.0 note**: Auto-migration from legacy stdio registrations.
 mnemo launched with stdin piped (i.e. invoked by Claude Code's

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -936,7 +936,7 @@ targets:
     discovered: 2026-04-21
   T34:
     name: mnemo indexes synthesis docs across configurable roots with taxonomy awareness
-    status: converging
+    status: achieved
     value: 0.0
     cost: 0.0
     observable: true
@@ -951,6 +951,7 @@ targets:
     context: 'User has established a four-dir synthesis-doc taxonomy (papers/design/analysis/plans) in ~/.claude/CLAUDE.md, with audit-log.md and convergence-report.md as adjacent snapshot artifacts. Synthesis docs live in repos under ~/work AND in non-repo planning space under ~/think. Goal: give mnemo a taxonomy-aware query surface so a future /synth portfolio skill (or any cross-repo synthesis query) has the same ergonomics as mnemo_search. Builds on existing IngestDocs infrastructure — does not replace it.'
     origin: 'user request 2026-04-24: integrate Karpathy wiki ideas into existing system; synthesis docs stay in repos but mnemo provides global query layer'
     discovered: 2026-04-24
+    achieved: 2026-04-25
   T35:
     name: Indexer is idempotent — re-reading a transcript file does not duplicate rows in entries
     status: identified

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -181,6 +181,26 @@ maintenance activities. Append-only — newest entries at the bottom.
   cutting the real tag, per the new release-workflow-touch signal
   in the /release skill. Homebrew formula updated.
 
+## 2026-04-25 — /release v0.27.0
+
+- **Commit**: `pending`
+- **Outcome**: Released v0.27.0. Trim `mnemo_status` defaults so
+  routine calls stay inline in Claude Code (under 25KB tool-result
+  threshold). User reported a 74KB response from `mnemo_status`
+  with default args on a moderately busy machine, which Claude
+  Code persisted to disk and showed only a 2KB preview. Cause:
+  defaults were `max_sessions=3`, `max_excerpts=20`,
+  `truncate_len=200` and truncation applied only to assistant
+  messages — user pastes (logs, command output, code) escaped the
+  cap entirely. Defaults are now `max_sessions=2`,
+  `max_excerpts=6`, `truncate_len=160`, and truncation applies to
+  every excerpt regardless of role. Estimated response-size
+  reduction: ~10× on the reported workload (74KB → ~6KB). All
+  three knobs remain caller-overridable for users who actually
+  want the verbose form. Pure UX/default change in
+  `internal/store/store.go` and `internal/tools/tools.go`. No
+  schema or protocol impact. Homebrew formula updated.
+
 ## 2026-04-25 — /release v0.26.0
 
 - **Commit**: `aabd560`

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4917,8 +4917,10 @@ func (s *Store) Status(days int, repoFilter string, maxSessions int, maxExcerpts
 				if err := msgRows.Scan(&m.ID, &m.Role, &m.Text, &m.Timestamp); err != nil {
 					continue
 				}
-				// Truncate assistant messages.
-				if m.Role == "assistant" && len(m.Text) > truncateLen {
+				// Truncate every excerpt — user pastes (logs, code,
+				// command output) inflate response size just as much
+				// as assistant tool-call serialisations do.
+				if len(m.Text) > truncateLen {
 					m.Text = m.Text[:truncateLen] + "..."
 					m.Truncated = true
 				}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -721,15 +721,15 @@ func (h *callHandler) status(args map[string]any) (string, bool, error) {
 		days = int(d)
 	}
 	repoFilter, _ := args["repo"].(string)
-	maxSessions := 3
+	maxSessions := 2
 	if m, ok := args["max_sessions"].(float64); ok && m > 0 {
 		maxSessions = int(m)
 	}
-	maxExcerpts := 20
+	maxExcerpts := 6
 	if m, ok := args["max_excerpts"].(float64); ok && m > 0 {
 		maxExcerpts = int(m)
 	}
-	truncateLen := 200
+	truncateLen := 160
 	if t, ok := args["truncate_len"].(float64); ok && t > 0 {
 		truncateLen = int(t)
 	}

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ Then restart this Claude Code session.`
 var agentsGuide string
 
 const (
-	version     = "0.26.0"
+	version     = "0.27.0"
 	defaultAddr = ":19419"
 )
 


### PR DESCRIPTION
User reported a 74KB mnemo_status response on a moderately busy
machine — Claude Code persisted it to disk and showed only a 2KB
preview. Cause: defaults too generous (3 sessions × 20 excerpts
per repo) and truncation applied only to assistant messages, so
user pastes (logs, command output, code) escaped the cap.

- internal/tools/tools.go: max_sessions 3 -> 2,
  max_excerpts 20 -> 6, truncate_len 200 -> 160.
- internal/store/store.go: truncation now applies to every
  excerpt regardless of role (user pastes were dominating
  response size more than assistant tool-call serialisations).

Estimated reduction: ~10x on the reported workload. All three
knobs remain caller-overridable for deep introspection.
