### PR TITLE
Release v0.32.0 — streamable-HTTP MCP keepalive

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -9,7 +9,23 @@ new product. The pre-1.0 period exists to get these surfaces right.
 
 ## Interaction surface catalogue
 
-Snapshot as of v0.31.0.
+Snapshot as of v0.32.0.
+
+**v0.32.0 note**: Two-commit reliability/test release. **MCP keepalive**
+(`49e015f`): the local streamable-HTTP server (`:19419`) and the
+federated mTLS endpoint (`:19420`) now pass
+`server.WithHeartbeatInterval(30*time.Second)` to `mark3labs/mcp-go`'s
+`NewStreamableHTTPServer`. Sends a `ping` JSON-RPC frame on each
+session's GET (SSE) stream every 30s so OS / NAT / proxy idle timeouts
+don't collapse the underlying TCP — fixes the user-visible
+`MCP error -32000: Connection closed` that surfaced on the first tool
+call after ~3 minutes of idle. No public-surface change; pure
+reliability fix. **`mnemo_rework_history` test coverage** (`20203fd`):
+the tool itself shipped in v0.31.0 (commit `09a3149`, missed by that
+release's STABILITY.md update) and is now fully exercised by tests
+plus documented in this catalogue (see `### MCP tools` below).
+**Stability**: heartbeat interval is internal; no behavioural promise
+on its exact cadence.
 
 **v0.31.0 note**: Two-target follow-up to v0.30.0. **`mnemo_repos`
 gains four new per-repo fields** (🎯T40): `Summary` (first
@@ -707,6 +723,23 @@ hits. Replaces Python-loop-over-JSONL workarounds for
 debugging session chaining and tracing tool_use_id retries.
 **Stability**: Needs review — output is structured JSON; shape may
 add e.g. confidence ranking before 1.0.
+
+#### `mnemo_rework_history`
+
+**Added in v0.31.0** (commit `09a3149`; catalogue entry retroactively
+added in v0.32.0). Returns prior rework attempts for a bullseye
+target, ordered most-recent first. Each result is one compaction span
+in which the target appeared as actively worked on (in
+`targets_active` or `targets_progressed`); fields are session ID,
+timestamp, repo, the per-target progress note (if the compactor
+recorded one), the prose summary of the span, and any open threads
+left unresolved. Designed to feed `bullseye_rework`'s `mnemo_history`
+parameter so the rework agent sees what was tried before. Parameters:
+`target_id` (required, exact match against `targets_active` /
+`targets_progressed` keys, e.g. "T1.5"), `repo` (optional path
+fragment filter), `limit` (default 20). **Stability**: Needs review —
+the per-span fields are likely stable, but the ordering / dedup story
+across overlapping spans may evolve before 1.0.
 
 ### Store / Backend interface methods
 

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -392,3 +392,33 @@ maintenance activities. Append-only — newest entries at the bottom.
   can't deliver real-time wakeup), 🎯T43 raised (review-worker
   scale hardening for when multi-user / cold-start cost matters).
   Homebrew formula updated.
+
+## 2026-04-26 — /release v0.32.0
+
+- **Commit**: `pending`
+- **Outcome**: Released v0.32.0. Two-commit reliability/test
+  release. **MCP keepalive fix** (#64): the local streamable-HTTP
+  MCP server (`:19419`) and the federated mTLS endpoint (`:19420`)
+  now pass `server.WithHeartbeatInterval(30*time.Second)` to
+  `mark3labs/mcp-go`'s `NewStreamableHTTPServer`, sending a `ping`
+  JSON-RPC frame on each session's GET (SSE) stream every 30s.
+  Resolves the user-visible `MCP error -32000: Connection closed`
+  that surfaced on the first tool call after ~3 minutes of session
+  idle (OS / NAT / proxy collapsed the underlying TCP because no
+  app-layer keepalive was active). Diagnosed from a real claudia-
+  repo Claude Code session that disconnected at 11:14:35Z; mnemo's
+  log over the same window showed no panic, no restart, just the
+  default `mcp-go` library option `WithHeartbeatInterval` not set.
+  **mnemo_rework_history test coverage** + STABILITY.md catalogue
+  entry — the tool itself shipped in v0.31.0 (commit `09a3149`)
+  but was missed by that release's catalogue update; tests landed
+  alongside the docs update in commit `20203fd`. Targets
+  housekeeping: forks raised in adjacent repos (sawmill 🎯T28,
+  spyder 🎯T40, mcpbridge 🎯T6) for the same `mcp-go`
+  heartbeat-default footgun in their own streamable-HTTP servers,
+  plus a defensive client-side ping design for mcpbridge to
+  protect non-owned upstreams. Global directive amendment:
+  removed the "target-only edits stop at the push" rule from
+  `~/.claude/CLAUDE.md` and `~/.claude/skills/push/SKILL.md` —
+  causing more friction than visibility benefit for solo repos.
+  Homebrew formula updated.

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ Then restart this Claude Code session.`
 var agentsGuide string
 
 const (
-	version              = "0.31.0"
+	version              = "0.32.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
## Summary

Release v0.32.0. Two-commit reliability/test release.

- **MCP keepalive fix** (#64). Local (`:19419`) and federated (`:19420`) streamable-HTTP MCP servers now pass `server.WithHeartbeatInterval(30*time.Second)`. Resolves the user-visible `MCP error -32000: Connection closed` that surfaced on the first tool call after ~3 minutes of session idle.
- **`mnemo_rework_history`** test coverage + STABILITY.md catalogue entry. The tool shipped in v0.31.0 but was missed by that release's catalogue update; tests landed in commit `20203fd`.

This release-prep PR bumps `main.go` to `0.32.0`, updates STABILITY.md, and appends the audit-log entry with `Commit: pending` (real merge hash patched in by the standard follow-up PR after this lands).

## Test plan

- [x] `go build -tags "sqlite_fts5" ./...` clean
- [x] `go test -tags "sqlite_fts5" ./...` passes
- [ ] CI green on the PR branch
- [ ] After merge, follow-up PR rewrites `pending` to the squash-merge hash
- [ ] After merge + tag, release.yml builds binaries and homebrew-releaser updates the tap formula
- [ ] `brew upgrade marcelocantos/tap/mnemo` picks up v0.32.0 locally
