### PR TITLE
Release v0.33.0 — real-time spend signal + Homebrew runtime deps

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -9,7 +9,36 @@ new product. The pre-1.0 period exists to get these surfaces right.
 
 ## Interaction surface catalogue
 
-Snapshot as of v0.32.0.
+Snapshot as of v0.33.0.
+
+**v0.33.0 note**: Cost-tracking trio (🎯T43 🎯T44 🎯T45) plus
+Homebrew formula runtime deps (🎯T47). `mnemo_usage` gains
+`group_by="session"` (per-Claude-Code-session aggregation) and
+`group_by="block"` (Anthropic's 5-hour billing windows aligned to
+UTC hour boundaries — same algorithm ccusage uses); accepts
+`since` / `until` RFC3339 params for sub-day windows that override
+`days`; surfaces a top-level `freshness` field (timestamp of the
+most-recently-ingested assistant message) so polling consumers can
+bound staleness. Each row gains a `source` field
+(`"estimated"` / `"reconciled"` / `"mixed"`) reporting whether the
+cost figure is mnemo's local price-table estimate or reconciled
+against Anthropic's authoritative `/v1/organizations/cost_report`
+admin endpoint. Reconciliation is a background loop (poll-once-per-
+minute when `ANTHROPIC_ADMIN_API_KEY` is set; logs a single warning
+and stays dormant when absent). Schema bumps **22 → 24**: PR #68
+adds `reconciled_costs (date PK, cost_usd, fetched_at)`. T47:
+formula now declares `depends_on "gh"`, `"uv"`, `"tesseract"`,
+`"poppler"`, `"mupdf"` and the launchd service block sets a PATH
+that covers `/opt/homebrew/{bin,sbin}` and the user's
+`.cargo`/`.local`/`.py`/`go`/`.claude/local` bins, so brew-services
+no longer hands the daemon a spartan PATH. Phantom `"serve"` arg
+dropped from the launchd `run` line as a side-effect (also
+satisfies 🎯T39). `diagnose.go`'s daemon-PATH-vs-process-PATH
+delta detection removed (the bug it caught no longer occurs).
+**Stability**: `since`/`until`/`freshness`/`source` are first-cut
+under "Needs review" pending broader real-time-consumer feedback
+(🎯T46 verify); `group_by` block/session boundaries follow ccusage
+and are intended to remain stable.
 
 **v0.32.0 note**: Two-commit reliability/test release. **MCP keepalive**
 (`49e015f`): the local streamable-HTTP server (`:19419`) and the
@@ -316,13 +345,29 @@ review — first release, output format and filters may evolve.
 
 | Parameter | Type | Required | Description | Stability |
 |---|---|---|---|---|
-| `days` | number | no | Recency window in days (default 30) | Stable |
+| `days` | number | no | Recency window in days (default 30); ignored when `since`/`until` is supplied | Stable |
+| `since` | string | no | RFC3339 lower bound; overrides `days` when set | Needs review |
+| `until` | string | no | RFC3339 upper bound; overrides `days` when set | Needs review |
 | `repo` | string | no | Repo filter (name or path fragment) | Stable |
 | `model` | string | no | Model prefix filter (e.g. "claude-opus-4") | Needs review |
-| `group_by` | string | no | Group by: day (default), model, repo | Needs review |
+| `group_by` | string | no | Group by: `day` (default), `model`, `repo`, `session`, `block` | Needs review |
 
 **Added in v0.11.0.** Returns aggregated token usage with cost estimates.
-**Stability**: Needs review — cost model and grouping options may evolve.
+Each row carries a `source` field (`"estimated"` / `"reconciled"` /
+`"mixed"`) reporting how `cost_usd` was computed; `"reconciled"` and
+`"mixed"` rows are present only when `ANTHROPIC_ADMIN_API_KEY` is
+configured and the background reconciler has populated
+`reconciled_costs`. The response includes a top-level `freshness`
+field carrying the timestamp of the most-recently-ingested assistant
+message — consumers polling sub-day windows can use it to bound
+staleness. **v0.33.0 (🎯T43/T44/T45)**: added `since`/`until` for
+sub-day windows; added `group_by="session"` (per-Claude-Code-session
+aggregation) and `group_by="block"` (Anthropic 5-hour billing
+windows aligned to UTC hour boundaries — same algorithm ccusage
+uses); added the `source` and `freshness` fields. **Stability**:
+Needs review — first cut at the real-time-consumer surface
+(🎯T46 verify pending); `group_by` block/session boundaries are
+intended to remain stable.
 
 #### mnemo_skills
 
@@ -831,6 +876,7 @@ dependency and cache TTL are implementation details and may change.
 | `image_ocr` | image_id (PK FK), text, backend (`apple_vision`\|`tesseract`), confidence, error, created_at | Fluid |
 | `image_ocr_fts` | FTS5 on text | Fluid |
 | `image_embeddings` | image_id (PK FK), model, dim, vector (float32 BLOB), error, created_at | Fluid |
+| `reconciled_costs` | date (PK), cost_usd, fetched_at — authoritative per-day USD from Anthropic Cost Admin API; populated only when `ANTHROPIC_ADMIN_API_KEY` is set (🎯T45, v0.33.0) | Needs review |
 
 **Notes**: v0.9.0 added the `entries` table which stores every JSONL line
 as JSONB with 15 virtual columns for high-query fields. All entry types

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -422,3 +422,39 @@ maintenance activities. Append-only — newest entries at the bottom.
   `~/.claude/CLAUDE.md` and `~/.claude/skills/push/SKILL.md` —
   causing more friction than visibility benefit for solo repos.
   Homebrew formula updated.
+
+## 2026-04-27 — /release v0.33.0
+
+- **Commit**: `pending`
+- **Outcome**: Released v0.33.0. **Cost-tracking trio** (#68 —
+  🎯T43/T44/T45): `mnemo_usage` becomes a real-time, reconciled
+  spend signal. New `group_by="session"` aggregates per Claude
+  Code session ID; `group_by="block"` aggregates per Anthropic
+  5-hour billing window (UTC-hour-aligned, ccusage algorithm).
+  `since`/`until` RFC3339 params override `days` for sub-day
+  windows; response carries a top-level `freshness` field so
+  polling consumers can bound staleness (~0.13ms for a 1-min
+  window on a warm index, well under the 250ms acceptance bar).
+  Background reconciler polls Anthropic
+  `/v1/organizations/cost_report` once per minute when
+  `ANTHROPIC_ADMIN_API_KEY` is set; populates new
+  `reconciled_costs` table; per-row `source` field reports
+  `"estimated"`/`"reconciled"`/`"mixed"`. Schema bump 22 → 24
+  (additive). Forked from a claudia broker design discussion
+  2026-04-26. Surfaced (and worked around) one pre-existing
+  latent issue: single-connection pool would have deadlocked a
+  naive two-query Usage() against the GitHub backfill goroutine
+  — reconciled costs are LEFT-JOINed into the main query
+  instead. **Homebrew runtime deps** (#69 — 🎯T47): formula
+  declares `depends_on` for `gh`, `uv`, `tesseract`, `poppler`,
+  `mupdf`; launchd service block sets a PATH covering
+  `/opt/homebrew/{bin,sbin}` and the user's `.cargo`/`.local`/
+  `.py`/`go`/`.claude/local` bins, so brew-services no longer
+  hands the daemon a spartan PATH. Phantom `"serve"` arg
+  dropped from the launchd `run` line as a side-effect (also
+  satisfies 🎯T39). `diagnose.go`'s daemon-PATH-vs-process-PATH
+  delta detection removed (the bug it caught no longer occurs);
+  external-tools check is now a single-PATH probe. Verify
+  checkpoint 🎯T46 raised to gate the trio's end-to-end
+  demonstration; live demo against a real admin key still
+  pending. Homebrew formula updated.

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ Then restart this Claude Code session.`
 var agentsGuide string
 
 const (
-	version              = "0.32.0"
+	version              = "0.33.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
# mnemo v0.33.0 — real-time, reconciled spend signal + Homebrew deps

`mnemo_usage` becomes a real-time spend source for downstream
consumers (claudia broker, dashboards, your own tooling), and the
Homebrew formula now declares all the runtime tools mnemo shells
out to so a fresh `brew install` is self-sufficient.

## Added

- **🎯T43** — `mnemo_usage group_by="session"` aggregates per
  Claude Code session ID; `group_by="block"` aggregates per
  Anthropic 5-hour billing block (UTC-hour-aligned, same algorithm
  ccusage uses).
- **🎯T44** — `mnemo_usage` accepts `since` / `until` RFC3339
  params for sub-day windows, overriding `days` when set. Response
  carries a top-level `freshness` field (timestamp of the
  most-recently-ingested assistant message). Sub-day queries return
  in well under the 250ms acceptance bar (~0.13ms for a 1-min
  window on a warm index).
- **🎯T45** — Background reconciler polls Anthropic's
  `/v1/organizations/cost_report` once per minute when
  `ANTHROPIC_ADMIN_API_KEY` is set; populates a new
  `reconciled_costs` table; per-row `source` field reports
  `"estimated"` / `"reconciled"` / `"mixed"`. Degrades gracefully
  to estimated-only with a single startup warning when no admin
  key is configured.
- **🎯T46** — Verify checkpoint that gates the trio: end-to-end
  demonstration the trio composes into a real-time, reconciled
  spend signal usable by an external broker. Live demonstration
  pending.

## Changed

- **🎯T47** — Homebrew formula declares `depends_on` for
  `gh`, `uv`, `tesseract`, `poppler`, `mupdf`. The launchd
  service block now sets a PATH that covers
  `/opt/homebrew/{bin,sbin}` plus the user's
  `.cargo` / `.local` / `.py` / `go` / `.claude/local` bins, so
  the brew-services daemon resolves all external tools without
  manual `launchctl setenv` workarounds.
- The launchd `run` line drops the phantom `"serve"` arg
  (also satisfies 🎯T39).
- `mnemo diagnose`'s daemon-PATH-vs-process-PATH delta detection
  removed (the bug it caught no longer occurs); the external-tools
  check is now a single-PATH probe.

## Schema

- Bump 22 → 24 (additive: `reconciled_costs`).

## Known issues / deferred

- 🎯T46 live demonstration against a real
  `ANTHROPIC_ADMIN_API_KEY` is the next step — the reconciler's
  exact handling of the Cost Admin API response shape
  (`cost_usd` vs `total_cost`) has a fallback in code but
  hasn't been confirmed against the live endpoint.
