### PR TITLE
🎯T28: mnemo_session_structure tool

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -805,7 +805,7 @@ targets:
     achieved: 2026-04-18
   T28:
     name: mnemo exposes session-structure introspection
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -815,6 +815,7 @@ targets:
     context: 'Data-mined from 180 days of Claude session transcripts (2026-04-19). In post-mnemo sessions, Claude still falls back to bash against .claude/projects/... with inline-Python patterns that Counter() the entry types, assistant stop_reasons, system subtypes, and content-block kinds of a session JSONL. 16 post-mnemo sessions showed this pattern. No existing mnemo tool answers it: mnemo_read_session returns raw messages, mnemo_query can do it but requires hand-written SQL each time. A dedicated mnemo_session_structure(session_id) would retire this whole class of bash fallback.'
     origin: doit data-mining 2026-04-19
     discovered: 2026-04-19
+    achieved: 2026-04-26
   T29:
     name: mnemo surfaces raw tool-result bodies
     status: identified

--- a/internal/store/iface.go
+++ b/internal/store/iface.go
@@ -52,4 +52,5 @@ type Backend interface {
 	RecordConnectionSession(connectionID, sessionID string)
 	ConnectionsForSession(sessionID string) ([]ConnectionSession, error)
 	InferChainHeuristic(sessionID string, limit int) ([]ChainCandidate, error)
+	SessionStructure(sessionID string) (*SessionStructure, error)
 }

--- a/internal/store/session_structure.go
+++ b/internal/store/session_structure.go
@@ -1,0 +1,195 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+// SessionStructure summarises the entry types and content-block shapes
+// present in a single session transcript. It is the structured answer to
+// "what is in this session?" — replacing inline-Python JSONL inspection.
+type SessionStructure struct {
+	// SessionID is the resolved (full) session ID.
+	SessionID string `json:"session_id"`
+
+	// TotalEntries is the count of all JSONL lines (entries) in the session.
+	TotalEntries int `json:"total_entries"`
+
+	// EntryTypes maps entry type ("user", "assistant", "system",
+	// "progress", "file-history-snapshot", …) to occurrence count.
+	EntryTypes map[string]int `json:"entry_types"`
+
+	// AssistantStopReasons maps stop_reason values ("end_turn", "tool_use",
+	// "max_tokens", …) to count. Only populated for assistant entries.
+	AssistantStopReasons map[string]int `json:"assistant_stop_reasons,omitempty"`
+
+	// SystemSubtypes maps the $.subtype field of system entries to count.
+	// Common values: "prompt", "reminder", "tool_list", etc.
+	SystemSubtypes map[string]int `json:"system_subtypes,omitempty"`
+
+	// ContentBlockKinds maps content-block type strings ("text",
+	// "tool_use", "tool_result", "thinking") to count across all messages.
+	ContentBlockKinds map[string]int `json:"content_block_kinds,omitempty"`
+
+	// ToolNames maps tool names from tool_use content blocks to count.
+	// Gives an at-a-glance view of which tools were exercised.
+	ToolNames map[string]int `json:"tool_names,omitempty"`
+}
+
+// SessionStructure returns a structural summary of the session identified
+// by sessionID (exact or prefix). Counts are aggregated from the entries
+// and messages tables using SQLite JSON1 extraction.
+func (s *Store) SessionStructure(sessionID string) (*SessionStructure, error) {
+	s.rwmu.RLock()
+	defer s.rwmu.RUnlock()
+
+	resolvedID, err := s.resolveSessionID(sessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &SessionStructure{
+		SessionID:            resolvedID,
+		EntryTypes:           make(map[string]int),
+		AssistantStopReasons: make(map[string]int),
+		SystemSubtypes:       make(map[string]int),
+		ContentBlockKinds:    make(map[string]int),
+		ToolNames:            make(map[string]int),
+	}
+
+	// --- Entry type counts ---
+	entryRows, err := s.db.Query(`
+		SELECT type, COUNT(*) AS cnt
+		FROM entries
+		WHERE session_id = ?
+		GROUP BY type
+		ORDER BY cnt DESC
+	`, resolvedID)
+	if err != nil {
+		return nil, err
+	}
+	defer entryRows.Close()
+	for entryRows.Next() {
+		var typ string
+		var cnt int
+		if err := entryRows.Scan(&typ, &cnt); err != nil {
+			continue
+		}
+		result.TotalEntries += cnt
+		result.EntryTypes[typ] = cnt
+	}
+	if err := entryRows.Err(); err != nil {
+		return nil, err
+	}
+
+	// --- Assistant stop_reason counts ---
+	stopRows, err := s.db.Query(`
+		SELECT COALESCE(stop_reason, '(null)') AS sr, COUNT(*) AS cnt
+		FROM entries
+		WHERE session_id = ? AND type = 'assistant'
+		GROUP BY sr
+		ORDER BY cnt DESC
+	`, resolvedID)
+	if err != nil {
+		return nil, err
+	}
+	defer stopRows.Close()
+	for stopRows.Next() {
+		var sr string
+		var cnt int
+		if err := stopRows.Scan(&sr, &cnt); err != nil {
+			continue
+		}
+		result.AssistantStopReasons[sr] = cnt
+	}
+	if err := stopRows.Err(); err != nil {
+		return nil, err
+	}
+
+	// --- System subtype counts ---
+	// subtype is not a virtual column; extract directly from JSONB.
+	subtypeRows, err := s.db.Query(`
+		SELECT COALESCE(json_extract(raw, '$.subtype'), '(none)') AS st, COUNT(*) AS cnt
+		FROM entries
+		WHERE session_id = ? AND type = 'system'
+		GROUP BY st
+		ORDER BY cnt DESC
+	`, resolvedID)
+	if err != nil {
+		return nil, err
+	}
+	defer subtypeRows.Close()
+	for subtypeRows.Next() {
+		var st string
+		var cnt int
+		if err := subtypeRows.Scan(&st, &cnt); err != nil {
+			continue
+		}
+		result.SystemSubtypes[st] = cnt
+	}
+	if err := subtypeRows.Err(); err != nil {
+		return nil, err
+	}
+
+	// --- Content-block kind counts (from messages table) ---
+	blockRows, err := s.db.Query(`
+		SELECT content_type, COUNT(*) AS cnt
+		FROM messages
+		WHERE session_id = ?
+		GROUP BY content_type
+		ORDER BY cnt DESC
+	`, resolvedID)
+	if err != nil {
+		return nil, err
+	}
+	defer blockRows.Close()
+	for blockRows.Next() {
+		var ct string
+		var cnt int
+		if err := blockRows.Scan(&ct, &cnt); err != nil {
+			continue
+		}
+		result.ContentBlockKinds[ct] = cnt
+	}
+	if err := blockRows.Err(); err != nil {
+		return nil, err
+	}
+
+	// --- Tool name counts ---
+	toolRows, err := s.db.Query(`
+		SELECT tool_name, COUNT(*) AS cnt
+		FROM messages
+		WHERE session_id = ? AND content_type = 'tool_use' AND tool_name IS NOT NULL
+		GROUP BY tool_name
+		ORDER BY cnt DESC
+	`, resolvedID)
+	if err != nil {
+		return nil, err
+	}
+	defer toolRows.Close()
+	for toolRows.Next() {
+		var name string
+		var cnt int
+		if err := toolRows.Scan(&name, &cnt); err != nil {
+			continue
+		}
+		result.ToolNames[name] = cnt
+	}
+	if err := toolRows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Prune empty maps so output stays compact.
+	if len(result.AssistantStopReasons) == 0 {
+		result.AssistantStopReasons = nil
+	}
+	if len(result.SystemSubtypes) == 0 {
+		result.SystemSubtypes = nil
+	}
+	if len(result.ContentBlockKinds) == 0 {
+		result.ContentBlockKinds = nil
+	}
+	if len(result.ToolNames) == 0 {
+		result.ToolNames = nil
+	}
+
+	return result, nil
+}

--- a/internal/store/session_structure_test.go
+++ b/internal/store/session_structure_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"testing"
+)
+
+// assistantWithBlocks returns a raw assistant entry whose message has an
+// array of content blocks, including tool_use calls and a stop_reason.
+func assistantWithBlocks(ts, stopReason string, blocks []map[string]any) map[string]any {
+	return map[string]any{
+		"type":      "assistant",
+		"timestamp": ts,
+		"message": map[string]any{
+			"role":        "assistant",
+			"stop_reason": stopReason,
+			"content":     blocks,
+		},
+	}
+}
+
+// userWithToolResult returns a raw user entry whose message contains a
+// tool_result content block (the canonical shape Claude Code produces).
+func userWithToolResult(ts, toolUseID, resultText string) map[string]any {
+	return map[string]any{
+		"type":      "user",
+		"timestamp": ts,
+		"message": map[string]any{
+			"role": "user",
+			"content": []map[string]any{
+				{
+					"type":        "tool_result",
+					"tool_use_id": toolUseID,
+					"content":     resultText,
+				},
+			},
+		},
+	}
+}
+
+// systemEntry returns a raw system-type entry with the given subtype.
+func systemEntry(ts, subtype string) map[string]any {
+	e := map[string]any{
+		"type":      "system",
+		"timestamp": ts,
+	}
+	if subtype != "" {
+		e["subtype"] = subtype
+	}
+	return e
+}
+
+func TestSessionStructure_Basic(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// Session with a mix of entry types and content-block kinds.
+	writeJSONL(t, projectDir, "myproject", "sess-struct1", []map[string]any{
+		// System entry with subtype.
+		systemEntry("2026-04-01T10:00:00Z", "prompt"),
+		// User text message.
+		msg("user", "Run the build for me.", "2026-04-01T10:00:01Z"),
+		// Assistant with tool_use + stop_reason "tool_use".
+		assistantWithBlocks("2026-04-01T10:00:02Z", "tool_use", []map[string]any{
+			{"type": "text", "text": "I'll run the build."},
+			{"type": "tool_use", "id": "tu1", "name": "Bash", "input": map[string]any{"command": "make"}},
+		}),
+		// User with tool_result.
+		userWithToolResult("2026-04-01T10:00:03Z", "tu1", "Build succeeded."),
+		// Assistant with end_turn stop reason.
+		assistantWithBlocks("2026-04-01T10:00:04Z", "end_turn", []map[string]any{
+			{"type": "text", "text": "Build completed successfully."},
+		}),
+		// Another system entry, no subtype.
+		systemEntry("2026-04-01T10:00:05Z", ""),
+	})
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := s.SessionStructure("sess-struct1")
+	if err != nil {
+		t.Fatalf("SessionStructure: %v", err)
+	}
+
+	// Session ID should be resolved.
+	if st.SessionID != "sess-struct1" {
+		t.Errorf("unexpected session_id: %s", st.SessionID)
+	}
+
+	// TotalEntries: 6 JSONL lines.
+	if st.TotalEntries != 6 {
+		t.Errorf("TotalEntries: want 6, got %d", st.TotalEntries)
+	}
+
+	// EntryTypes: 2 user, 2 assistant, 2 system.
+	if st.EntryTypes["user"] != 2 {
+		t.Errorf("EntryTypes[user]: want 2, got %d", st.EntryTypes["user"])
+	}
+	if st.EntryTypes["assistant"] != 2 {
+		t.Errorf("EntryTypes[assistant]: want 2, got %d", st.EntryTypes["assistant"])
+	}
+	if st.EntryTypes["system"] != 2 {
+		t.Errorf("EntryTypes[system]: want 2, got %d", st.EntryTypes["system"])
+	}
+
+	// AssistantStopReasons: 1 tool_use, 1 end_turn.
+	if st.AssistantStopReasons["tool_use"] != 1 {
+		t.Errorf("stop_reasons[tool_use]: want 1, got %d", st.AssistantStopReasons["tool_use"])
+	}
+	if st.AssistantStopReasons["end_turn"] != 1 {
+		t.Errorf("stop_reasons[end_turn]: want 1, got %d", st.AssistantStopReasons["end_turn"])
+	}
+
+	// SystemSubtypes: 1 "prompt", 1 "(none)".
+	if st.SystemSubtypes["prompt"] != 1 {
+		t.Errorf("system_subtypes[prompt]: want 1, got %d", st.SystemSubtypes["prompt"])
+	}
+	if st.SystemSubtypes["(none)"] != 1 {
+		t.Errorf("system_subtypes[(none)]: want 1, got %d", st.SystemSubtypes["(none)"])
+	}
+
+	// ContentBlockKinds: text (3 blocks), tool_use (1), tool_result (1).
+	// Note: the second user message is stored as a plain text string ("Run the build for me.")
+	// via the simple-string path in extractBlocks, giving content_type "text" for that message too.
+	if st.ContentBlockKinds["text"] < 1 {
+		t.Errorf("content_block_kinds[text]: want ≥1, got %d", st.ContentBlockKinds["text"])
+	}
+	if st.ContentBlockKinds["tool_use"] != 1 {
+		t.Errorf("content_block_kinds[tool_use]: want 1, got %d", st.ContentBlockKinds["tool_use"])
+	}
+	if st.ContentBlockKinds["tool_result"] != 1 {
+		t.Errorf("content_block_kinds[tool_result]: want 1, got %d", st.ContentBlockKinds["tool_result"])
+	}
+
+	// ToolNames: Bash called once.
+	if st.ToolNames["Bash"] != 1 {
+		t.Errorf("tool_names[Bash]: want 1, got %d", st.ToolNames["Bash"])
+	}
+}
+
+func TestSessionStructure_PrefixResolution(t *testing.T) {
+	projectDir := t.TempDir()
+
+	writeJSONL(t, projectDir, "proj", "sess-prefix-abc", []map[string]any{
+		msg("user", "hello", "2026-04-01T10:00:00Z"),
+		msg("assistant", "hi", "2026-04-01T10:00:01Z"),
+	})
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Resolve by prefix.
+	st, err := s.SessionStructure("sess-prefix")
+	if err != nil {
+		t.Fatalf("SessionStructure prefix: %v", err)
+	}
+	if st.SessionID != "sess-prefix-abc" {
+		t.Errorf("resolved session_id: want sess-prefix-abc, got %s", st.SessionID)
+	}
+	if st.TotalEntries != 2 {
+		t.Errorf("TotalEntries: want 2, got %d", st.TotalEntries)
+	}
+}
+
+func TestSessionStructure_NotFound(t *testing.T) {
+	projectDir := t.TempDir()
+	s := newTestStore(t, projectDir)
+	// No ingest — the session doesn't exist.
+	_, err := s.SessionStructure("nonexistent-session")
+	if err == nil {
+		t.Fatal("expected error for nonexistent session, got nil")
+	}
+}
+
+func TestSessionStructure_AmbiguousPrefix(t *testing.T) {
+	projectDir := t.TempDir()
+
+	writeJSONL(t, projectDir, "proj", "sess-dup-aaa", []map[string]any{
+		msg("user", "hello", "2026-04-01T10:00:00Z"),
+	})
+	writeJSONL(t, projectDir, "proj", "sess-dup-bbb", []map[string]any{
+		msg("user", "world", "2026-04-01T10:00:00Z"),
+	})
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := s.SessionStructure("sess-dup")
+	if err == nil {
+		t.Fatal("expected error for ambiguous prefix, got nil")
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -396,6 +396,19 @@ Returns candidate features with evidence counts, example sessions, and suggested
 			mcp.WithString("repo", mcp.Description("Filter by repo name or path fragment")),
 			mcp.WithNumber("min_occurrences", mcp.Description("Minimum pattern occurrences to report (default 3)")),
 		),
+		mcp.NewTool("mnemo_session_structure",
+			mcp.WithDescription(`Return a structural summary of a session's entry types and content-block shapes.
+
+Answers "what is in this session?" without reading full transcript text. Returns:
+- entry_types: count per JSONL entry type (user, assistant, system, progress, ...)
+- assistant_stop_reasons: count per stop_reason (end_turn, tool_use, max_tokens, ...)
+- system_subtypes: count per $.subtype for system entries
+- content_block_kinds: count per content-block type (text, tool_use, tool_result, thinking)
+- tool_names: count per tool name in tool_use blocks
+
+Use this to quickly understand a session's shape before deep-reading it, to compare session structures, or to verify that a session contains the content type you expect.`),
+			mcp.WithString("session_id", mcp.Required(), mcp.Description("Session ID (exact or prefix, consistent with mnemo_read_session)")),
+		),
 		mcp.NewTool("mnemo_images",
 			mcp.WithDescription(`Search images captured from Claude Code transcripts. Three search modes: (1) text (default) — FTS5 over AI descriptions and OCR text; (2) semantic — embed the query text and find images by meaning using CLIP k-NN (requires embed backend); (3) similar — find visually similar images given an image ID. Use 'text' to find images by paraphrase, 'semantic' for conceptual matches like "architecture diagram", and 'similar' to browse related screenshots.`),
 			mcp.WithString("query", mcp.Description("Search query. Used in 'text' and 'semantic' modes. Omit to list recent (text mode).")),
@@ -495,6 +508,8 @@ func (h *Handler) Call(cc CallContext, name string, args map[string]any) (string
 		return ch.discoverPatterns(args)
 	case "mnemo_images":
 		return ch.images(args)
+	case "mnemo_session_structure":
+		return ch.sessionStructure(args)
 	default:
 		return "", false, fmt.Errorf("unknown tool: %s", name)
 	}
@@ -1746,4 +1761,20 @@ func (h *callHandler) images(args map[string]any) (string, bool, error) {
 		b.WriteByte('\n')
 	}
 	return b.String(), false, nil
+}
+
+func (h *callHandler) sessionStructure(args map[string]any) (string, bool, error) {
+	sessionID, _ := args["session_id"].(string)
+	if sessionID == "" {
+		return "session_id is required", true, nil
+	}
+	result, err := h.mem.SessionStructure(sessionID)
+	if err != nil {
+		return fmt.Sprintf("session_structure failed: %v", err), true, nil
+	}
+	out, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("marshal failed: %v", err), true, nil
+	}
+	return string(out), false, nil
 }


### PR DESCRIPTION
## Summary

Adds the `mnemo_session_structure(session_id)` MCP tool — a structured summary of a session's entry types and shape (counts of entry types, assistant stop_reasons, system subtypes, content-block kinds) that replaces the inline-Python JSONL introspection patterns Claude was falling back to in 16 post-mnemo sessions.

## Test plan

- [x] `make bullseye` green locally
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)