### PR TITLE
🎯T37: launchd PATH for compactor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,4 +237,5 @@ jobs:
               log_path var/"log/mnemo.log"
               error_log_path var/"log/mnemo.log"
               working_dir HOMEBREW_PREFIX
+              environment_variables PATH: "#{HOMEBREW_PREFIX}/bin:#{ENV["HOME"]}/.claude/local:/usr/bin:/bin:/usr/sbin:/sbin"
             end

--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ installer.
 
 Logs on macOS: `$(brew --prefix)/var/log/mnemo.log`.
 
+> **PATH note for service deployments**: mnemo's compactor shells out
+> to `claude -p`. Services (launchd, systemd) inherit a minimal
+> `PATH` that typically excludes the `claude` binary. The Homebrew
+> formula's service block sets `PATH` to include
+> `$(brew --prefix)/bin` and `~/.claude/local` automatically. If you
+> run mnemo via a custom plist or systemd unit, set `PATH` explicitly
+> to include the directory where `claude` is installed. Without it,
+> compaction will fail with a logged ERROR.
+
 **Manually**:
 
 ```bash

--- a/agents-guide.md
+++ b/agents-guide.md
@@ -33,6 +33,16 @@ brew services start mnemo
 This starts mnemo on `:19419` via launchd and keeps it running across
 reboots. Logs go to `$(brew --prefix)/var/log/mnemo.log`.
 
+The Homebrew formula's service block sets `PATH` to
+`$(brew --prefix)/bin:~/.claude/local:/usr/bin:/bin:/usr/sbin:/sbin`
+so that mnemo's compactor can find the `claude` binary. If you run
+mnemo via a different mechanism (custom launchctl plist, manual
+invocation), make sure `PATH` includes the directory containing
+`claude` — typically `/opt/homebrew/bin` (npm/bun install) or
+`~/.claude/local` (Anthropic's official installer). Without a `claude`
+binary on `PATH`, compaction fails and mnemo logs an ERROR:
+`compact: claude subprocess spawn failed — executable not found in PATH`.
+
 **Linux (systemd)** — create `~/.config/systemd/user/mnemo.service`:
 
 ```ini
@@ -42,12 +52,19 @@ Description=mnemo MCP server
 [Service]
 ExecStart=%h/.local/bin/mnemo
 Restart=always
+Environment=PATH=/usr/local/bin:/usr/bin:/bin:%h/.claude/local
 
 [Install]
 WantedBy=default.target
 ```
 
 Then: `systemctl --user enable --now mnemo`
+
+> **Note for service deployments**: launchd and systemd both start
+> processes with a minimal `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`).
+> The `Environment=` line above adds `~/.claude/local` (Anthropic's
+> official install path). Add `/usr/local/bin` or other prefixes as
+> needed for your setup.
 
 **Manual** (any platform):
 

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1009,6 +1009,24 @@ targets:
     - research
     origin: user 2026-04-25 — "think about mnemo for teams"
     discovered: 2026-04-25
+  T37:
+    name: The compactor's claudia.Task subprocess can find and execute the Claude CLI when mnemo is launched by launchd
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - The launchd plist (or a wrapper script) sets PATH to include the directory containing the claude binary, so claudia.Task does not fail with 'executable file not found'.
+    - mnemo logs a clear, single-line ERROR (not a generic Warn) when the LLM subprocess fails to spawn, including the resolved PATH it tried, so the failure is debuggable from the log alone.
+    - Documentation (README or agent-guide) records the PATH requirement so users running mnemo as a launchd/systemd service know what to set.
+    context: claude is defined as a zsh function in ~/.zshrc (wraps the c helper); some setups have a binary at /opt/homebrew/bin/claude or ~/.claude/local/claude. mnemo runs under launchd with default PATH=/usr/bin:/bin:/usr/sbin:/sbin — even a binary at /opt/homebrew/bin/claude is unreachable. claudia.Task (in github.com/marcelocantos/claudia) shells out to claude -p. Exec failure was silent because the watcher's error path was slog.Warn.
+    tags:
+    - compactor
+    - launchd
+    - path
+    - observability
+    origin: manual
+    discovered: 2026-04-26
+    achieved: 2026-04-26
   T4:
     name: Individual session transcript access
     status: achieved

--- a/internal/compact/watcher.go
+++ b/internal/compact/watcher.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -254,6 +256,13 @@ func (w *connWorker) tick(ctx context.Context) {
 				"conn", w.connectionID, "session", sessionID)
 			w.budgetWarned = true
 		}
+	case errors.Is(err, exec.ErrNotFound):
+		slog.Error("compact: claude subprocess spawn failed — executable not found in PATH",
+			"err", err,
+			"path", os.Getenv("PATH"),
+			"conn", w.connectionID,
+			"session", sessionID,
+		)
 	default:
 		slog.Warn("compact: compaction failed",
 			"conn", w.connectionID, "session", sessionID, "err", err)


### PR DESCRIPTION
## Summary

Three-part fix so the compactor can find the `claude` CLI when mnemo runs under launchd or systemd:

- **Part 1 (`.github/workflows/release.yml`)**: Add `environment_variables PATH:` to the Homebrew formula service block. Takes effect on the next release (v0.30.0) via homebrew-releaser.
- **Part 2 (`internal/compact/watcher.go`)**: Emit `slog.Error` with resolved PATH on `exec.ErrNotFound`, not the generic `slog.Warn`.
- **Part 3 (`agents-guide.md`, `README.md`)**: Document the PATH requirement for launchd/systemd deployments.

## Test plan

- [ ] `go build -tags sqlite_fts5 ./...` passes
- [ ] `go test -tags sqlite_fts5 ./internal/compact/` passes
- [ ] Confirm slog.Error fires with PATH logged when claude is not on PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)