### PR TITLE
🎯T29: mnemo_tool_result tool

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -818,7 +818,7 @@ targets:
     achieved: 2026-04-26
   T29:
     name: mnemo surfaces raw tool-result bodies
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -829,6 +829,7 @@ targets:
     context: 'Data-mined from 180 days of Claude session transcripts (2026-04-19). Observed post-mnemo workaround: cat and tail against .claude/projects/<project>/<session>/tool-results/<id>.txt. Tool-result payloads are stored on disk as separate files (one per tool_use_id) but arent directly retrievable via mnemo. mnemo_read_session returns the message stream with tool_use inputs but not the full tool-result text bodies. A mnemo_tool_result(session_id, tool_use_id) tool would remove another class of direct .claude/projects/ bash access.'
     origin: doit data-mining 2026-04-19
     discovered: 2026-04-19
+    achieved: 2026-04-26
   T3:
     name: Active work dashboard data
     status: achieved

--- a/internal/store/iface.go
+++ b/internal/store/iface.go
@@ -44,6 +44,7 @@ type Backend interface {
 	SearchImagesFiltered(query string, repo string, session string, days int, limit int, searchFields string) ([]ImageSearchResult, error)
 	SearchImagesSemantic(query string, repo string, session string, days int, limit int) ([]ImageSearchResult, error)
 	SearchImagesSimilar(similarTo int, repo string, session string, days int, limit int) ([]ImageSearchResult, error)
+	ToolResult(sessionID, toolUseID string, offset, truncateLen int) (*ToolResultPayload, error)
 	ChainCompactions(sessionID string) ([]Compaction, error)
 	CompactionsForConnection(connectionID string) ([]Compaction, error)
 	SessionTokens(sessionID string) (int64, int64, error)

--- a/internal/store/tool_result.go
+++ b/internal/store/tool_result.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import "database/sql"
+
+// ToolResultPayload holds the raw text body of a tool-result message.
+type ToolResultPayload struct {
+	Text      string `json:"text"`
+	IsError   bool   `json:"is_error"`
+	TotalLen  int    `json:"total_len"`
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
+// ToolResult returns the raw text body for a tool-result message identified
+// by session_id and tool_use_id. Supports session_id prefix matching.
+// truncateLen <= 0 means no truncation. offset skips the first N bytes.
+func (s *Store) ToolResult(sessionID, toolUseID string, offset, truncateLen int) (*ToolResultPayload, error) {
+	s.rwmu.RLock()
+	defer s.rwmu.RUnlock()
+
+	resolvedID, err := s.resolveSessionID(sessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	var text string
+	var isError int
+	err = s.db.QueryRow(
+		`SELECT text, is_error FROM messages
+		 WHERE session_id = ? AND content_type = 'tool_result' AND tool_use_id = ?
+		 LIMIT 1`,
+		resolvedID, toolUseID,
+	).Scan(&text, &isError)
+	if err == sql.ErrNoRows {
+		return nil, &ToolResultNotFoundError{SessionID: resolvedID, ToolUseID: toolUseID}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	total := len(text)
+
+	// Apply byte offset.
+	if offset > 0 {
+		if offset >= len(text) {
+			text = ""
+		} else {
+			text = text[offset:]
+		}
+	}
+
+	truncated := false
+	if truncateLen > 0 && len(text) > truncateLen {
+		text = text[:truncateLen]
+		truncated = true
+	}
+
+	return &ToolResultPayload{
+		Text:      text,
+		IsError:   isError != 0,
+		TotalLen:  total,
+		Truncated: truncated,
+	}, nil
+}
+
+// ToolResultNotFoundError is returned when no matching tool-result is found.
+type ToolResultNotFoundError struct {
+	SessionID string
+	ToolUseID string
+}
+
+func (e *ToolResultNotFoundError) Error() string {
+	return "no tool_result found for tool_use_id " + e.ToolUseID + " in session " + e.SessionID
+}

--- a/internal/store/tool_result_test.go
+++ b/internal/store/tool_result_test.go
@@ -1,0 +1,210 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// toolUseMsg builds a JSONL assistant message containing a tool_use block.
+func toolUseMsg(ts, toolName, toolUseID string, input map[string]any) map[string]any {
+	return map[string]any{
+		"type":      "assistant",
+		"timestamp": ts,
+		"message": map[string]any{
+			"content": []any{
+				map[string]any{
+					"type":  "tool_use",
+					"id":    toolUseID,
+					"name":  toolName,
+					"input": input,
+				},
+			},
+		},
+	}
+}
+
+// toolResultMsg builds a JSONL user message containing a tool_result block.
+func toolResultMsg(ts, toolUseID, content string) map[string]any {
+	return map[string]any{
+		"type":      "user",
+		"timestamp": ts,
+		"message": map[string]any{
+			"content": []any{
+				map[string]any{
+					"type":        "tool_result",
+					"tool_use_id": toolUseID,
+					"content":     content,
+				},
+			},
+		},
+	}
+}
+
+// toolResultErrorMsg builds a JSONL user message with an is_error tool_result.
+func toolResultErrorMsg(ts, toolUseID, content string) map[string]any {
+	return map[string]any{
+		"type":      "user",
+		"timestamp": ts,
+		"message": map[string]any{
+			"content": []any{
+				map[string]any{
+					"type":        "tool_result",
+					"tool_use_id": toolUseID,
+					"content":     content,
+					"is_error":    true,
+				},
+			},
+		},
+	}
+}
+
+func TestToolResult(t *testing.T) {
+	projectDir := t.TempDir()
+
+	const sessionID = "sess-tr-001"
+	const toolUseID = "toolu_abc123"
+	const resultBody = "file contents here\nline two\nline three"
+
+	writeJSONL(t, projectDir, "myproject", sessionID, []map[string]any{
+		metaMsg("user", "Read the file for me", "2026-04-10T10:00:00Z",
+			"/Users/dev/work/github.com/acme/webapp", "main"),
+		toolUseMsg("2026-04-10T10:00:01Z", "Read", toolUseID,
+			map[string]any{"file_path": "/some/file.txt"}),
+		toolResultMsg("2026-04-10T10:00:02Z", toolUseID, resultBody),
+	})
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("basic lookup", func(t *testing.T) {
+		payload, err := s.ToolResult(sessionID, toolUseID, 0, 0)
+		if err != nil {
+			t.Fatalf("ToolResult: %v", err)
+		}
+		if payload.Text != resultBody {
+			t.Errorf("got text %q, want %q", payload.Text, resultBody)
+		}
+		if payload.IsError {
+			t.Error("expected IsError=false")
+		}
+		if payload.TotalLen != len(resultBody) {
+			t.Errorf("TotalLen=%d, want %d", payload.TotalLen, len(resultBody))
+		}
+		if payload.Truncated {
+			t.Error("expected Truncated=false")
+		}
+	})
+
+	t.Run("prefix session_id", func(t *testing.T) {
+		payload, err := s.ToolResult("sess-tr", toolUseID, 0, 0)
+		if err != nil {
+			t.Fatalf("ToolResult with prefix: %v", err)
+		}
+		if payload.Text != resultBody {
+			t.Errorf("prefix lookup got %q, want %q", payload.Text, resultBody)
+		}
+	})
+
+	t.Run("truncate_len", func(t *testing.T) {
+		payload, err := s.ToolResult(sessionID, toolUseID, 0, 10)
+		if err != nil {
+			t.Fatalf("ToolResult with truncate: %v", err)
+		}
+		if payload.Text != resultBody[:10] {
+			t.Errorf("truncated text=%q, want %q", payload.Text, resultBody[:10])
+		}
+		if !payload.Truncated {
+			t.Error("expected Truncated=true")
+		}
+		if payload.TotalLen != len(resultBody) {
+			t.Errorf("TotalLen=%d, want %d", payload.TotalLen, len(resultBody))
+		}
+	})
+
+	t.Run("offset", func(t *testing.T) {
+		payload, err := s.ToolResult(sessionID, toolUseID, 5, 0)
+		if err != nil {
+			t.Fatalf("ToolResult with offset: %v", err)
+		}
+		want := resultBody[5:]
+		if payload.Text != want {
+			t.Errorf("offset text=%q, want %q", payload.Text, want)
+		}
+		if payload.TotalLen != len(resultBody) {
+			t.Errorf("TotalLen=%d, want %d", payload.TotalLen, len(resultBody))
+		}
+	})
+
+	t.Run("offset+truncate", func(t *testing.T) {
+		payload, err := s.ToolResult(sessionID, toolUseID, 5, 6)
+		if err != nil {
+			t.Fatalf("ToolResult with offset+truncate: %v", err)
+		}
+		want := resultBody[5 : 5+6]
+		if payload.Text != want {
+			t.Errorf("offset+truncate text=%q, want %q", payload.Text, want)
+		}
+		if !payload.Truncated {
+			t.Error("expected Truncated=true")
+		}
+	})
+
+	t.Run("missing tool_use_id", func(t *testing.T) {
+		_, err := s.ToolResult(sessionID, "toolu_nonexistent", 0, 0)
+		if err == nil {
+			t.Fatal("expected error for missing tool_use_id, got nil")
+		}
+		var notFound *ToolResultNotFoundError
+		if !errors.As(err, &notFound) {
+			t.Errorf("expected ToolResultNotFoundError, got %T: %v", err, err)
+		}
+		if !strings.Contains(err.Error(), "toolu_nonexistent") {
+			t.Errorf("error message should mention tool_use_id, got: %v", err)
+		}
+	})
+
+	t.Run("missing session_id", func(t *testing.T) {
+		_, err := s.ToolResult("sess-does-not-exist", toolUseID, 0, 0)
+		if err == nil {
+			t.Fatal("expected error for missing session, got nil")
+		}
+	})
+}
+
+func TestToolResultIsError(t *testing.T) {
+	projectDir := t.TempDir()
+
+	const sessionID = "sess-tr-err"
+	const toolUseID = "toolu_err456"
+	const errBody = "file not found: /missing.txt"
+
+	writeJSONL(t, projectDir, "myproject", sessionID, []map[string]any{
+		metaMsg("user", "Read missing file", "2026-04-10T11:00:00Z",
+			"/Users/dev/work/github.com/acme/webapp", "main"),
+		toolUseMsg("2026-04-10T11:00:01Z", "Read", toolUseID,
+			map[string]any{"file_path": "/missing.txt"}),
+		toolResultErrorMsg("2026-04-10T11:00:02Z", toolUseID, errBody),
+	})
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	payload, err := s.ToolResult(sessionID, toolUseID, 0, 0)
+	if err != nil {
+		t.Fatalf("ToolResult: %v", err)
+	}
+	if !payload.IsError {
+		t.Error("expected IsError=true")
+	}
+	if payload.Text != errBody {
+		t.Errorf("got text %q, want %q", payload.Text, errBody)
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -420,6 +420,17 @@ Use this to quickly understand a session's shape before deep-reading it, to comp
 			mcp.WithNumber("limit", mcp.Description("Max results (default 20)")),
 			mcp.WithString("search_fields", mcp.Description(`For text mode: which indexes to search: "both" (default), "description" (AI descriptions only), or "ocr" (extracted text only).`)),
 		),
+		mcp.NewTool("mnemo_tool_result",
+			mcp.WithDescription(`Return the raw tool-result payload for a specific tool invocation.
+
+Looks up the tool-result body stored at ingest time, identified by its tool_use_id within a session. Replaces the cat ~/.claude/projects/<project>/<session>/tool-results/<id>.txt workaround.
+
+Returns the full text, is_error flag, and total byte length. Use offset and truncate_len to page through large payloads.`),
+			mcp.WithString("session_id", mcp.Required(), mcp.Description("Session ID (or unique prefix) containing the tool invocation.")),
+			mcp.WithString("tool_use_id", mcp.Required(), mcp.Description("The tool_use_id of the tool invocation whose result you want.")),
+			mcp.WithNumber("offset", mcp.Description("Skip the first N bytes of the result text (default 0).")),
+			mcp.WithNumber("truncate_len", mcp.Description("Maximum bytes to return (default: no limit). Use with offset to page.")),
+		),
 	}
 }
 
@@ -510,6 +521,8 @@ func (h *Handler) Call(cc CallContext, name string, args map[string]any) (string
 		return ch.images(args)
 	case "mnemo_session_structure":
 		return ch.sessionStructure(args)
+	case "mnemo_tool_result":
+		return ch.toolResult(args)
 	default:
 		return "", false, fmt.Errorf("unknown tool: %s", name)
 	}
@@ -1777,4 +1790,43 @@ func (h *callHandler) sessionStructure(args map[string]any) (string, bool, error
 		return fmt.Sprintf("marshal failed: %v", err), true, nil
 	}
 	return string(out), false, nil
+}
+
+func (h *callHandler) toolResult(args map[string]any) (string, bool, error) {
+	sessionID, _ := args["session_id"].(string)
+	if sessionID == "" {
+		return "session_id is required", true, nil
+	}
+	toolUseID, _ := args["tool_use_id"].(string)
+	if toolUseID == "" {
+		return "tool_use_id is required", true, nil
+	}
+	offset := 0
+	if o, ok := args["offset"].(float64); ok && o >= 0 {
+		offset = int(o)
+	}
+	truncateLen := 0
+	if t, ok := args["truncate_len"].(float64); ok && t > 0 {
+		truncateLen = int(t)
+	}
+
+	payload, err := h.mem.ToolResult(sessionID, toolUseID, offset, truncateLen)
+	if err != nil {
+		return fmt.Sprintf("tool_result lookup failed: %v", err), true, nil
+	}
+
+	var b strings.Builder
+	if payload.IsError {
+		b.WriteString("[error] ")
+	}
+	fmt.Fprintf(&b, "total_len=%d", payload.TotalLen)
+	if offset > 0 {
+		fmt.Fprintf(&b, " offset=%d", offset)
+	}
+	if payload.Truncated {
+		fmt.Fprintf(&b, " truncated=true")
+	}
+	b.WriteString("\n\n")
+	b.WriteString(payload.Text)
+	return b.String(), false, nil
 }


### PR DESCRIPTION
## Summary

- Adds new MCP tool `mnemo_tool_result(session_id, tool_use_id)` that returns the raw tool-result payload text for a given tool invocation
- Replaces the `cat ~/.claude/projects/<project>/<session>/tool-results/<id>.txt` workaround
- Lookup is O(1) via the existing `idx_messages_tool_use_id` index on the `messages` table
- Supports `truncate_len` and `offset` parameters for paging through large payloads
- Handles missing `tool_use_id` gracefully via `ToolResultNotFoundError` (clear message, no crash)
- Session ID prefix matching consistent with `mnemo_read_session`

## New files

- `internal/store/tool_result.go` — `ToolResult` method + `ToolResultPayload` type + `ToolResultNotFoundError`
- `internal/store/tool_result_test.go` — comprehensive tests

## Modified files

- `internal/store/iface.go` — added `ToolResult` to `Backend` interface
- `internal/tools/tools.go` — added tool definition in `Definitions()`, case in `Call()`, and `toolResult` handler

## Test plan

- [ ] `go test -tags sqlite_fts5 ./internal/store/ -run TestToolResult` — basic lookup, prefix session_id, truncate_len, offset, offset+truncate, missing tool_use_id, missing session all pass
- [ ] `go test -tags sqlite_fts5 ./internal/store/ -run TestToolResultIsError` — is_error flag surfaced correctly
- [ ] `go test -tags sqlite_fts5 ./...` — full suite green
- [ ] `make bullseye` — fmt, vet, build, tests all pass (dirty tree expected from local changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)