### PR TITLE
🎯T31: mnemo_locate_uuid tool

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -859,7 +859,7 @@ targets:
     achieved: 2026-04-26
   T31:
     name: mnemo locates an entry by UUID across sessions
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -870,6 +870,7 @@ targets:
     context: 'Data-mined from 180 days of Claude session transcripts (2026-04-19). Observed post-mnemo pattern: Python loops over session JSONL files grepping for specific UUIDs to answer which session contains entry X or to trace parent-UUID chains. No current mnemo tool does this directly; bash grep over JSONL files is the only path. Common use cases include debugging session chaining, tracking tool_use_ids through retries, and resolving cross-session references.'
     origin: doit data-mining 2026-04-19
     discovered: 2026-04-19
+    achieved: 2026-04-26
   T32:
     name: Non-technical Windows users install mnemo via a double-click installer, with no terminal required
     status: achieved

--- a/internal/store/iface.go
+++ b/internal/store/iface.go
@@ -55,4 +55,5 @@ type Backend interface {
 	ConnectionsForSession(sessionID string) ([]ConnectionSession, error)
 	InferChainHeuristic(sessionID string, limit int) ([]ChainCandidate, error)
 	SessionStructure(sessionID string) (*SessionStructure, error)
+	LocateUUID(prefix string, contextBefore, contextAfter int) ([]UUIDMatch, error)
 }

--- a/internal/store/locate_uuid.go
+++ b/internal/store/locate_uuid.go
@@ -1,0 +1,207 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// UUIDMatch is a single UUID lookup result. MatchKind describes which UUID
+// field in the entry matched the query prefix.
+//
+//   - "entry_uuid"     — the entry's own $.uuid field
+//   - "parent_uuid"    — the entry's $.parentUuid field
+//   - "tool_use_id"    — a tool_use content block's id ($.message.content[*].id)
+//   - "tool_result_id" — a tool_result content block's tool_use_id
+//   - "top_tool_use_id"   — $.toolUseID (entry-level, progress entries)
+//   - "parent_tool_use_id" — $.parentToolUseID (entry-level)
+type UUIDMatch struct {
+	EntryID   int              `json:"entry_id"`
+	SessionID string           `json:"session_id"`
+	Project   string           `json:"project"`
+	Type      string           `json:"type"`       // entry type: user, assistant, system, …
+	MatchKind string           `json:"match_kind"` // which UUID field matched
+	MatchedID string           `json:"matched_id"` // the full UUID that matched
+	Timestamp string           `json:"timestamp,omitempty"`
+	Before    []ContextMessage `json:"before,omitempty"`
+	After     []ContextMessage `json:"after,omitempty"`
+}
+
+// locateUUIDQuery runs a single lookup sub-query against the entries table.
+// matchKind names the field (e.g. "entry_uuid"), expr is a SQL expression
+// that extracts that field from the entries table. prefix is the user-supplied
+// UUID prefix.
+//
+// Returns (entryID, sessionID, project, entryType, matchedID, timestamp, ok, err).
+type uuidCandidate struct {
+	entryID   int
+	sessionID string
+	project   string
+	entryType string
+	matchKind string
+	matchedID string
+	timestamp string
+}
+
+// LocateUUID searches the entries table for any entry whose UUID fields
+// match the supplied prefix. The following fields are checked, in order:
+//
+//  1. $.uuid          (entry_uuid)
+//  2. $.parentUuid    (parent_uuid)
+//  3. $.toolUseID     (top_tool_use_id — virtual column)
+//  4. $.parentToolUseID (parent_tool_use_id — virtual column)
+//  5. any $.message.content[*].id where the element's type = "tool_use" (tool_use_id)
+//  6. any $.message.content[*].tool_use_id where the element's type = "tool_result" (tool_result_id)
+//
+// contextBefore and contextAfter control how many surrounding messages are
+// fetched from the messages table (same semantics as Search).
+func (s *Store) LocateUUID(prefix string, contextBefore, contextAfter int) ([]UUIDMatch, error) {
+	s.rwmu.RLock()
+	defer s.rwmu.RUnlock()
+
+	if prefix == "" {
+		return nil, fmt.Errorf("uuid prefix is required")
+	}
+	likeArg := prefix + "%"
+
+	// Build UNION query: each arm checks one UUID field.
+	// Arms 1-4 use either a virtual column or json_extract on the raw JSONB.
+	// Arms 5-6 use json_each to fan out over the content array.
+	const q = `
+SELECT e.id, e.session_id, e.project, e.type, e.timestamp,
+       'entry_uuid'          AS match_kind,
+       json_extract(e.raw, '$.uuid') AS matched_id
+FROM entries e
+WHERE json_extract(e.raw, '$.uuid') LIKE ?
+
+UNION ALL
+
+SELECT e.id, e.session_id, e.project, e.type, e.timestamp,
+       'parent_uuid'         AS match_kind,
+       json_extract(e.raw, '$.parentUuid') AS matched_id
+FROM entries e
+WHERE json_extract(e.raw, '$.parentUuid') LIKE ?
+
+UNION ALL
+
+SELECT e.id, e.session_id, e.project, e.type, e.timestamp,
+       'top_tool_use_id'     AS match_kind,
+       e.top_tool_use_id     AS matched_id
+FROM entries e
+WHERE e.top_tool_use_id LIKE ?
+
+UNION ALL
+
+SELECT e.id, e.session_id, e.project, e.type, e.timestamp,
+       'parent_tool_use_id'  AS match_kind,
+       e.parent_tool_use_id  AS matched_id
+FROM entries e
+WHERE e.parent_tool_use_id LIKE ?
+
+UNION ALL
+
+SELECT e.id, e.session_id, e.project, e.type, e.timestamp,
+       'tool_use_id'         AS match_kind,
+       jc.value->>'$.id'     AS matched_id
+FROM (SELECT * FROM entries WHERE json_type(raw, '$.message.content') = 'array') e
+JOIN json_each(e.raw, '$.message.content') jc
+WHERE jc.value->>'$.type' = 'tool_use'
+  AND jc.value->>'$.id' LIKE ?
+
+UNION ALL
+
+SELECT e.id, e.session_id, e.project, e.type, e.timestamp,
+       'tool_result_id'      AS match_kind,
+       jc.value->>'$.tool_use_id' AS matched_id
+FROM (SELECT * FROM entries WHERE json_type(raw, '$.message.content') = 'array') e
+JOIN json_each(e.raw, '$.message.content') jc
+WHERE jc.value->>'$.type' = 'tool_result'
+  AND jc.value->>'$.tool_use_id' LIKE ?
+
+ORDER BY 1
+LIMIT 50
+`
+	rows, err := s.db.Query(q,
+		likeArg, likeArg, likeArg, likeArg, likeArg, likeArg,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var candidates []uuidCandidate
+	for rows.Next() {
+		var c uuidCandidate
+		var ts sql.NullString
+		if err := rows.Scan(&c.entryID, &c.sessionID, &c.project, &c.entryType, &ts, &c.matchKind, &c.matchedID); err != nil {
+			continue
+		}
+		if ts.Valid {
+			c.timestamp = ts.String
+		}
+		candidates = append(candidates, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	// Deduplicate by (entryID, matchKind) — json_each can produce multiple
+	// rows if the content array has several matching blocks.
+	seen := map[string]bool{}
+	var matches []UUIDMatch
+	for _, c := range candidates {
+		key := fmt.Sprintf("%d\x00%s", c.entryID, c.matchKind)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		m := UUIDMatch{
+			EntryID:   c.entryID,
+			SessionID: c.sessionID,
+			Project:   c.project,
+			Type:      c.entryType,
+			MatchKind: c.matchKind,
+			MatchedID: c.matchedID,
+			Timestamp: c.timestamp,
+		}
+
+		// Fetch context from messages table using the entry's first message.
+		if contextBefore > 0 || contextAfter > 0 {
+			firstMsgID, err := s.firstMessageIDForEntry(c.entryID, c.sessionID)
+			if err == nil && firstMsgID > 0 {
+				if contextBefore > 0 {
+					m.Before = s.fetchContext(c.sessionID, firstMsgID, contextBefore, true, true)
+				}
+				if contextAfter > 0 {
+					m.After = s.fetchContext(c.sessionID, firstMsgID, contextAfter, false, true)
+				}
+			}
+		}
+
+		matches = append(matches, m)
+	}
+
+	return matches, nil
+}
+
+// firstMessageIDForEntry returns the minimum messages.id for the given entry,
+// so we can use fetchContext to pull surrounding messages.
+func (s *Store) firstMessageIDForEntry(entryID int, sessionID string) (int, error) {
+	var id int
+	err := s.db.QueryRow(
+		`SELECT MIN(id) FROM messages WHERE entry_id = ? AND session_id = ?`,
+		entryID, sessionID,
+	).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	return id, err
+}

--- a/internal/store/locate_uuid_test.go
+++ b/internal/store/locate_uuid_test.go
@@ -1,0 +1,302 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"testing"
+)
+
+// TestLocateUUID verifies that LocateUUID finds entries by each of the four
+// UUID sources: entry_uuid, parent_uuid, tool_use_id (content block), and
+// tool_result_id (content block). It also checks top_tool_use_id and
+// parent_tool_use_id (entry-level tool use fields used by progress entries).
+func TestLocateUUID(t *testing.T) {
+	projectDir := t.TempDir()
+	sessionID := "locate-uuid-sess"
+	project := "locatetest"
+
+	// Entry 1: a plain user entry — locate by entry_uuid and parent_uuid of entry 2.
+	entryUUID := "aaaa1111-0000-0000-0000-000000000001"
+
+	// Entry 2: an assistant entry with a tool_use content block.
+	assistantUUID := "bbbb2222-0000-0000-0000-000000000002"
+	toolUseContentID := "toolu_01AAABBBCCCDDDEEE" // content block id
+
+	// Entry 3: a user entry containing a tool_result that references entry 2's tool.
+	toolResultEntryUUID := "cccc3333-0000-0000-0000-000000000003"
+
+	// Entry 4: a progress/system entry with entry-level toolUseID.
+	progressUUID := "dddd4444-0000-0000-0000-000000000004"
+	entryLevelToolUseID := "toolu_01PROGRESSTOOLUSE"
+
+	// Entry 5: an entry with parentToolUseID.
+	resultEntryUUID := "eeee5555-0000-0000-0000-000000000005"
+	parentToolUseIDValue := "toolu_01PARENTTOOLUSE"
+
+	entries := []map[string]any{
+		// Entry 1: plain user message.
+		{
+			"type":       "user",
+			"uuid":       entryUUID,
+			"parentUuid": nil,
+			"timestamp":  "2026-04-01T10:00:00Z",
+			"sessionId":  sessionID,
+			"message": map[string]any{
+				"role":    "user",
+				"content": "Hello, please run a tool.",
+			},
+		},
+		// Entry 2: assistant with tool_use content block.
+		{
+			"type":       "assistant",
+			"uuid":       assistantUUID,
+			"parentUuid": entryUUID,
+			"timestamp":  "2026-04-01T10:00:05Z",
+			"sessionId":  sessionID,
+			"message": map[string]any{
+				"role": "assistant",
+				"content": []map[string]any{
+					{
+						"type": "text",
+						"text": "I will run the tool now.",
+					},
+					{
+						"type":  "tool_use",
+						"id":    toolUseContentID,
+						"name":  "Bash",
+						"input": map[string]any{"command": "echo hello"},
+					},
+				},
+			},
+		},
+		// Entry 3: user with tool_result referencing entry 2's tool.
+		{
+			"type":       "user",
+			"uuid":       toolResultEntryUUID,
+			"parentUuid": assistantUUID,
+			"timestamp":  "2026-04-01T10:00:10Z",
+			"sessionId":  sessionID,
+			"message": map[string]any{
+				"role": "user",
+				"content": []map[string]any{
+					{
+						"type":        "tool_result",
+						"tool_use_id": toolUseContentID,
+						"content":     "hello",
+					},
+				},
+			},
+		},
+		// Entry 4: progress entry with entry-level toolUseID.
+		{
+			"type":      "system",
+			"uuid":      progressUUID,
+			"toolUseID": entryLevelToolUseID,
+			"timestamp": "2026-04-01T10:00:15Z",
+			"sessionId": sessionID,
+			"message": map[string]any{
+				"role":    "user",
+				"content": "Tool is running...",
+			},
+		},
+		// Entry 5: result entry with parentToolUseID.
+		{
+			"type":            "user",
+			"uuid":            resultEntryUUID,
+			"parentToolUseID": parentToolUseIDValue,
+			"timestamp":       "2026-04-01T10:00:20Z",
+			"sessionId":       sessionID,
+			"message": map[string]any{
+				"role":    "user",
+				"content": "Tool result with parentToolUseID.",
+			},
+		},
+	}
+
+	writeJSONL(t, projectDir, project, sessionID, entries)
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name          string
+		prefix        string
+		wantMatchKind string
+		wantMatchedID string
+	}{
+		{
+			name:          "entry_uuid full",
+			prefix:        entryUUID,
+			wantMatchKind: "entry_uuid",
+			wantMatchedID: entryUUID,
+		},
+		{
+			name:          "entry_uuid prefix",
+			prefix:        "aaaa1111",
+			wantMatchKind: "entry_uuid",
+			wantMatchedID: entryUUID,
+		},
+		{
+			name:          "parent_uuid",
+			prefix:        entryUUID, // entry 2 has parentUuid = entryUUID
+			wantMatchKind: "parent_uuid",
+			wantMatchedID: entryUUID,
+		},
+		{
+			name:          "tool_use_id content block",
+			prefix:        toolUseContentID,
+			wantMatchKind: "tool_use_id",
+			wantMatchedID: toolUseContentID,
+		},
+		{
+			name:          "tool_result_id content block",
+			prefix:        toolUseContentID, // tool_result back-references same id
+			wantMatchKind: "tool_result_id",
+			wantMatchedID: toolUseContentID,
+		},
+		{
+			name:          "top_tool_use_id",
+			prefix:        entryLevelToolUseID,
+			wantMatchKind: "top_tool_use_id",
+			wantMatchedID: entryLevelToolUseID,
+		},
+		{
+			name:          "parent_tool_use_id",
+			prefix:        parentToolUseIDValue,
+			wantMatchKind: "parent_tool_use_id",
+			wantMatchedID: parentToolUseIDValue,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matches, err := s.LocateUUID(tc.prefix, 0, 0)
+			if err != nil {
+				t.Fatalf("LocateUUID(%q): %v", tc.prefix, err)
+			}
+
+			// Find a match with the expected match_kind.
+			var found *UUIDMatch
+			for i := range matches {
+				if matches[i].MatchKind == tc.wantMatchKind {
+					found = &matches[i]
+					break
+				}
+			}
+
+			if found == nil {
+				kinds := make([]string, len(matches))
+				for i, m := range matches {
+					kinds[i] = m.MatchKind
+				}
+				t.Fatalf("LocateUUID(%q): no match with kind %q; got kinds %v", tc.prefix, tc.wantMatchKind, kinds)
+			}
+
+			if found.MatchedID != tc.wantMatchedID {
+				t.Errorf("MatchedID = %q, want %q", found.MatchedID, tc.wantMatchedID)
+			}
+			if found.SessionID != sessionID {
+				t.Errorf("SessionID = %q, want %q", found.SessionID, sessionID)
+			}
+		})
+	}
+}
+
+// TestLocateUUIDNotFound verifies that LocateUUID returns nil (not an error)
+// when no entry matches the supplied prefix.
+func TestLocateUUIDNotFound(t *testing.T) {
+	projectDir := t.TempDir()
+	writeJSONL(t, projectDir, "empty", "empty-sess", []map[string]any{
+		{
+			"type":      "user",
+			"uuid":      "ffff0000-0000-0000-0000-000000000001",
+			"timestamp": "2026-04-01T10:00:00Z",
+			"sessionId": "empty-sess",
+			"message":   map[string]any{"role": "user", "content": "hi"},
+		},
+	})
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	matches, err := s.LocateUUID("00000000-dead-beef-0000-000000000000", 0, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("expected no matches, got %d", len(matches))
+	}
+}
+
+// TestLocateUUIDContext verifies that context messages are returned when
+// context_before/context_after are non-zero.
+func TestLocateUUIDContext(t *testing.T) {
+	projectDir := t.TempDir()
+	sessionID := "ctx-sess"
+
+	targetUUID := "ctx00001-0000-0000-0000-000000000003"
+
+	writeJSONL(t, projectDir, "ctxproj", sessionID, []map[string]any{
+		{
+			"type":      "user",
+			"uuid":      "ctx00001-0000-0000-0000-000000000001",
+			"timestamp": "2026-04-01T10:00:00Z",
+			"sessionId": sessionID,
+			"message":   map[string]any{"role": "user", "content": "message before target"},
+		},
+		{
+			"type":      "assistant",
+			"uuid":      "ctx00001-0000-0000-0000-000000000002",
+			"timestamp": "2026-04-01T10:00:05Z",
+			"sessionId": sessionID,
+			"message":   map[string]any{"role": "assistant", "content": "assistant before target"},
+		},
+		{
+			"type":      "user",
+			"uuid":      targetUUID,
+			"timestamp": "2026-04-01T10:00:10Z",
+			"sessionId": sessionID,
+			"message":   map[string]any{"role": "user", "content": "the target message"},
+		},
+		{
+			"type":      "assistant",
+			"uuid":      "ctx00001-0000-0000-0000-000000000004",
+			"timestamp": "2026-04-01T10:00:15Z",
+			"sessionId": sessionID,
+			"message":   map[string]any{"role": "assistant", "content": "assistant after target"},
+		},
+	})
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	matches, err := s.LocateUUID(targetUUID, 2, 2)
+	if err != nil {
+		t.Fatalf("LocateUUID: %v", err)
+	}
+
+	var found *UUIDMatch
+	for i := range matches {
+		if matches[i].MatchKind == "entry_uuid" {
+			found = &matches[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("no entry_uuid match found")
+	}
+
+	if len(found.Before) == 0 {
+		t.Error("expected Before context messages, got none")
+	}
+	if len(found.After) == 0 {
+		t.Error("expected After context messages, got none")
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -418,6 +418,24 @@ Answers "what is in this session?" without reading full transcript text. Returns
 Use this to quickly understand a session's shape before deep-reading it, to compare session structures, or to verify that a session contains the content type you expect.`),
 			mcp.WithString("session_id", mcp.Required(), mcp.Description("Session ID (exact or prefix, consistent with mnemo_read_session)")),
 		),
+		mcp.NewTool("mnemo_locate_uuid",
+			mcp.WithDescription(`Locate an entry by UUID across all sessions. Searches every UUID field in the transcript index and returns the session, entry, and which field matched.
+
+UUID fields searched:
+  - entry_uuid       — the entry's own $.uuid
+  - parent_uuid      — the parent entry's UUID ($.parentUuid)
+  - top_tool_use_id  — entry-level tool use ID ($.toolUseID, for progress/result entries)
+  - parent_tool_use_id — entry-level parent tool use ID ($.parentToolUseID)
+  - tool_use_id      — a tool_use content block's id inside $.message.content
+  - tool_result_id   — a tool_result content block's tool_use_id inside $.message.content
+
+Supports partial UUID prefixes — the first 8 characters are usually enough to uniquely identify an entry.
+
+Returns a structured result with session_id, entry_id, entry type, timestamp, match_kind (which field matched), the full matched UUID, and surrounding context messages. Returns "not found" when no entry matches.`),
+			mcp.WithString("uuid", mcp.Required(), mcp.Description("Full UUID or prefix to locate (e.g. \"abc12345\" or the full UUID)")),
+			mcp.WithNumber("context_before", mcp.Description("Number of messages before the entry to include (default 3)")),
+			mcp.WithNumber("context_after", mcp.Description("Number of messages after the entry to include (default 3)")),
+		),
 		mcp.NewTool("mnemo_images",
 			mcp.WithDescription(`Search images captured from Claude Code transcripts. Three search modes: (1) text (default) — FTS5 over AI descriptions and OCR text; (2) semantic — embed the query text and find images by meaning using CLIP k-NN (requires embed backend); (3) similar — find visually similar images given an image ID. Use 'text' to find images by paraphrase, 'semantic' for conceptual matches like "architecture diagram", and 'similar' to browse related screenshots.`),
 			mcp.WithString("query", mcp.Description("Search query. Used in 'text' and 'semantic' modes. Omit to list recent (text mode).")),
@@ -528,6 +546,8 @@ func (h *Handler) Call(cc CallContext, name string, args map[string]any) (string
 		return ch.listTemplates()
 	case "mnemo_discover_patterns":
 		return ch.discoverPatterns(args)
+	case "mnemo_locate_uuid":
+		return ch.locateUUID(args)
 	case "mnemo_images":
 		return ch.images(args)
 	case "mnemo_session_structure":
@@ -1881,4 +1901,33 @@ func (h *callHandler) toolResult(args map[string]any) (string, bool, error) {
 	b.WriteString("\n\n")
 	b.WriteString(payload.Text)
 	return b.String(), false, nil
+}
+
+func (h *callHandler) locateUUID(args map[string]any) (string, bool, error) {
+	prefix, _ := args["uuid"].(string)
+	if prefix == "" {
+		return "uuid is required", true, nil
+	}
+	contextBefore := 3
+	if cb, ok := args["context_before"].(float64); ok && cb >= 0 {
+		contextBefore = int(cb)
+	}
+	contextAfter := 3
+	if ca, ok := args["context_after"].(float64); ok && ca >= 0 {
+		contextAfter = int(ca)
+	}
+
+	matches, err := h.mem.LocateUUID(prefix, contextBefore, contextAfter)
+	if err != nil {
+		return fmt.Sprintf("locate_uuid failed: %v", err), true, nil
+	}
+	if len(matches) == 0 {
+		return fmt.Sprintf("UUID %q not found in any session.", prefix), false, nil
+	}
+
+	out, err := json.MarshalIndent(matches, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("marshal failed: %v", err), true, nil
+	}
+	return string(out), false, nil
 }


### PR DESCRIPTION
## Summary

- Adds `mnemo_locate_uuid(uuid, context_before, context_after)` MCP tool that locates any transcript entry by UUID across all sessions
- Searches all six UUID fields: `entry_uuid`, `parent_uuid`, `top_tool_use_id`, `parent_tool_use_id`, `tool_use_id` (content block), and `tool_result_id` (content block)
- Supports partial UUID prefixes (first 8 chars typically sufficient) and returns structured JSON with `session_id`, `entry_id`, `type`, `timestamp`, `match_kind`, `matched_id`, and surrounding context messages
- Handles UUID-not-found gracefully with a descriptive message

## Implementation

- `internal/store/locate_uuid.go` — `LocateUUID` store method using a 6-arm UNION SQL query; pre-filters entries with array content before `json_each` to avoid malformed-JSON errors on string-content entries
- `internal/store/iface.go` — `LocateUUID` added to `Backend` interface
- `internal/tools/tools.go` — tool definition in `Definitions()` and handler in `Call()`
- `internal/store/locate_uuid_test.go` — tests for all six match kinds, not-found, and context fetching

## Test plan

- [x] `go test -tags sqlite_fts5 ./internal/store/ -run TestLocateUUID` — all subtests pass (entry_uuid full, entry_uuid prefix, parent_uuid, tool_use_id, tool_result_id, top_tool_use_id, parent_tool_use_id)
- [x] `TestLocateUUIDNotFound` — returns nil matches, no error
- [x] `TestLocateUUIDContext` — Before/After context messages populated
- [x] `make bullseye` — fmt ✓, vet ✓, build ✓, tests ✓ (dirty tree expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)