### PR TITLE
🎯T40: mnemo_repos returns CLAUDE.md summary + last-commit date (and 🎯T41 raise)

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1095,7 +1095,7 @@ targets:
     achieved: 2026-04-07
   T40:
     name: mnemo_repos can replace active-projects.md as the at-a-glance project view
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -1105,6 +1105,41 @@ targets:
     - Documentation (README or tool description) calls out this use case so future agents discover it instead of re-implementing an external generator
     context: 'active-projects.md is an auto-generated table of all repos that have a CLAUDE.md, sorted by last commit, with a one-line summary per repo pulled from CLAUDE.md. It is the primary ''what repos do I have and what is each one about'' view at session start. mnemo already indexes the underlying data — git commit history per repo, and CLAUDE.md files — but mnemo_repos today returns only name, path, session count, and last session activity. The two missing fields are CLAUDE.md first paragraph (or first line) and last commit date. Closing this gap lets the user retire active-projects.md and its update-active-projects launchd regenerator. How to apply: extend mnemo_repos with optional include_summary and include_last_commit flags that compose the existing indexed data. No new tool surface needed.'
     origin: discovered while pruning ~/think for Obsidian vault merge — active-projects.md flagged as redundant, user asked whether mnemo could close the gap
+    discovered: 2026-04-26
+    achieved: 2026-04-26
+  T41:
+    name: A repo's CLAUDE.md summary stays current — there is a defined pattern for periodically reviewing the first-paragraph summaries that mnemo_repos surfaces, so they don't silently drift away from what the project actually is
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - A documented review pattern exists (skill, scheduled agent, or periodic prompt) that compares each repo's CLAUDE.md first-paragraph summary against the repo's actual current shape (recent commits, current README, current code) and flags or rewrites stale ones.
+    - The pattern is discoverable from mnemo's docs (README or agents-guide) so users adopt it instead of reading stale summaries indefinitely.
+    - 'Mechanism for surfacing staleness: either (a) the review skill itself emits a per-repo report of summaries that look stale with proposed rewrites, OR (b) mnemo_repos annotates each summary with an age/staleness signal (e.g. days since CLAUDE.md last touched, OR a ''last-reviewed'' timestamp written into the file).'
+    - The review pattern is bounded — it does not require reading every line of every repo on every run; it uses cheap signals (file mtime, last commit on CLAUDE.md, recent activity in the repo) to gate the expensive LLM review.
+    context: |-
+      Raised 2026-04-26 alongside 🎯T40. T40 makes mnemo_repos surface a one-line summary derived from each repo's CLAUDE.md. That solves the at-a-glance scan but introduces a freshness problem: summaries stop being right the moment the project pivots and CLAUDE.md gets rewritten. Without a review pattern, a stale summary is worse than no summary — it confidently misrepresents the project to every agent that reads it.
+
+      The active-projects.md generator this is replacing handled freshness implicitly: the launchd job re-extracted the summary on every run, so a CLAUDE.md edit propagated automatically within a day. mnemo_repos under T40 either has to do the same (re-extract on every call, cheap because it's already indexed) OR rely on the indexer's update path keeping summaries in sync (CLAUDE.md changes trigger re-indexing → summary auto-refreshes). That covers extraction freshness.
+
+      The harder freshness problem is content drift: CLAUDE.md itself gets stale. The first-paragraph hasn't changed in months but the project has. No automated extraction can catch that. Hence the need for a periodic *human-or-LLM* review pattern.
+
+      Possible shapes for the pattern (the design question):
+      1. **Periodic skill** — `/review-summaries` or similar, run weekly via the `/schedule` infrastructure. For each active repo, compares CLAUDE.md first paragraph against recent commit messages, recent session topics, and the current README; flags repos where the summary looks divergent and proposes a rewrite for user approval.
+      2. **mnemo_repos annotation** — surface a staleness signal per summary (e.g., 'CLAUDE.md unchanged for 90+ days, repo has had 50 commits since' is high-staleness; 'CLAUDE.md updated last week' is low). Agents reading mnemo_repos see the signal and decide whether to trust the summary.
+      3. **In-file convention** — CLAUDE.md gains a 'last-reviewed: YYYY-MM-DD' frontmatter field; mnemo_repos shows the age. A periodic review updates the field after a human/LLM check.
+
+      Cheap-signal gating is important because doing a full LLM review of every repo every week is expensive. The review pattern should only do the expensive comparison for repos where the cheap signals (CLAUDE.md mtime vs repo last commit, recent session activity, etc.) suggest divergence is plausible.
+
+      Sequencing: depends on 🎯T40 (need the summary surface to exist before reviewing it makes sense).
+    depends_on:
+    - T40
+    tags:
+    - mnemo_repos
+    - freshness
+    - claude-md
+    - ops
+    origin: user 2026-04-26 — "we need a pattern to periodically review these summaries and keep them up to date"
     discovered: 2026-04-26
   T5:
     name: Self-improving tool discovery

--- a/internal/store/list_repos_test.go
+++ b/internal/store/list_repos_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractClaudeMDSummary(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{
+			name: "skips top-level heading then takes first sentence",
+			in: `# mnemo
+
+Searchable memory across Claude Code sessions. Indexes JSONL files
+and exposes search via MCP.
+`,
+			want: "Searchable memory across Claude Code sessions.",
+		},
+		{
+			name: "skips multiple heading levels and blank lines",
+			in: `# bullseye
+
+
+# Bullseye target tracker
+
+Track convergence targets across projects. Each target has a
+status, weight, and evaluation criteria.
+`,
+			want: "Track convergence targets across projects.",
+		},
+		{
+			name: "no period — returns whole first body line",
+			in: `# claudia
+
+A small Go SDK for spawning Claude Code subprocesses
+`,
+			want: "A small Go SDK for spawning Claude Code subprocesses",
+		},
+		{
+			name: "long single sentence — truncated with ellipsis",
+			in: `# foo
+
+` + strings.Repeat("x", 200),
+			want: strings.Repeat("x", 119) + "…",
+		},
+		{
+			name: "empty content — empty result",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "headings only — empty result",
+			in: `# foo
+## bar
+### baz
+`,
+			want: "",
+		},
+		{
+			name: "first sentence stops at period+space, not period+newline",
+			in: `# x
+
+Version 1.0 of mnemo. Federation across instances.
+`,
+			want: "Version 1.0 of mnemo.",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := extractClaudeMDSummary(c.in)
+			if got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestListReposIncludesSummaryAndLastCommit injects fake CLAUDE.md
+// content + git commit rows alongside the session metadata produced by
+// the standard ingest path, then verifies ListRepos picks them up via
+// the new sub-selects in the SQL query.
+func TestListReposIncludesSummaryAndLastCommit(t *testing.T) {
+	projectDir := t.TempDir()
+	writeJSONL(t, projectDir, "demo", "sess-123", []map[string]any{
+		metaMsg("user", "hello", "2026-04-01T10:00:00Z",
+			"/Users/dev/work/github.com/acme/demo", "main"),
+		msg("assistant", "world", "2026-04-01T10:00:05Z"),
+		msg("user", "more", "2026-04-01T10:01:00Z"),
+		msg("assistant", "ok", "2026-04-01T10:01:10Z"),
+	})
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Find the auto-derived repo string the ingest assigned.
+	pre, err := s.ListRepos("")
+	if err != nil {
+		t.Fatalf("ListRepos pre-seed: %v", err)
+	}
+	if len(pre) == 0 {
+		t.Fatal("no repos after ingest")
+	}
+	repo := pre[0].Repo
+
+	// Inject a CLAUDE.md row + a couple of git commits keyed on that
+	// repo. ListRepos's sub-selects join purely on the repo column.
+	if _, err := s.db.Exec(`
+		INSERT INTO claude_configs (repo, file_path, content, updated_at) VALUES
+			(?, ?, ?, '2026-04-25T00:00:00Z'),
+			(?, ?, ?, '2026-04-25T00:00:00Z')
+	`,
+		repo, "/path/to/repo/CLAUDE.md",
+		"# demo\n\nThe demo repo. Used for testing.\n",
+		repo, "/path/to/repo/sub/CLAUDE.md",
+		"# sub\n\nSubdirectory notes — should be ignored.\n",
+	); err != nil {
+		t.Fatalf("insert claude_configs: %v", err)
+	}
+	if _, err := s.db.Exec(`
+		INSERT INTO git_commits (repo, commit_hash, author_name, author_email, commit_date, subject) VALUES
+			(?, 'abc123', 'A', 'a@x', '2026-04-26T08:00:00Z', 'first'),
+			(?, 'def456', 'A', 'a@x', '2026-04-26T12:34:56Z', 'second')
+	`, repo, repo); err != nil {
+		t.Fatalf("insert git_commits: %v", err)
+	}
+
+	got, err := s.ListRepos("")
+	if err != nil {
+		t.Fatalf("ListRepos: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(got))
+	}
+	r := got[0]
+	if r.Summary != "The demo repo." {
+		t.Errorf("Summary = %q, want %q (root CLAUDE.md should win over subdir)",
+			r.Summary, "The demo repo.")
+	}
+	// LastCommit should match the latest of the two seeded commits,
+	// truncated to second precision.
+	if r.LastCommit != "2026-04-26T12:34:56" {
+		t.Errorf("LastCommit = %q, want 2026-04-26T12:34:56", r.LastCommit)
+	}
+}
+
+// TestListReposNoClaudeMDOrCommits exercises the LEFT-join fallback —
+// repos with no indexed CLAUDE.md or git_commits rows must still
+// appear in the listing, with empty Summary and LastCommit.
+func TestListReposNoClaudeMDOrCommits(t *testing.T) {
+	projectDir := t.TempDir()
+	writeJSONL(t, projectDir, "bare", "sess-bare", []map[string]any{
+		metaMsg("user", "hello", "2026-04-01T10:00:00Z",
+			"/Users/dev/work/github.com/acme/bare", "main"),
+		msg("assistant", "world", "2026-04-01T10:00:05Z"),
+		msg("user", "more", "2026-04-01T10:01:00Z"),
+		msg("assistant", "ok", "2026-04-01T10:01:10Z"),
+	})
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.ListRepos("")
+	if err != nil {
+		t.Fatalf("ListRepos: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(got))
+	}
+	if got[0].Summary != "" {
+		t.Errorf("Summary should be empty when no CLAUDE.md indexed, got %q", got[0].Summary)
+	}
+	if got[0].LastCommit != "" {
+		t.Errorf("LastCommit should be empty when no commits indexed, got %q", got[0].LastCommit)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -170,6 +170,16 @@ type RepoInfo struct {
 	Path         string `json:"path"`
 	Sessions     int    `json:"sessions"`
 	LastActivity string `json:"last_activity"`
+	// Summary is the first non-blank, non-heading sentence of the
+	// repo's root CLAUDE.md, capped at ~120 chars. Empty when the
+	// repo has no indexed CLAUDE.md. Auto-refreshes on next ingest
+	// when the file changes.
+	Summary string `json:"summary,omitempty"`
+	// LastCommit is the timestamp of the most recent commit on any
+	// branch indexed for this repo, in the same format as
+	// LastActivity (UTC, second-precision). Empty when git history
+	// hasn't been indexed for this repo.
+	LastCommit string `json:"last_commit,omitempty"`
 }
 
 // RecentActivityInfo summarises recent session activity for a single repo.
@@ -4177,18 +4187,49 @@ func (s *Store) ListRepos(filter string) ([]RepoInfo, error) {
 		args = []any{pattern, pattern}
 	}
 
+	// CTE so the subselects below can reference display_repo.
+	// SQLite does not propagate outer-SELECT aliases into inline
+	// subqueries (unlike PostgreSQL), so a flat SELECT with inline
+	// sub-selects against the alias fails with "no such column".
+	//
+	// Inner sub-selects pick:
+	//   - the shortest CLAUDE.md path per repo as the canonical root
+	//     (subdirectory CLAUDE.md files are usually scoped notes,
+	//     not the project summary). LENGTH() ordering is cheap and
+	//     deterministic.
+	//   - MAX(commit_date) per repo for the last-commit signal.
 	q := `
+		WITH base AS (
+			SELECT
+				CASE WHEN sm.repo != '' THEN sm.repo ELSE sm.cwd END AS display_repo,
+				MAX(sm.cwd) AS path,
+				COUNT(DISTINCT sm.session_id) AS sessions,
+				MAX(ss.last_msg) AS last_activity
+			FROM session_meta sm
+			JOIN session_summary ss ON ss.session_id = sm.session_id
+			` + where + `
+			GROUP BY display_repo
+			HAVING display_repo != ''
+		)
 		SELECT
-			CASE WHEN sm.repo != '' THEN sm.repo ELSE sm.cwd END AS display_repo,
-			MAX(sm.cwd) AS path,
-			COUNT(DISTINCT sm.session_id) AS sessions,
-			MAX(ss.last_msg) AS last_activity
-		FROM session_meta sm
-		JOIN session_summary ss ON ss.session_id = sm.session_id
-		` + where + `
-		GROUP BY display_repo
-		HAVING display_repo != ''
-		ORDER BY last_activity DESC
+			base.display_repo,
+			base.path,
+			base.sessions,
+			base.last_activity,
+			(
+				SELECT cc.content
+				FROM claude_configs cc
+				WHERE cc.repo = base.display_repo
+				ORDER BY LENGTH(cc.file_path) ASC
+				LIMIT 1
+			) AS claude_md_content,
+			(
+				SELECT MAX(gc.commit_date)
+				FROM git_commits gc
+				WHERE gc.repo = base.display_repo
+			) AS last_commit
+		FROM base
+		ORDER BY base.last_activity DESC
 	`
 
 	rows, err := s.db.Query(q, args...)
@@ -4200,12 +4241,53 @@ func (s *Store) ListRepos(filter string) ([]RepoInfo, error) {
 	var results []RepoInfo
 	for rows.Next() {
 		var r RepoInfo
-		if err := rows.Scan(&r.Repo, &r.Path, &r.Sessions, &r.LastActivity); err != nil {
+		var claudeMD, lastCommit sql.NullString
+		if err := rows.Scan(&r.Repo, &r.Path, &r.Sessions, &r.LastActivity,
+			&claudeMD, &lastCommit); err != nil {
 			continue
+		}
+		if claudeMD.Valid {
+			r.Summary = extractClaudeMDSummary(claudeMD.String)
+		}
+		if lastCommit.Valid {
+			r.LastCommit = lastCommit.String
+			if len(r.LastCommit) > 19 {
+				r.LastCommit = r.LastCommit[:19]
+			}
 		}
 		results = append(results, r)
 	}
 	return results, nil
+}
+
+// extractClaudeMDSummary pulls a one-line summary out of CLAUDE.md
+// content: skip leading blank lines and top-level headings, take the
+// first non-blank line of body prose, then the first sentence of that
+// line. Capped at 120 chars so the at-a-glance view stays scannable.
+//
+// This is best-effort prose extraction, not Markdown parsing — bullet
+// lists and code fences are rare as the FIRST body content of a
+// CLAUDE.md, and falling through to "use the first non-empty line"
+// gives a useful answer even on edge cases.
+func extractClaudeMDSummary(content string) string {
+	const maxLen = 120
+	for line := range strings.Lines(content) {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// First sentence: split on ". " (period + space) which
+		// catches normal English; fall through to the whole line if
+		// no sentence boundary is found.
+		if idx := strings.Index(line, ". "); idx > 0 && idx < maxLen {
+			line = line[:idx+1]
+		}
+		if len(line) > maxLen {
+			line = line[:maxLen-1] + "…"
+		}
+		return line
+	}
+	return ""
 }
 
 // RecentActivity returns per-repo summaries of session activity within the

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -165,7 +165,9 @@ Tip: If you find yourself running the same complex query pattern repeatedly, sav
 			mcp.WithString("query", mcp.Required(), mcp.Description("SQL SELECT/WITH query, or sqldeep nested syntax (FROM ... SELECT { ... })")),
 		),
 		mcp.NewTool("mnemo_repos",
-			mcp.WithDescription(`List repositories that have been worked on in Claude Code sessions. Returns repo name, filesystem path, session count, and last activity. Use this to discover repo locations, find related projects, or get an overview of recent work.`),
+			mcp.WithDescription(`List repositories that have been worked on in Claude Code sessions. Returns, per repo: name, filesystem path, session count, last session activity, last git commit date, and a one-line summary derived from the repo's root CLAUDE.md (first non-blank, non-heading sentence, capped at ~120 chars).
+
+This is the canonical at-a-glance "what repos do I have and what is each one about?" view — sufficient to replace an externally-generated active-projects.md or similar overview file. Summaries refresh automatically when CLAUDE.md is re-indexed.`),
 			mcp.WithString("filter", mcp.Description(`Optional filter. Supports: bare name ("mnemo"), org/repo ("marcelocantos/mnemo"), path fragment ("/work/github"), or glob ("marcelocantos/sql*"). Omit to list all repos.`)),
 		),
 		mcp.NewTool("mnemo_stats",
@@ -753,8 +755,19 @@ func (h *callHandler) repos(args map[string]any) (string, bool, error) {
 		if len(lastActivity) > 19 {
 			lastActivity = lastActivity[:19]
 		}
-		fmt.Fprintf(&b, "%-45s  %4d sessions  %s  %s\n",
-			r.Repo, r.Sessions, lastActivity, r.Path)
+		// Date column shows last_commit when available (truer signal
+		// for "is this repo alive?"), falling back to last_activity.
+		dateCol := r.LastCommit
+		dateLabel := "commit"
+		if dateCol == "" {
+			dateCol = lastActivity
+			dateLabel = "session"
+		}
+		fmt.Fprintf(&b, "%-45s  %4d sessions  %s %s  %s\n",
+			r.Repo, r.Sessions, dateLabel, dateCol, r.Path)
+		if r.Summary != "" {
+			fmt.Fprintf(&b, "    %s\n", r.Summary)
+		}
 	}
 	return b.String(), false, nil
 }


### PR DESCRIPTION
## Summary

Extends `mnemo_repos` so its output is sufficient to replace an externally-generated `active-projects.md` (or similar at-a-glance project view).

**New per-repo fields** (`omitempty` — JSON-stable for callers that don't read them):

- `Summary` — first non-blank, non-heading sentence of the repo's root CLAUDE.md, capped at 120 chars. Auto-refreshes on next ingest when CLAUDE.md changes.
- `LastCommit` — `MAX(commit_date)` from the indexed `git_commits` table, truncated to second precision.

Implementation wraps `ListRepos` in a CTE so two inline sub-selects can reference the `display_repo` alias (SQLite doesn't propagate outer-SELECT aliases into sub-selects, unlike PostgreSQL). Root CLAUDE.md picked by smallest `file_path` length per repo — subdirectory CLAUDE.md files are scoped notes, not the project summary.

Tool description and output formatter updated to surface the new fields and document the at-a-glance use case.

## 🎯T41 also raised in this PR

Companion target for the periodic summary-review pattern. Extraction freshness is solved by re-indexing CLAUDE.md (this PR), but **content drift** (CLAUDE.md itself going stale) needs a separate review loop. T41 captures the design space — periodic skill, mnemo_repos staleness annotation, in-file `last-reviewed` convention — without committing to a shape yet. Depends on T40.

## Test plan

- [x] `extractClaudeMDSummary`: 7 sub-tests covering heading skip, multi-heading, no-period fallback, ellipsis truncation, empty input, headings-only, sentence-boundary detection
- [x] `ListRepos` end-to-end: root vs subdir CLAUDE.md selection, last-commit MAX ordering, LEFT-join fallback for repos without indexed CLAUDE.md/commits
- [x] `make bullseye` green locally
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)