### PR TITLE
🎯T30: mnemo_get_memory tool

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -845,7 +845,7 @@ targets:
     achieved: 2026-04-07
   T30:
     name: mnemo returns raw content of a named memory file
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -856,6 +856,7 @@ targets:
     context: 'Data-mined from 180 days of Claude session transcripts (2026-04-19). Observed post-mnemo pattern: cat of /Users/marcelo/.claude/projects/<project>/memory/<name>.md and find for *.md under memory directories. mnemo_memories exists but returns search hits, not the full body of a named memory file. When Claude knows the project plus memory name it wants the raw text directly; today it either cats the file or runs mnemo_memories with a query it hopes will match and then has to open the file anyway.'
     origin: doit data-mining 2026-04-19
     discovered: 2026-04-19
+    achieved: 2026-04-26
   T31:
     name: mnemo locates an entry by UUID across sessions
     status: identified

--- a/internal/store/iface.go
+++ b/internal/store/iface.go
@@ -18,6 +18,7 @@ type Backend interface {
 	Status(days int, repoFilter string, maxSessions int, maxExcerpts int, truncateLen int) (*StatusResult, error)
 	Usage(days int, repoFilter, model, groupBy string) (*UsageResult, error)
 	SearchMemories(query string, memType string, project string, limit int) ([]MemoryInfo, error)
+	GetMemory(project, name string) (*MemoryInfo, error)
 	SearchSkills(query string, limit int) ([]SkillInfo, error)
 	SearchClaudeConfigs(query string, repo string, limit int) ([]ClaudeConfigInfo, error)
 	SearchAuditLogs(query string, repo string, skill string, limit int) ([]AuditEntryInfo, error)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1524,6 +1524,45 @@ func (s *Store) queryMemories(q string, args ...any) ([]MemoryInfo, error) {
 	return results, nil
 }
 
+// GetMemory retrieves a single named memory file for a project.
+// project is matched as a substring of the stored project value (consistent
+// with SearchMemories). name is matched case-insensitively as a substring
+// of either the frontmatter name field or the file base name (without .md).
+// Returns nil without error when the project or memory is not found.
+func (s *Store) GetMemory(project, name string) (*MemoryInfo, error) {
+	s.rwmu.RLock()
+	defer s.rwmu.RUnlock()
+
+	if project == "" {
+		return nil, fmt.Errorf("project is required")
+	}
+	if name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	// Retrieve all memories for the project, then match name in Go.
+	q := `SELECT id, project, file_path, name, description, memory_type, content, updated_at
+		FROM memories
+		WHERE project LIKE ?
+		ORDER BY updated_at DESC`
+	candidates, err := s.queryMemories(q, "%"+project+"%")
+	if err != nil {
+		return nil, err
+	}
+
+	nameLower := strings.ToLower(name)
+	for i := range candidates {
+		m := &candidates[i]
+		// Match against frontmatter name or file base name (stem).
+		stem := strings.TrimSuffix(filepath.Base(m.FilePath), ".md")
+		if strings.Contains(strings.ToLower(m.Name), nameLower) ||
+			strings.Contains(strings.ToLower(stem), nameLower) {
+			return m, nil
+		}
+	}
+	return nil, nil
+}
+
 // SkillInfo holds a single skill record from the index.
 type SkillInfo struct {
 	ID          int    `json:"id"`

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -1228,6 +1229,115 @@ The revised protocol uses ECDH key exchange after QR scan.
 	}
 	if results[0].Name != "QR transfer protocol (revised)" {
 		t.Errorf("expected updated name, got %q", results[0].Name)
+	}
+}
+
+func TestGetMemory(t *testing.T) {
+	projectDir := t.TempDir()
+
+	memDir := filepath.Join(projectDir, "myproject", "memory")
+	if err := os.MkdirAll(memDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Memory file with frontmatter.
+	topicContent := `---
+name: QR transfer protocol
+description: Design decisions for QR-based session transfer
+type: project
+---
+
+The QR transfer uses a token-based handoff.
+`
+	if err := os.WriteFile(filepath.Join(memDir, "qr_transfer.md"), []byte(topicContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// MEMORY.md index file (no frontmatter, plain markdown).
+	indexContent := "- [QR transfer](qr_transfer.md) — QR-based session transfer design\n"
+	if err := os.WriteFile(filepath.Join(memDir, "MEMORY.md"), []byte(indexContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	writeJSONL(t, projectDir, "myproject", "sess-get-mem", []map[string]any{
+		msg("user", "hello", "2026-04-01T10:00:00Z"),
+	})
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.IngestMemories(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Retrieve by frontmatter name substring.
+	m, err := s.GetMemory("myproject", "QR transfer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m == nil {
+		t.Fatal("expected memory, got nil")
+	}
+	if m.Name != "QR transfer protocol" {
+		t.Errorf("expected name %q, got %q", "QR transfer protocol", m.Name)
+	}
+	if m.MemoryType != "project" {
+		t.Errorf("expected type %q, got %q", "project", m.MemoryType)
+	}
+	if !strings.Contains(m.Content, "token-based handoff") {
+		t.Errorf("expected content to contain 'token-based handoff', got %q", m.Content)
+	}
+
+	// Retrieve by file stem (case-insensitive).
+	m2, err := s.GetMemory("myproject", "qr_transfer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m2 == nil {
+		t.Fatal("expected memory via file stem lookup, got nil")
+	}
+	if m2.Name != "QR transfer protocol" {
+		t.Errorf("expected name via stem %q, got %q", "QR transfer protocol", m2.Name)
+	}
+
+	// Retrieve MEMORY.md by file stem.
+	mIdx, err := s.GetMemory("myproject", "MEMORY")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mIdx == nil {
+		t.Fatal("expected MEMORY.md to be retrievable by stem, got nil")
+	}
+
+	// Not found — wrong name.
+	mMissing, err := s.GetMemory("myproject", "nonexistent_memory_xyz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mMissing != nil {
+		t.Errorf("expected nil for unknown memory, got %+v", mMissing)
+	}
+
+	// Not found — wrong project.
+	mWrongProj, err := s.GetMemory("no-such-project", "QR transfer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mWrongProj != nil {
+		t.Errorf("expected nil for unknown project, got %+v", mWrongProj)
+	}
+
+	// Error — empty project.
+	_, errEmpty := s.GetMemory("", "QR transfer")
+	if errEmpty == nil {
+		t.Error("expected error for empty project, got nil")
+	}
+
+	// Error — empty name.
+	_, errEmptyName := s.GetMemory("myproject", "")
+	if errEmptyName == nil {
+		t.Error("expected error for empty name, got nil")
 	}
 }
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -199,6 +199,15 @@ Use this to find decisions, preferences, and context captured in any project —
 			mcp.WithString("project", mcp.Description("Filter by project name substring")),
 			mcp.WithNumber("limit", mcp.Description("Max results (default 20)")),
 		),
+		mcp.NewTool("mnemo_get_memory",
+			mcp.WithDescription(`Return the raw markdown content of a named memory file, or list available memories when name is omitted.
+
+Replaces the cat ~/.claude/projects/<project>/memory/<name>.md workaround. Project is matched as a substring (consistent with mnemo_memories). Name is matched case-insensitively against the frontmatter name field and the file base name (without .md extension).
+
+When name is omitted, returns a list of all memories for the project with their name, type, and description.`),
+			mcp.WithString("project", mcp.Required(), mcp.Description(`Project to look up. Accepts bare name ("mnemo"), org/repo fragment ("marcelocantos/mnemo"), or path fragment ("-Users-marcelo-work-github-com-marcelocantos-mnemo").`)),
+			mcp.WithString("name", mcp.Description("Memory name to retrieve (matches frontmatter name or file stem). Omit to list available memories.")),
+		),
 		mcp.NewTool("mnemo_usage",
 			mcp.WithDescription(`Token usage analytics across sessions. Aggregates input, output, cache read, and cache creation tokens with cost estimates.
 
@@ -473,6 +482,8 @@ func (h *Handler) Call(cc CallContext, name string, args map[string]any) (string
 		return ch.stats()
 	case "mnemo_memories":
 		return ch.memories(args)
+	case "mnemo_get_memory":
+		return ch.getMemory(args)
 	case "mnemo_skills":
 		return ch.skills(args)
 	case "mnemo_usage":
@@ -831,6 +842,47 @@ func (h *callHandler) memories(args map[string]any) (string, bool, error) {
 			m.Name, m.MemoryType, proj, m.Description, m.Content)
 	}
 	return b.String(), false, nil
+}
+
+func (h *callHandler) getMemory(args map[string]any) (string, bool, error) {
+	project, _ := args["project"].(string)
+	name, _ := args["name"].(string)
+
+	if project == "" {
+		return "project is required", true, nil
+	}
+
+	// When name is omitted, list all memories for the project.
+	if name == "" {
+		results, err := h.mem.SearchMemories("", "", project, 100)
+		if err != nil {
+			return fmt.Sprintf("memory list failed: %v", err), true, nil
+		}
+		if len(results) == 0 {
+			return fmt.Sprintf("No memories found for project %q.", project), false, nil
+		}
+		var b strings.Builder
+		fmt.Fprintf(&b, "Memories for project %q:\n\n", project)
+		for _, m := range results {
+			fmt.Fprintf(&b, "- **%s** [%s]: %s\n", m.Name, m.MemoryType, m.Description)
+		}
+		return b.String(), false, nil
+	}
+
+	m, err := h.mem.GetMemory(project, name)
+	if err != nil {
+		return fmt.Sprintf("get memory failed: %v", err), true, nil
+	}
+	if m == nil {
+		// Check whether the project itself exists.
+		all, listErr := h.mem.SearchMemories("", "", project, 1)
+		if listErr == nil && len(all) == 0 {
+			return fmt.Sprintf("Project %q not found.", project), false, nil
+		}
+		return fmt.Sprintf("Memory %q not found in project %q.", name, project), false, nil
+	}
+
+	return m.Content, false, nil
 }
 
 func (h *callHandler) skills(args map[string]any) (string, bool, error) {


### PR DESCRIPTION
## Summary\n\n- Adds `mnemo_get_memory(project, name)` MCP tool that returns the raw markdown body of a named memory file, replacing the `cat ~/.claude/projects/<project>/memory/<name>.md` workaround.\n- `project` is matched as a substring (consistent with `mnemo_memories`).\n- `name` is matched case-insensitively against the frontmatter name field or the file stem.\n- When `name` is omitted, lists all memories for the project with name, type, and description.\n- Returns clear messages when the project or memory is not found.\n- Adds `GetMemory(project, name string)` to the `Backend` interface with a `Store` implementation.\n\n## Test plan\n\n- [ ] `TestGetMemory` passes: retrieval by frontmatter name, by file stem, MEMORY.md index retrieval, not-found (wrong name, wrong project), empty-arg errors\n- [ ] Full test suite green: `go test -tags sqlite_fts5 ./...`\n- [ ] Build clean: `go build -tags sqlite_fts5 ./...`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)