### PR TITLE
Release v0.31.0 — at-a-glance project view + summary review worker

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -9,7 +9,29 @@ new product. The pre-1.0 period exists to get these surfaces right.
 
 ## Interaction surface catalogue
 
-Snapshot as of v0.30.0.
+Snapshot as of v0.31.0.
+
+**v0.31.0 note**: Two-target follow-up to v0.30.0. **`mnemo_repos`
+gains four new per-repo fields** (🎯T40): `Summary` (first
+non-blank, non-heading sentence of the repo's root CLAUDE.md, capped
+at 120 chars), `LastCommit` (MAX commit_date from indexed
+git_commits, second precision), `SummaryVerdict` (latest LLM-review
+verdict — see below), `SummaryReviewedAt` (timestamp of that
+verdict). Output is now sufficient to replace an externally
+maintained `active-projects.md` for the at-a-glance scan; the tool
+description calls out this use case. **New background reviewer
+worker** (🎯T41): per-user goroutine, ticks every 10 minutes with
+60s startup delay, scans every repo with an indexed CLAUDE.md, and
+when a cheap-signal trigger fires (≥500 entries since last review,
+OR ≥50 entries AND ≥24h since last review) invokes `claudia.Task`
+to compare the existing summary against recent activity. Verdict is
+one of `current` / `stale` / `rewritten`, recorded in the new
+`claude_md_reviews` table with optional `proposed_summary` /
+`proposed_claude_md`. Schema bump 22 → **23**. Nothing
+auto-applies; `mnemo_repos` annotates summaries with `[stale,
+reviewed <ts>]` or `[needs rewrite, reviewed <ts>]` markers.
+**Stability**: Fluid — trigger thresholds, verdict vocabulary, and
+the marker rendering may evolve before 1.0.
 
 **v0.30.0 note**: Eight targets shipped in parallel. Four new MCP
 tools — `mnemo_session_structure(session_id)` (🎯T28, structural

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1144,9 +1144,10 @@ targets:
     achieved: 2026-04-26
   T42:
     name: mnemo provides a cross-session message bus for Claude Code agents
-    status: identified
+    status: set_aside
     value: 0.0
     cost: 0.0
+    set_aside_reason: 'Won''t fix — wrong shape for the actual use case. Acceptance was a pull-based message bus assuming long-lived listener sessions. Real use case is cross-repo agent coordination ("A finishes its bit, B resumes") which Claude Code agents can''t satisfy via pull (no event loop between turns) or via RemoteTrigger composition (RemoteTrigger spawns sessions on Anthropic''s hosted infrastructure, which can''t reach localhost mnemo without the federated mTLS endpoint AND can''t push back to local sessions either). PR #59 was opened, then closed during the design discussion. Retired-then-set-aside because the original retire was premature: the work landed on a feature branch that we then killed before merging, so no production change. If a future design surfaces a primitive that genuinely fits the coordination use case, raise it as a fresh target rather than reviving this one.'
     acceptance:
     - mnemo exposes mnemo_message_post(topic, body, reply_to?) — posts a message to a topic
     - mnemo exposes mnemo_message_recv(topic, since?, mark_read?) — pulls messages from a topic, optionally marking read

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -363,3 +363,32 @@ maintenance activities. Append-only — newest entries at the bottom.
   predictable conflicts at `Definitions()` in `internal/tools/tools.go`
   (T28-T31) and at `internal/compact/watcher.go` (T37+T38), all
   resolved manually. Homebrew formula updated.
+
+## 2026-04-26 — /release v0.31.0
+
+- **Commit**: `pending`
+- **Outcome**: Released v0.31.0. Two-target follow-up to v0.30.0:
+  🎯T40 (mnemo_repos returns CLAUDE.md first-paragraph summary
+  + last-commit date — at-a-glance project view sufficient to
+  replace an externally maintained active-projects.md, summaries
+  auto-refresh on CLAUDE.md re-index) and 🎯T41 (background
+  reviewer worker that ticks every 10 minutes per user, gates on
+  a cheap signal — entries since last review crossing high
+  threshold of 500 OR low threshold of 50 with ≥24h age — and
+  on trigger invokes claudia.Task to compare the existing
+  summary against recent activity, recording a verdict of
+  current/stale/rewritten plus optional proposed rewrites in
+  the new claude_md_reviews table; nothing auto-applies, only
+  surfaces via mnemo_repos as `[stale, reviewed <ts>]` markers).
+  Schema bump 22 → 23 for the reviews table. New internal
+  packages: internal/reviewer/ (worker + LLM bridge) and
+  internal/storetest/ (cross-package fixture helpers). One
+  trivial gofmt fix on internal/store/store.go bundled in.
+  Targets housekeeping: 🎯T39 raised (Homebrew formula's
+  `serve` arg is a phantom subcommand), 🎯T42 set aside
+  (cross-session message bus design didn't fit the actual
+  cross-repo agent coordination use case — Claude Code agents
+  are turn-driven, not event-driven, and pull-based bus alone
+  can't deliver real-time wakeup), 🎯T43 raised (review-worker
+  scale hardening for when multi-user / cold-start cost matters).
+  Homebrew formula updated.

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ Then restart this Claude Code session.`
 var agentsGuide string
 
 const (
-	version              = "0.30.0"
+	version              = "0.31.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
## Summary

Releases v0.31.0. Two-target follow-up to v0.30.0:

- **🎯T40** — `mnemo_repos` returns CLAUDE.md first-paragraph summary + last-commit date. At-a-glance project view sufficient to replace an externally maintained `active-projects.md`. Summaries auto-refresh on CLAUDE.md re-index.
- **🎯T41** — Background reviewer worker that compares each repo's CLAUDE.md summary against recent activity, gated by a cheap-signal trigger (entry counts since last review). Records verdict + optional proposed rewrite in `claude_md_reviews` (schema 22 → 23). Surfaces in `mnemo_repos` as `[stale, reviewed <ts>]` markers; nothing auto-applies.

Plus targets-state housekeeping carried over from this session: 🎯T39 raised (formula `serve` arg cleanup), 🎯T42 set aside (cross-session message bus design didn't fit the actual cross-repo coordination use case), 🎯T43 raised (review-worker scale hardening for when multi-user / cold-start cost matters).

## Test plan

- [x] `make bullseye` green locally
- [x] All store + reviewer tests pass (12-case `ShouldReview` table test, recv/list/topic-list bus tests *not* present — set aside, see T42)
- [ ] CI green on this PR
- [ ] After merge: tag → `release.yml` → tarballs uploaded → homebrew formula updated → `brew upgrade` to v0.31.0 locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
