### PR TITLE
🎯T46: emit freshness from group_by=block path

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4768,6 +4768,7 @@ func (s *Store) usageByBlock(
 	}
 
 	var msgs []msgRow
+	var maxTS time.Time
 	for rows.Next() {
 		var tsStr, mdl string
 		var inp, out, cr, cc int64
@@ -4777,6 +4778,9 @@ func (s *Store) usageByBlock(
 		ts, err := parseTimestamp(tsStr)
 		if err != nil {
 			continue
+		}
+		if ts.After(maxTS) {
+			maxTS = ts
 		}
 		msgs = append(msgs, msgRow{ts, mdl, inp, out, cr, cc})
 	}
@@ -4851,6 +4855,9 @@ func (s *Store) usageByBlock(
 	}
 	result.Total.Period = "total"
 	result.Total.Source = "estimated"
+	if !maxTS.IsZero() {
+		result.Freshness = maxTS.UTC().Format(time.RFC3339Nano)
+	}
 
 	return result, nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -2263,6 +2264,19 @@ func TestUsageGroupByBlock(t *testing.T) {
 	// Total messages should equal all 4 assistant messages.
 	if result.Total.Messages != 4 {
 		t.Errorf("expected 4 total messages, got %d", result.Total.Messages)
+	}
+
+	// Freshness must reflect the most-recent assistant timestamp so real-time
+	// consumers (e.g. the claudia broker) can bound indexer lag.
+	if result.Freshness == "" {
+		t.Errorf("expected non-empty freshness for block grouping")
+	} else {
+		ts, err := time.Parse(time.RFC3339Nano, result.Freshness)
+		if err != nil {
+			t.Errorf("freshness not RFC3339Nano: %q (%v)", result.Freshness, err)
+		} else if want := time.Date(2026, 4, 9, 16, 0, 0, 0, time.UTC); !ts.Equal(want) {
+			t.Errorf("freshness = %s, want %s", ts.Format(time.RFC3339), want.Format(time.RFC3339))
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Sets `result.Freshness` on the `group_by=\"block\"` code path so realtime brokers can bound indexer lag — the existing main grouping path does this, but `usageByBlock` was missed.
- Adds a unit-test assertion in `TestUsageGroupByBlock` covering the freshness field.

## Why
While running the 🎯T46 showcase (verify-target for the cost-tracking trio T43/T44/T45) the live `mnemo_usage(group_by=\"block\", since=…, until=…)` response had no `freshness` field, despite the tool's documented contract. Tracked the gap to `internal/store/store.go:usageByBlock` — the per-message scan never recorded the latest timestamp. Surfacing it lets the claudia broker know how far behind the index is for the *current* 5-hour billing block.

## Test plan
- [x] `go test -tags sqlite_fts5 -run TestUsageGroupByBlock ./internal/store/` passes
- [x] `make bullseye` green (fmt, vet, build, tests)
- [ ] After merge + brew install + restart: live `mnemo_usage(group_by=\"block\", …)` returns a `freshness` field matching the most-recent assistant timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)