### PR TITLE
feat(rework-history): mnemo_rework_history tool for bullseye T1.5 integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ user. Good moments to reach for mnemo:
 - `mnemo_prs` — Search GitHub PRs and issues across all indexed repos. FTS5 on title/body. Supports state, author, type (pr/issue) filters. Retroactive: backfills from GitHub API at startup.
 - `mnemo_discover_patterns` — Analyze transcript history to find workaround patterns suggesting missing features. Detects direct JSONL reads, transcript dir greps, repeated query shapes, and recurring searches.
 - `mnemo_images` — Search images captured from transcripts. Inline base64 and file-path image references are extracted at ingest, stored as BLOBs with width/height/MIME metadata, and described by AI using surrounding conversation context. Searchable via FTS5 on descriptions. Requires ANTHROPIC_API_KEY for description generation.
+- `mnemo_rework_history` — Return prior rework attempts for a bullseye target, ordered most-recent first. Sourced from compaction spans where the target appeared in targets_active or targets_progressed. Returns session_id, timestamp, repo, progress note, prose summary, and open threads. Feed output as `mnemo_history` to `bullseye_rework` to avoid repeating prior failed approaches.
 
 ## Code Structure
 

--- a/internal/federation/fanout.go
+++ b/internal/federation/fanout.go
@@ -45,6 +45,7 @@ var FanoutToolNames = map[string]struct{}{
 	"mnemo_ci":                {},
 	"mnemo_images":            {},
 	"mnemo_discover_patterns": {},
+	"mnemo_rework_history":    {},
 }
 
 // PeerResult holds the raw text response from one peer's instance of

--- a/internal/store/iface.go
+++ b/internal/store/iface.go
@@ -56,4 +56,5 @@ type Backend interface {
 	InferChainHeuristic(sessionID string, limit int) ([]ChainCandidate, error)
 	SessionStructure(sessionID string) (*SessionStructure, error)
 	LocateUUID(prefix string, contextBefore, contextAfter int) ([]UUIDMatch, error)
+	ReworkHistory(targetID string, repo string, limit int) ([]ReworkAttempt, error)
 }

--- a/internal/store/rework_history_test.go
+++ b/internal/store/rework_history_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestReworkHistoryWithAttempts(t *testing.T) {
+	s := newTestStore(t, t.TempDir())
+
+	base := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+
+	// Three compaction spans touching T5, ordered oldest → newest.
+	// First: T5 appears in targets_active.
+	if _, err := s.PutCompaction(Compaction{
+		SessionID:   "sess-a",
+		GeneratedAt: base,
+		Summary:     "first attempt at T5 — linker error",
+		PayloadJSON: `{"targets_active":["T5","T3"],"targets_progressed":{},"open_threads":["arm64 stub missing"]}`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second: T5 appears in targets_progressed.
+	if _, err := s.PutCompaction(Compaction{
+		SessionID:   "sess-b",
+		GeneratedAt: base.Add(time.Hour),
+		Summary:     "second attempt at T5 — wrong flag",
+		PayloadJSON: `{"targets_active":[],"targets_progressed":{"T5":"tried conditional compilation flag, still failing"},"open_threads":[]}`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Third: T5 in active, more recent.
+	if _, err := s.PutCompaction(Compaction{
+		SessionID:   "sess-c",
+		GeneratedAt: base.Add(2 * time.Hour),
+		Summary:     "third attempt at T5 — partial fix",
+		PayloadJSON: `{"targets_active":["T5"],"targets_progressed":{},"open_threads":["tests still red"]}`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// A span that doesn't touch T5 — should be excluded.
+	if _, err := s.PutCompaction(Compaction{
+		SessionID:   "sess-d",
+		GeneratedAt: base.Add(3 * time.Hour),
+		Summary:     "unrelated work on T7",
+		PayloadJSON: `{"targets_active":["T7"],"targets_progressed":{},"open_threads":[]}`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	attempts, err := s.ReworkHistory("T5", "", 10)
+	if err != nil {
+		t.Fatalf("ReworkHistory: %v", err)
+	}
+
+	// Expect 3 results, most-recent first.
+	if len(attempts) != 3 {
+		t.Fatalf("expected 3 attempts, got %d: %+v", len(attempts), attempts)
+	}
+	if attempts[0].SessionID != "sess-c" {
+		t.Errorf("attempt[0] should be sess-c (most recent), got %q", attempts[0].SessionID)
+	}
+	if attempts[1].SessionID != "sess-b" {
+		t.Errorf("attempt[1] should be sess-b, got %q", attempts[1].SessionID)
+	}
+	if attempts[2].SessionID != "sess-a" {
+		t.Errorf("attempt[2] should be sess-a (oldest), got %q", attempts[2].SessionID)
+	}
+
+	// Second attempt should carry progress note.
+	if attempts[1].Progress != "tried conditional compilation flag, still failing" {
+		t.Errorf("attempt[1].Progress unexpected: %q", attempts[1].Progress)
+	}
+
+	// First attempt should carry open_threads.
+	if len(attempts[2].OpenThreads) != 1 || attempts[2].OpenThreads[0] != "arm64 stub missing" {
+		t.Errorf("attempt[2].OpenThreads unexpected: %v", attempts[2].OpenThreads)
+	}
+
+	// Summaries should be populated.
+	if attempts[0].Summary != "third attempt at T5 — partial fix" {
+		t.Errorf("attempt[0].Summary unexpected: %q", attempts[0].Summary)
+	}
+}
+
+func TestReworkHistoryNoHistory(t *testing.T) {
+	s := newTestStore(t, t.TempDir())
+
+	// Insert a compaction for a different target.
+	if _, err := s.PutCompaction(Compaction{
+		SessionID:   "sess-x",
+		GeneratedAt: time.Now().UTC(),
+		Summary:     "work on T99",
+		PayloadJSON: `{"targets_active":["T99"],"targets_progressed":{},"open_threads":[]}`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	attempts, err := s.ReworkHistory("T5", "", 10)
+	if err != nil {
+		t.Fatalf("ReworkHistory unexpected error: %v", err)
+	}
+	if len(attempts) != 0 {
+		t.Fatalf("expected empty result for unknown target, got %d: %+v", len(attempts), attempts)
+	}
+}
+
+func TestReworkHistoryMalformedTargetID(t *testing.T) {
+	s := newTestStore(t, t.TempDir())
+
+	// Insert a compaction that would partially match "T1" via substring.
+	if _, err := s.PutCompaction(Compaction{
+		SessionID:   "sess-y",
+		GeneratedAt: time.Now().UTC(),
+		Summary:     "work on T10 and T11",
+		PayloadJSON: `{"targets_active":["T10","T11"],"targets_progressed":{},"open_threads":[]}`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty target ID — should fail gracefully (returns empty, not a panic).
+	attempts, err := s.ReworkHistory("", "", 10)
+	if err != nil {
+		t.Fatalf("ReworkHistory('') unexpected error: %v", err)
+	}
+	if len(attempts) != 0 {
+		// An empty target ID LIKE-matches everything; the precise JSON membership
+		// check must prevent false positives.
+		t.Logf("empty target_id returned %d attempts (no crash is what matters)", len(attempts))
+	}
+
+	// "T1" should NOT match "T10" or "T11" — exact membership check must hold.
+	attempts, err = s.ReworkHistory("T1", "", 10)
+	if err != nil {
+		t.Fatalf("ReworkHistory('T1') unexpected error: %v", err)
+	}
+	if len(attempts) != 0 {
+		t.Errorf("T1 should not match T10/T11, got %d false-positive hits", len(attempts))
+	}
+}
+
+func TestReworkHistoryRepoFilter(t *testing.T) {
+	s := newTestStore(t, t.TempDir())
+
+	base := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+
+	// Insert session_meta rows so the repo filter has data to match.
+	mustExec := func(q string, args ...any) {
+		t.Helper()
+		if _, err := s.db.Exec(q, args...); err != nil {
+			t.Fatalf("exec %q: %v", q, err)
+		}
+	}
+	mustExec(`INSERT INTO session_meta (session_id, repo) VALUES (?, ?)`,
+		"sess-bullseye", "marcelocantos/bullseye")
+	mustExec(`INSERT INTO session_meta (session_id, repo) VALUES (?, ?)`,
+		"sess-other", "marcelocantos/other")
+
+	if _, err := s.PutCompaction(Compaction{
+		SessionID:   "sess-bullseye",
+		GeneratedAt: base,
+		Summary:     "T5 in bullseye",
+		PayloadJSON: `{"targets_active":["T5"],"targets_progressed":{},"open_threads":[]}`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.PutCompaction(Compaction{
+		SessionID:   "sess-other",
+		GeneratedAt: base.Add(time.Minute),
+		Summary:     "T5 in other repo",
+		PayloadJSON: `{"targets_active":["T5"],"targets_progressed":{},"open_threads":[]}`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Filter to bullseye only.
+	attempts, err := s.ReworkHistory("T5", "bullseye", 10)
+	if err != nil {
+		t.Fatalf("ReworkHistory with repo filter: %v", err)
+	}
+	if len(attempts) != 1 {
+		t.Fatalf("expected 1 attempt for bullseye repo, got %d: %+v", len(attempts), attempts)
+	}
+	if attempts[0].SessionID != "sess-bullseye" {
+		t.Errorf("expected sess-bullseye, got %q", attempts[0].SessionID)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2831,6 +2831,109 @@ func (s *Store) SearchDecisions(query string, repo string, days int, limit int) 
 	return results, nil
 }
 
+// ReworkAttempt is one compaction span that touched a given target,
+// indicating a prior work or rework cycle. Returned by ReworkHistory.
+type ReworkAttempt struct {
+	SessionID   string `json:"session_id"`
+	GeneratedAt string `json:"generated_at"`
+	Repo        string `json:"repo,omitempty"`
+	// Progress is the targets_progressed note for this target, if present.
+	Progress    string `json:"progress,omitempty"`
+	// Summary is the compaction's prose abstract.
+	Summary     string `json:"summary,omitempty"`
+	// OpenThreads lists unresolved items recorded in the span.
+	OpenThreads []string `json:"open_threads,omitempty"`
+}
+
+// ReworkHistory returns compaction spans that actively worked on targetID,
+// ordered most-recent first. A span qualifies when targetID appears in
+// targets_active or targets_progressed. Optional repo filter is a substring
+// match against session_meta.repo.
+func (s *Store) ReworkHistory(targetID string, repo string, limit int) ([]ReworkAttempt, error) {
+	s.rwmu.RLock()
+	defer s.rwmu.RUnlock()
+
+	if limit <= 0 {
+		limit = 20
+	}
+
+	// Use a LIKE pre-filter on payload_json for speed (target IDs are
+	// short alphanumeric tokens), then verify membership precisely via
+	// json_each in a CASE expression to avoid false positives from
+	// substring collisions (e.g. "T1" matching "T10").
+	like := `%"` + targetID + `"%`
+	q := `
+		SELECT c.session_id, c.generated_at, COALESCE(sm.repo, ''), c.payload_json, c.summary
+		FROM compactions c
+		LEFT JOIN session_meta sm ON sm.session_id = c.session_id
+		WHERE c.payload_json LIKE ?`
+	args := []any{like}
+	if repo != "" {
+		q += ` AND sm.repo LIKE ?`
+		args = append(args, "%"+repo+"%")
+	}
+	q += ` ORDER BY c.generated_at DESC, c.id DESC LIMIT ?`
+	args = append(args, limit*5) // over-fetch to allow post-filter
+
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("rework history query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ReworkAttempt
+	for rows.Next() && len(out) < limit {
+		var sessionID, generatedAt, repoVal, payloadJSON, summary string
+		if err := rows.Scan(&sessionID, &generatedAt, &repoVal, &payloadJSON, &summary); err != nil {
+			continue
+		}
+		// Decode payload to verify precise membership and extract fields.
+		var payload struct {
+			TargetsActive     []string          `json:"targets_active"`
+			Targets           []string          `json:"targets"`
+			TargetsProgressed map[string]string `json:"targets_progressed"`
+			OpenThreads       []string          `json:"open_threads"`
+		}
+		if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+			continue
+		}
+		active := payload.TargetsActive
+		if len(active) == 0 {
+			active = payload.Targets
+		}
+		found := false
+		for _, id := range active {
+			if id == targetID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			if _, ok := payload.TargetsProgressed[targetID]; ok {
+				found = true
+			}
+		}
+		if !found {
+			continue
+		}
+		attempt := ReworkAttempt{
+			SessionID:   sessionID,
+			GeneratedAt: generatedAt,
+			Repo:        repoVal,
+			Summary:     summary,
+			OpenThreads: payload.OpenThreads,
+		}
+		if note, ok := payload.TargetsProgressed[targetID]; ok {
+			attempt.Progress = note
+		}
+		out = append(out, attempt)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rework history scan: %w", err)
+	}
+	return out, nil
+}
+
 // proposalPhrases are patterns that indicate an assistant is proposing a course of action.
 var proposalPhrases = []string{
 	"i'll ", "i will ", "let me ", "i propose ", "i suggest ", "should we ",

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -458,6 +458,16 @@ Returns the full text, is_error flag, and total byte length. Use offset and trun
 			mcp.WithNumber("offset", mcp.Description("Skip the first N bytes of the result text (default 0).")),
 			mcp.WithNumber("truncate_len", mcp.Description("Maximum bytes to return (default: no limit). Use with offset to page.")),
 		),
+		mcp.NewTool("mnemo_rework_history",
+			mcp.WithDescription(`Return prior rework attempts for a bullseye target, ordered most-recent first.
+
+Each result is one compaction span (a background-summarised session segment) in which the target appeared as actively worked on (in targets_active or targets_progressed). Provides: session ID, timestamp, repo, the per-target progress note if the compactor recorded one, the prose summary of the span, and any open threads left unresolved.
+
+Use this to build a rework diagnosis context: the bullseye_rework tool accepts the output as its mnemo_history parameter so the rework agent sees what was tried before, what failed, and what was left open — avoiding repeating the same failed approaches.`),
+			mcp.WithString("target_id", mcp.Required(), mcp.Description("Bullseye target ID (e.g. \"T1.5\"). Exact match against targets_active and targets_progressed keys.")),
+			mcp.WithString("repo", mcp.Description("Filter by repo name or path fragment (optional).")),
+			mcp.WithNumber("limit", mcp.Description("Max attempts to return (default 20).")),
+		),
 	}
 }
 
@@ -554,6 +564,8 @@ func (h *Handler) Call(cc CallContext, name string, args map[string]any) (string
 		return ch.sessionStructure(args)
 	case "mnemo_tool_result":
 		return ch.toolResult(args)
+	case "mnemo_rework_history":
+		return ch.reworkHistory(args)
 	default:
 		return "", false, fmt.Errorf("unknown tool: %s", name)
 	}
@@ -1930,4 +1942,49 @@ func (h *callHandler) locateUUID(args map[string]any) (string, bool, error) {
 		return fmt.Sprintf("marshal failed: %v", err), true, nil
 	}
 	return string(out), false, nil
+}
+
+func (h *callHandler) reworkHistory(args map[string]any) (string, bool, error) {
+	targetID, _ := args["target_id"].(string)
+	if targetID == "" {
+		return "target_id is required", true, nil
+	}
+	repo, _ := args["repo"].(string)
+	limit := 20
+	if l, ok := args["limit"].(float64); ok && l > 0 {
+		limit = int(l)
+	}
+
+	attempts, err := h.mem.ReworkHistory(targetID, repo, limit)
+	if err != nil {
+		return fmt.Sprintf("rework_history failed: %v", err), true, nil
+	}
+	if len(attempts) == 0 {
+		return fmt.Sprintf("No prior rework attempts found for target %s.", targetID), false, nil
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Prior rework attempts for %s (%d span(s)):\n\n", targetID, len(attempts))
+	for i, a := range attempts {
+		sid := a.SessionID
+		if len(sid) > 10 {
+			sid = sid[:10]
+		}
+		fmt.Fprintf(&b, "── Attempt %d  [%s]  %s", i+1, sid, a.GeneratedAt)
+		if a.Repo != "" {
+			fmt.Fprintf(&b, "  (%s)", a.Repo)
+		}
+		b.WriteString(" ──\n")
+		if a.Progress != "" {
+			fmt.Fprintf(&b, "Progress: %s\n", a.Progress)
+		}
+		if a.Summary != "" {
+			fmt.Fprintf(&b, "Summary: %s\n", a.Summary)
+		}
+		if len(a.OpenThreads) > 0 {
+			fmt.Fprintf(&b, "Open threads: %s\n", strings.Join(a.OpenThreads, "; "))
+		}
+		b.WriteByte('\n')
+	}
+	return b.String(), false, nil
 }


### PR DESCRIPTION
Closing in favour of #63 — the implementation was already merged into master via PR #54, so this PR only needed the tests. Superseded by the clean cherry-pick branch.