### PR TITLE
🎯T35: idempotent indexer (UNIQUE constraint + dedupe migration)

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -969,7 +969,7 @@ targets:
     achieved: 2026-04-25
   T35:
     name: Indexer is idempotent — re-reading a transcript file does not duplicate rows in entries
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -979,6 +979,7 @@ targets:
     context: 'The entries table has no uniqueness constraint on (session_id, msg_uuid) — only id is a key. Each backfill cycle re-reads JSONL files end-to-end and inserts every row again. Concrete evidence (session 39f9a984-... in -Users-marcelo-think): 125 lines on disk, 94 distinct uuids, 348 rows in mnemo (~3.7× bloat). Older messages have 6 copies; newer messages have 4 — the per-message copy count equals the number of backfill cycles run since the message was written, so storage and query cost grow without bound. All aggregate queries currently need COUNT(DISTINCT timestamp) or DISTINCT on uuid to produce correct counts. Likely fix: add UNIQUE(session_id, raw->>''$.uuid'') with INSERT OR IGNORE, plus a one-shot dedupe migration; or track last-indexed uuid/offset per session. Discovered while auditing skill usage on 2026-04-24.'
     origin: forked from skill-usage audit, 2026-04-24
     discovered: 2026-04-24
+    achieved: 2026-04-26
   T36:
     name: A design exists for mnemo as a team-shared index — contributors push their local sessions to a central mnemo per repo/org so a newcomer can pick up an ongoing program of work without personal archaeology
     status: identified

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -377,7 +377,7 @@ func relaxQuery(q string) string {
 
 // schemaVersion is incremented whenever the database schema changes.
 // On mismatch the database file is deleted and rebuilt from transcripts.
-const schemaVersion = 21
+const schemaVersion = 22
 
 func openDB(dbPath string) (*sql.DB, error) {
 	db, err := sql.Open("sqlite3", dbPath)
@@ -437,6 +437,7 @@ func New(dbPath, projectDir string) (*Store, error) {
 			timestamp TEXT,
 			raw BLOB,
 			-- Virtual columns for high-query entry-level fields.
+			uuid TEXT GENERATED ALWAYS AS (COALESCE(raw->>'$.uuid', raw->>'$.messageId')),
 			model TEXT GENERATED ALWAYS AS (raw->>'$.message.model'),
 			stop_reason TEXT GENERATED ALWAYS AS (raw->>'$.message.stop_reason'),
 			input_tokens INTEGER GENERATED ALWAYS AS (json_extract(raw, '$.message.usage.input_tokens')),
@@ -771,6 +772,7 @@ func New(dbPath, projectDir string) (*Store, error) {
 	// Create indexes.
 	_, err = db.Exec(`
 		CREATE INDEX IF NOT EXISTS idx_entries_session ON entries(session_id);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_entries_session_uuid ON entries(session_id, uuid) WHERE uuid IS NOT NULL;
 		CREATE INDEX IF NOT EXISTS idx_entries_project ON entries(project);
 		CREATE INDEX IF NOT EXISTS idx_entries_type ON entries(type);
 		CREATE INDEX IF NOT EXISTS idx_entries_timestamp ON entries(timestamp);
@@ -3270,7 +3272,7 @@ func (s *Store) IngestAll() error {
 }
 
 const (
-	entryInsertSQL = `INSERT INTO entries
+	entryInsertSQL = `INSERT OR IGNORE INTO entries
 		(session_id, project, type, timestamp, raw)
 		VALUES (?, ?, ?, ?, jsonb(?))`
 	messageInsertSQL = `INSERT INTO messages
@@ -3366,6 +3368,8 @@ func (s *Store) runWriter(parsedCh <-chan parsedFile, totalFiles int) error {
 				"eta", eta.Round(time.Second))
 		}
 		// Insert all raw entries and build entryIdx→entryID map.
+		// INSERT OR IGNORE skips duplicate (session_id, uuid) pairs, so
+		// only record the entry ID when a row was actually inserted.
 		entryIDs := make(map[int]int64, len(pf.entries))
 		for i, e := range pf.entries {
 			result, err := ws.entryStmt.Exec(pf.sessionID, pf.project, e.entryType, e.timestamp, string(e.raw))
@@ -3373,18 +3377,25 @@ func (s *Store) runWriter(parsedCh <-chan parsedFile, totalFiles int) error {
 				slog.Warn("entry insert failed", "session", pf.sessionID, "err", err)
 				continue
 			}
-			if id, err := result.LastInsertId(); err == nil {
-				entryIDs[i] = id
+			n, _ := result.RowsAffected()
+			if n > 0 {
+				if id, err := result.LastInsertId(); err == nil {
+					entryIDs[i] = id
+				}
 			}
 		}
 
 		// Insert content block messages linked to their entries.
+		// Skip messages whose entry was a duplicate (INSERT OR IGNORE, entryID == 0).
 		for _, m := range pf.messages {
+			entryID := entryIDs[m.entryIdx]
+			if entryID == 0 {
+				continue // entry was duplicate — skip associated messages
+			}
 			var toolInput any
 			if m.toolInput != nil {
 				toolInput = string(m.toolInput)
 			}
-			entryID := entryIDs[m.entryIdx]
 			ws.msgStmt.Exec(entryID, pf.sessionID, pf.project, m.role, m.text, m.timestamp, m.typ, m.isNoise,
 				m.contentType, m.toolName, m.toolUseID, toolInput, m.isError)
 
@@ -5571,14 +5582,19 @@ func (s *Store) ingestFile(path string) error {
 		}
 
 		// Insert every JSONL line into entries table.
+		// INSERT OR IGNORE skips duplicate (session_id, uuid) pairs, so
+		// only record the entry ID when a row was actually inserted.
 		var entryID int64
 		result, entryErr := ws.entryStmt.Exec(sessionID, project, entry.Type, ts, string(line))
 		if entryErr == nil {
-			entryID, _ = result.LastInsertId()
+			if n, _ := result.RowsAffected(); n > 0 {
+				entryID, _ = result.LastInsertId()
+			}
 		}
 
 		// Only extract content blocks for user/assistant messages.
-		if entry.Type != "user" && entry.Type != "assistant" {
+		// Skip if the entry was a duplicate (INSERT OR IGNORE, entryID == 0).
+		if entry.Type != "user" && entry.Type != "assistant" || entryID == 0 {
 			goto yieldCheck
 		}
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1959,3 +1959,78 @@ func padMinutes(m int) string {
 	}
 	return string(rune('0'+m/10)) + string(rune('0'+m%10))
 }
+
+// msgWithUUID creates a user/assistant message entry with a uuid field.
+func msgWithUUID(typ, text, ts, uuid string) map[string]any {
+	return map[string]any{
+		"type":      typ,
+		"timestamp": ts,
+		"uuid":      uuid,
+		"message":   map[string]any{"content": text},
+	}
+}
+
+// TestIngestIdempotent verifies that indexing the same JSONL file twice
+// produces no duplicate rows in entries or messages — satisfying 🎯T35.
+func TestIngestIdempotent(t *testing.T) {
+	projectDir := t.TempDir()
+
+	entries := []map[string]any{
+		msgWithUUID("user", "How do I fix the auth bug?", "2026-04-01T10:00:00Z", "uuid-001"),
+		msgWithUUID("assistant", "Check the session token expiry.", "2026-04-01T10:00:05Z", "uuid-002"),
+		msgWithUUID("user", "That fixed it, thanks!", "2026-04-01T10:01:00Z", "uuid-003"),
+		// A file-history-snapshot entry: no uuid but has messageId, which
+		// the uuid generated column falls back to for deduplication.
+		{
+			"type":      "file-history-snapshot",
+			"messageId": "snapshot-mid-001",
+			"timestamp": "2026-04-01T10:01:01Z",
+			"snapshot":  map[string]any{"trackedFileBackups": map[string]any{}},
+		},
+	}
+
+	writeJSONL(t, projectDir, "myproject", "sess-idem", entries)
+
+	s := newTestStore(t, projectDir)
+
+	// First ingest.
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Count rows after first ingest.
+	var entriesAfterFirst, messagesAfterFirst int
+	s.db.QueryRow("SELECT COUNT(*) FROM entries WHERE session_id = 'sess-idem'").Scan(&entriesAfterFirst)
+	s.db.QueryRow("SELECT COUNT(*) FROM messages WHERE session_id = 'sess-idem'").Scan(&messagesAfterFirst)
+
+	if entriesAfterFirst == 0 {
+		t.Fatal("expected entries after first ingest")
+	}
+
+	// Reset the in-memory offset so IngestAll re-reads the file from the
+	// beginning, simulating what happens after a schema-version rebuild
+	// (where ingest_state is wiped).
+	s.mu.Lock()
+	for k := range s.offsets {
+		delete(s.offsets, k)
+	}
+	s.mu.Unlock()
+	s.db.Exec("DELETE FROM ingest_state")
+
+	// Second ingest of the same file.
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Row counts must be identical — no duplicates introduced.
+	var entriesAfterSecond, messagesAfterSecond int
+	s.db.QueryRow("SELECT COUNT(*) FROM entries WHERE session_id = 'sess-idem'").Scan(&entriesAfterSecond)
+	s.db.QueryRow("SELECT COUNT(*) FROM messages WHERE session_id = 'sess-idem'").Scan(&messagesAfterSecond)
+
+	if entriesAfterSecond != entriesAfterFirst {
+		t.Errorf("entries duplicated: first=%d second=%d", entriesAfterFirst, entriesAfterSecond)
+	}
+	if messagesAfterSecond != messagesAfterFirst {
+		t.Errorf("messages duplicated: first=%d second=%d", messagesAfterFirst, messagesAfterSecond)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a UNIQUE constraint on `(session_id, raw->>'$.uuid')` with INSERT OR IGNORE so re-reading a transcript file does not duplicate rows in the entries table. One-shot dedupe migration for existing bloat.

Without this fix, each backfill cycle re-inserted every row — the per-message copy count equalled the number of backfill cycles since the message was written. Concrete example from a -Users-marcelo-think session: 125 lines on disk, 94 distinct uuids, **348 rows in mnemo (~3.7× bloat)**.

## Test plan

- [x] `make bullseye` green locally
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)