### PR TITLE
Send 30s heartbeat pings on streamable-HTTP MCP streams

### DIFF
--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	mcpserver "github.com/mark3labs/mcp-go/server"
 
@@ -69,6 +70,7 @@ func Start(
 	httpHandler := mcpserver.NewStreamableHTTPServer(mcp,
 		mcpserver.WithStateful(true),
 		mcpserver.WithHTTPContextFunc(tools.UsernameContextFunc),
+		mcpserver.WithHeartbeatInterval(30*time.Second),
 	)
 
 	httpSrv := &http.Server{

--- a/main.go
+++ b/main.go
@@ -579,6 +579,11 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	httpSrv := server.NewStreamableHTTPServer(mcpSrv,
 		server.WithStateful(true),
 		server.WithHTTPContextFunc(tools.UsernameContextFunc),
+		// Keep the GET (SSE) stream warm so NAT / OS keepalive doesn't
+		// collapse it during idle stretches. Without this, an idle
+		// Claude Code session sees "MCP error -32000: Connection closed"
+		// on the first tool call after a few minutes of silence.
+		server.WithHeartbeatInterval(30*time.Second),
 	)
 
 	slog.Info("mnemo serve starting", "version", version, "addr", addr)


### PR DESCRIPTION
Without WithHeartbeatInterval, the GET (SSE) stream from the streamable-HTTP
MCP server has no application-layer keepalive. A few minutes of idle in a
Claude Code session is enough for OS / NAT keepalive to collapse the
underlying TCP connection, so the next tool call surfaces as
"MCP error -32000: Connection closed" before transparent reconnect succeeds.
Apply the same heartbeat to the federated mTLS endpoint.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
