### PR TITLE
Release v0.30.0 — eight targets shipped in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,12 +185,16 @@ mid-session are not picked up.
 | `mnemo_chain` | Retrieve the full `/clear`-bounded session chain for any session |
 | `mnemo_self` | Discover the calling session's ID via two-phase nonce protocol |
 | `mnemo_decisions` | Search past decisions (proposal + confirmation pairs) across sessions |
+| `mnemo_session_structure` | Structural summary of a session — counts of entry types, stop_reasons, content-block kinds, tool names |
+| `mnemo_tool_result` | Raw tool-result payload by `(session_id, tool_use_id)` — supports byte offset + truncation |
+| `mnemo_locate_uuid` | Locate any entry by full or prefix UUID across six uuid sources, with surrounding context |
 
 ### Cross-project knowledge
 
 | Tool | Description |
 |---|---|
 | `mnemo_memories` | Search auto-memory files from all projects |
+| `mnemo_get_memory` | Read the raw markdown body of a named memory file (or list memories) |
 | `mnemo_skills` | Search skill files from `~/.claude/skills/` |
 | `mnemo_configs` | Search CLAUDE.md project instructions from all repos |
 | `mnemo_targets` | Search convergence targets from all repos |

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -9,7 +9,32 @@ new product. The pre-1.0 period exists to get these surfaces right.
 
 ## Interaction surface catalogue
 
-Snapshot as of v0.29.0.
+Snapshot as of v0.30.0.
+
+**v0.30.0 note**: Eight targets shipped in parallel. Four new MCP
+tools — `mnemo_session_structure(session_id)` (🎯T28, structural
+counts of entry types / stop_reasons / system subtypes / content-block
+kinds), `mnemo_tool_result(session_id, tool_use_id, offset?,
+truncate_len?)` (🎯T29, raw tool-result payload lookup with paging),
+`mnemo_get_memory(project, name?)` (🎯T30, raw memory file content;
+lists when name is omitted), `mnemo_locate_uuid(uuid,
+context_before?, context_after?)` (🎯T31, locate any entry by full or
+prefix UUID across six uuid sources: entry_uuid, parent_uuid,
+top_tool_use_id, parent_tool_use_id, content-block tool_use_id,
+content-block tool_result_id). Indexer is now idempotent (🎯T35) —
+schema bumped to **22** with a UNIQUE(session_id, raw->>'$.uuid')
+constraint + INSERT OR IGNORE; one-shot dedupe migration removes
+existing bloat (was ~3.7× on backfill-heavy sessions). Compactor's
+launchd PATH issue (🎯T37) — Homebrew formula service block now
+sets `PATH=#{HOMEBREW_PREFIX}/bin:#{ENV["HOME"]}/.claude/local:...`
+so `claudia.Task`'s `claude -p` subprocess can find the binary; spawn
+failures emit a distinct `slog.Error` with the resolved PATH. Watcher
+tick observability (🎯T38) — every tick emits a single structured
+`compact: tick` line with `outcome` (compacted / nothing_to_compact /
+budget_exceeded / failed / skipped_self / skipped_no_session) at
+DEBUG/INFO/WARN as appropriate. Team-mnemo design doc (🎯T36) lives
+at `docs/design/team-mnemo.md` — research-shaped target, no runtime
+change.
 
 **v0.29.0 note (🎯T15)**: Federation across linked mnemo instances.
 A second mTLS-authenticated MCP endpoint on `:19420` exposes a
@@ -591,6 +616,75 @@ embedding via a local Python helper). Backfill runs at startup; fresh
 images process on arrival throttled by a shared `runtime.NumCPU()`
 semaphore. **Stability**: Fluid — output format, score field
 interpretation, mode set, and descriptor vs OCR balance may evolve.
+
+#### mnemo_session_structure
+
+| Parameter | Type | Required | Description | Stability |
+|---|---|---|---|---|
+| `session_id` | string | yes | Full ID or prefix (consistent with `mnemo_read_session`) | Needs review |
+
+**Added in v0.30.0** (🎯T28). Returns a structural summary of a
+session — counts of entry types (user/assistant/system/progress/...),
+assistant `stop_reason` values, system `subtype` values, content-block
+kinds (text/tool_use/tool_result/thinking), and tool names invoked
+inside `tool_use` blocks. Output is a single compact JSON object;
+shape designed to be diffable across sessions. Replaces the
+inline-Python `Counter()` JSONL introspection pattern observed in 16
+post-mnemo sessions. **Stability**: Needs review — shape may add
+fields (e.g. byte counts per kind) before 1.0.
+
+#### mnemo_tool_result
+
+| Parameter | Type | Required | Description | Stability |
+|---|---|---|---|---|
+| `session_id` | string | yes | Full ID or prefix | Needs review |
+| `tool_use_id` | string | yes | Tool-use identifier from a prior tool_use block | Needs review |
+| `offset` | number | no | Byte offset into the payload (default 0) | Needs review |
+| `truncate_len` | number | no | Max bytes to return; 0 = full payload | Needs review |
+
+**Added in v0.30.0** (🎯T29). Returns the raw text of a single
+tool-result payload by `(session_id, tool_use_id)` lookup against the
+indexed `messages` table (O(1) via existing `idx_messages_tool_use_id`).
+Output prefixes `total_len=N`, optional `offset=N` and
+`truncated=true` markers, then a blank line and the (possibly sliced)
+payload. Replaces `cat ~/.claude/projects/<project>/<session>/tool-results/<id>.txt`
+as a workaround. **Stability**: Needs review — header format and
+default truncate behaviour may change.
+
+#### mnemo_get_memory
+
+| Parameter | Type | Required | Description | Stability |
+|---|---|---|---|---|
+| `project` | string | yes | Project name or path fragment | Needs review |
+| `name` | string | no | Memory file name (frontmatter name OR file stem). Omit to list all memories for the project. | Needs review |
+
+**Added in v0.30.0** (🎯T30). Returns the raw markdown body of a
+named memory file; lists available memories when `name` is omitted.
+Project lookup uses the same substring matching as `mnemo_memories`.
+Name matching is case-insensitive against the YAML frontmatter `name`
+field OR the file stem (basename without `.md`). Replaces `cat
+/Users/.../memory/<name>.md` workarounds. **Stability**: Needs
+review — listing format may evolve.
+
+#### mnemo_locate_uuid
+
+| Parameter | Type | Required | Description | Stability |
+|---|---|---|---|---|
+| `uuid` | string | yes | Full UUID or prefix (≥ 8 chars usually unique) | Needs review |
+| `context_before` | number | no | Messages before the matched entry (default 3) | Needs review |
+| `context_after` | number | no | Messages after the matched entry (default 3) | Needs review |
+
+**Added in v0.30.0** (🎯T31). Locates an entry by UUID across all
+sessions via a 6-arm UNION SQL query covering: `entry_uuid`,
+`parent_uuid`, `top_tool_use_id`, `parent_tool_use_id`,
+content-block `tool_use_id`, content-block `tool_result_id`. Returns
+each match with `session_id`, `entry_id`, entry type, timestamp,
+`match_kind` (which arm matched), the full matched UUID, and the
+surrounding context window. Returns "not found" cleanly when no arm
+hits. Replaces Python-loop-over-JSONL workarounds for
+debugging session chaining and tracing tool_use_id retries.
+**Stability**: Needs review — output is structured JSON; shape may
+add e.g. confidence ranking before 1.0.
 
 ### Store / Backend interface methods
 

--- a/agents-guide.md
+++ b/agents-guide.md
@@ -410,6 +410,62 @@ The nonce appears in your transcript and is detected during ingestion.
 Use the resolved session ID with `mnemo_read_session` to read your own
 transcript.
 
+### mnemo_session_structure
+
+Returns a structural summary of a session — counts of entry types,
+assistant `stop_reason` values, system `subtype` values, content-block
+kinds (text / tool_use / tool_result / thinking), and tool names
+invoked inside `tool_use` blocks. JSON output, compact enough to
+inspect directly. Use to quickly answer "what is in this session?"
+without deep-reading the transcript, or to compare session shapes.
+
+Parameters:
+- `session_id` (required) — full ID or prefix
+
+### mnemo_tool_result
+
+Returns the raw text payload of a single tool-result by
+`(session_id, tool_use_id)`. Output prefixes a header line
+(`total_len=N` plus optional `offset=N` / `truncated=true` markers),
+a blank line, then the (possibly sliced) payload. Use when
+`mnemo_read_session` shows a `tool_use` whose result you need to
+inspect in full — particularly large Bash/Read outputs that the
+inline display truncated.
+
+Parameters:
+- `session_id` (required) — full ID or prefix
+- `tool_use_id` (required) — the id from the prior `tool_use` block
+- `offset` — byte offset into the payload (default 0)
+- `truncate_len` — max bytes to return (0 = full payload)
+
+### mnemo_get_memory
+
+Returns the raw markdown body of a named memory file, or lists all
+memories for a project when `name` is omitted. Project matching is
+substring; name matching is case-insensitive against the YAML
+frontmatter `name` field OR the file stem. Use when you know the
+project and the memory name and want the body directly.
+
+Parameters:
+- `project` (required) — project name or path fragment
+- `name` — memory name; omit to list available memories
+
+### mnemo_locate_uuid
+
+Locates an entry by full or prefix UUID across all sessions. Searches
+six uuid sources: `entry_uuid`, `parent_uuid`, `top_tool_use_id`,
+`parent_tool_use_id`, content-block `tool_use_id`, content-block
+`tool_result_id`. Returns each match with `session_id`, `entry_id`,
+type, timestamp, `match_kind` (which arm matched), the full matched
+UUID, and surrounding context. Use to debug session chaining, trace
+tool_use_id retries, or resolve cross-session references when all you
+have is an opaque uuid.
+
+Parameters:
+- `uuid` (required) — full UUID or prefix (≥ 8 chars usually unique)
+- `context_before` — context messages before the match (default 3)
+- `context_after` — context messages after the match (default 3)
+
 ## Federation across linked instances
 
 If `~/.mnemo/config.json` declares `linked_instances`, 16 read-shaped

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -335,3 +335,31 @@ maintenance activities. Append-only — newest entries at the bottom.
   repos; updated `discover.sh` to emit `merge_strategy` and
   branched the SKILL.md handling accordingly. Homebrew formula
   updated.
+
+## 2026-04-26 — /release v0.30.0
+
+- **Commit**: `pending`
+- **Outcome**: Released v0.30.0. Eight targets shipped in parallel
+  via worktree-isolated agents. Four new MCP tools:
+  `mnemo_session_structure` (🎯T28, structural counts),
+  `mnemo_tool_result` (🎯T29, raw payload lookup with paging),
+  `mnemo_get_memory` (🎯T30, raw memory body or listing),
+  `mnemo_locate_uuid` (🎯T31, 6-arm uuid lookup with context).
+  Indexer is now idempotent (🎯T35) — schema bumped to 22 with a
+  UNIQUE(session_id, raw->>'$.uuid') constraint and INSERT OR
+  IGNORE; one-shot dedupe migration removes existing ~3.7× row
+  bloat from prior backfill cycles. Compactor's launchd PATH issue
+  fixed (🎯T37) — Homebrew formula service block now sets PATH so
+  `claudia.Task`'s `claude -p` exec can find the binary; spawn
+  failures emit a distinct `slog.Error` with the resolved PATH.
+  Watcher tick observability (🎯T38) — every tick emits a single
+  structured `compact: tick` log line with outcome
+  (compacted/nothing_to_compact/budget_exceeded/failed/skipped_*) at
+  DEBUG/INFO/WARN as appropriate. Team-mnemo design doc (🎯T36)
+  written at `docs/design/team-mnemo.md` proposing
+  write-aggregation layered on T15 federation. Skipped: T26 (sqlpipe
+  refactor — too invasive for parallel batch) and T33 (Windows EV
+  cert — needs paid procurement). Sequencing of merges produced
+  predictable conflicts at `Definitions()` in `internal/tools/tools.go`
+  (T28-T31) and at `internal/compact/watcher.go` (T37+T38), all
+  resolved manually. Homebrew formula updated.

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ Then restart this Claude Code session.`
 var agentsGuide string
 
 const (
-	version              = "0.29.0"
+	version              = "0.30.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
## Summary

Releases v0.30.0. Ships **eight targets** that landed in parallel via worktree-isolated agents (T28, T29, T30, T31, T35, T36, T37, T38). Doc-only release-prep on top.

### What's in the release

**Four new MCP tools:**
- `mnemo_session_structure(session_id)` — Counter-style summary of entry types, stop_reasons, content-block kinds, tool names (🎯T28)
- `mnemo_tool_result(session_id, tool_use_id, offset?, truncate_len?)` — raw payload lookup with byte paging (🎯T29)
- `mnemo_get_memory(project, name?)` — raw memory body or listing (🎯T30)
- `mnemo_locate_uuid(uuid, context_before?, context_after?)` — 6-arm uuid lookup with context window (🎯T31)

**Indexer idempotency** (🎯T35) — schema 21 → 22 with `UNIQUE(session_id, raw->>'$.uuid')` + INSERT OR IGNORE; one-shot dedupe migration removes existing ~3.7× row bloat.

**Compactor launchd PATH fix** (🎯T37) — Homebrew formula service block now sets PATH so `claudia.Task`'s `claude -p` exec succeeds; spawn failures emit a distinct `slog.Error` with the resolved PATH.

**Watcher tick observability** (🎯T38) — single structured `compact: tick` log line per tick with outcome category at DEBUG/INFO/WARN.

**Team-mnemo design doc** (🎯T36) at `docs/design/team-mnemo.md` — research-shaped, no runtime change.

### Release-workflow risk

T37 modified `.github/workflows/release.yml` (added `formula_includes` with `environment_variables PATH:` on the brew service block). That YAML only runs end-to-end on a real release event — PR CI can't exercise it. User opted to YOLO past the prerelease dry-run; if homebrew-releaser fails after tag, we iterate.

## Test plan

- [x] `make bullseye` green locally
- [x] All 16 federation + 4 new tool tests pass
- [ ] CI green on this PR
- [ ] After merge: tag → `release.yml` → tarballs uploaded → homebrew formula updated → `brew upgrade` to v0.30.0 locally
- [ ] Verify Homebrew formula's new `service` block PATH expansion is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)
