### PR TITLE
feat: opt-in Obsidian/Logseq vault export (vault_path config)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,22 @@ claude mcp add --scope user --transport http mnemo http://localhost:19419/mcp
 Restart your agent session after registration — tools registered
 mid-session are not picked up.
 
+## Vault export (optional)
+
+Export your knowledge graph as Markdown notes compatible with Obsidian
+and Logseq. Human annotations sync back into mnemo's FTS5 search within
+~2 seconds. Zero overhead when disabled.
+
+Add to `~/.mnemo/config.json` and restart the daemon:
+
+```json
+{
+  "vault_path": "~/Documents/mnemo-vault"
+}
+```
+
+Full setup guide: [`internal/vault/README.md`](internal/vault/README.md)
+
 ## MCP Tools
 
 ### Transcript search and browsing
@@ -236,6 +252,13 @@ mid-session are not picked up.
 | Tool | Description |
 |---|---|
 | `mnemo_restore` | Retrieve compacted context from prior `/clear` boundaries |
+
+### Vault
+
+| Tool | Description |
+|---|---|
+| `mnemo_vault_sync` | Trigger an immediate vault sync (writes all changed notes to `vault_path`) |
+| `mnemo_vault_status` | Show vault path and current Markdown file count |
 
 For full parameter documentation, see [`agents-guide.md`](agents-guide.md)
 or run `mnemo --help-agent`.

--- a/diagnose.go
+++ b/diagnose.go
@@ -607,8 +607,26 @@ func checkConfiguration() checkResult {
 			r.add(pathStatus(p))
 		}
 	}
+	if home, err := os.UserHomeDir(); err == nil {
+		if vp := cfg.ResolvedVaultPath(home); vp != "" {
+			count := countMDFilesLocal(vp)
+			r.add(fmt.Sprintf("vault_path: %s (%d .md files)", vp, count))
+		}
+	}
 	r.status = statusOK
 	return r
+}
+
+// countMDFilesLocal counts .md files under root using filepath.WalkDir.
+func countMDFilesLocal(root string) int {
+	count := 0
+	_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+		if err == nil && !d.IsDir() && filepath.Ext(p) == ".md" {
+			count++
+		}
+		return nil
+	})
+	return count
 }
 
 func pathStatus(p string) string {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -133,8 +133,6 @@ func (r *Registry) ForUser(username string) (*store.Store, error) {
 	s.SetWorkspaceRoots(r.cfg.ResolvedWorkspaceRoots())
 	s.SetExtraProjectDirs(r.cfg.ExtraProjectDirs)
 
-	// Build synthesis roots: configured roots plus the vault dir (if
-	// vault is enabled) so human-added vault notes are FTS5-indexed.
 	synthRoots := r.cfg.ResolvedSynthesisRoots()
 	var vaultExp *vault.Exporter
 	if vaultPath := r.cfg.ResolvedVaultPath(home); vaultPath != "" {
@@ -143,7 +141,6 @@ func (r *Registry) ForUser(username string) (*store.Store, error) {
 			slog.Warn("vault: exporter creation failed", "path", vaultPath, "err", err)
 		} else {
 			vaultExp = exp
-			synthRoots = append(synthRoots, vaultPath)
 		}
 	}
 	s.SetSynthesisRoots(synthRoots)
@@ -213,16 +210,19 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 			logger.Error("synthesis ingest failed", "err", err)
 		}
 		// Initial vault sync: materialise all knowledge-graph entities as
-		// Markdown notes. Runs in this goroutine (after ingest, before
-		// Watch) so the SQLite index is fully populated. mtime-based
-		// skip makes subsequent daemon restarts fast. Watch() starts
-		// after sync completes; the typical sync for a fresh vault is
-		// O(seconds), not O(minutes), so Watch delay is acceptable.
+		// Markdown notes. Spawned in its own goroutine so Watch() starts
+		// immediately and live JSONL ingestion is not delayed. The SQLite
+		// index is fully populated at this point (all Ingest* calls above
+		// have completed), so the sync goroutine reads a consistent snapshot.
 		if e.vault != nil {
-			logger.Info("vault: initial sync starting")
-			if err := e.vault.Sync(r.baseCtx); err != nil {
-				logger.Warn("vault: initial sync failed", "err", err)
-			}
+			e.workers.Add(1)
+			go func() {
+				defer e.workers.Done()
+				logger.Info("vault: initial sync starting")
+				if err := e.vault.Sync(r.baseCtx); err != nil {
+					logger.Warn("vault: initial sync failed", "err", err)
+				}
+			}()
 		}
 		if err := e.store.Watch(); err != nil {
 			logger.Error("watcher failed", "err", err)
@@ -250,37 +250,15 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 			}
 		}()
 
-		// Vault file watcher: re-indexes synthesis docs near-instantly
-		// when any .md file in the vault dir is created or modified —
-		// whether by vault.Sync() or by a human editor.
-		//
-		// Uses OS-native events (kqueue/inotify/ReadDirectoryChangesW)
-		// so CPU overhead is ~zero when the vault is idle. Changes are
-		// debounced with a 2-second quiet window to batch bursts from
-		// vault.Sync() writing many files into a single IngestSynthesis.
-		//
-		// Falls back gracefully: if fsnotify init fails the goroutine
-		// logs a warning and exits; IngestSynthesis still runs at the
-		// next daemon restart via the initial ingest goroutine.
+		// Vault file watcher: re-indexes human annotations (content below the
+		// <!-- mnemo:generated --> fence) within ~2 seconds of any .md save.
+		// IngestVaultAnnotations extracts only below-fence content, so
+		// generated blocks are never re-ingested and there is no feedback loop.
 		e.workers.Add(1)
 		go func() {
 			defer e.workers.Done()
 			vaultPath := e.vault.Path()
-
-			// Wait for the vault directory to be created by the initial
-			// Sync() which runs in the ingest goroutine concurrently.
-			waitTick := time.NewTicker(500 * time.Millisecond)
-			defer waitTick.Stop()
-			for {
-				if _, err := os.Stat(vaultPath); err == nil {
-					break
-				}
-				select {
-				case <-r.baseCtx.Done():
-					return
-				case <-waitTick.C:
-				}
-			}
+			// vault.New already called os.MkdirAll; the directory exists.
 
 			fw, err := fsnotify.NewWatcher()
 			if err != nil {
@@ -334,10 +312,10 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 					}
 					logger.Warn("vault: watcher error", "err", err)
 				case <-debounce.C:
-					if err := e.store.IngestSynthesis(); err != nil {
-						logger.Warn("vault: synthesis re-ingest failed", "err", err)
+					if err := e.store.IngestVaultAnnotations(vaultPath); err != nil {
+						logger.Warn("vault: annotation ingest failed", "err", err)
 					}
-					logger.Info("vault: synthesis re-ingested from file change")
+					logger.Info("vault: annotations indexed from file change")
 				}
 			}
 		}()

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -15,6 +15,7 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -219,7 +220,7 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 			go func() {
 				defer e.workers.Done()
 				logger.Info("vault: initial sync starting")
-				if err := e.vault.Sync(r.baseCtx); err != nil {
+				if err := e.vault.Sync(r.baseCtx); err != nil && !errors.Is(err, vault.ErrSyncInFlight) {
 					logger.Warn("vault: initial sync failed", "err", err)
 				}
 			}()
@@ -243,7 +244,7 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 				case <-r.baseCtx.Done():
 					return
 				case <-ticker.C:
-					if err := e.vault.Sync(r.baseCtx); err != nil {
+					if err := e.vault.Sync(r.baseCtx); err != nil && !errors.Is(err, vault.ErrSyncInFlight) {
 						logger.Warn("vault: periodic sync failed", "err", err)
 					}
 				}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -271,10 +271,16 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 			// fsnotify v1.9 does not expose a public WithRecursive option
 			// on all platforms, so we walk and add manually, then
 			// re-add any newly created subdirectory on CREATE events.
+			// Hidden dirs (.obsidian/, .git/, .trash/) are skipped to
+			// avoid wasting inotify slots on Linux and to skip Obsidian
+			// internal-state churn that has no signal for mnemo.
 			addVaultDirs := func(root string) {
 				_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
 					if err != nil || !d.IsDir() {
 						return nil
+					}
+					if p != root && strings.HasPrefix(d.Name(), ".") {
+						return filepath.SkipDir
 					}
 					_ = fw.Add(p)
 					return nil
@@ -296,10 +302,11 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 					if !ok {
 						return
 					}
-					// Watch newly created subdirectories so notes
+					// Watch newly created non-hidden subdirectories so notes
 					// written into new sections are also picked up.
 					if ev.Has(fsnotify.Create) {
-						if fi, err := os.Stat(ev.Name); err == nil && fi.IsDir() {
+						if fi, err := os.Stat(ev.Name); err == nil && fi.IsDir() &&
+							!strings.HasPrefix(filepath.Base(ev.Name), ".") {
 							_ = fw.Add(ev.Name)
 						}
 					}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -19,12 +19,15 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/marcelocantos/mnemo/internal/compact"
 	"github.com/marcelocantos/mnemo/internal/reviewer"
 	"github.com/marcelocantos/mnemo/internal/store"
+	"github.com/marcelocantos/mnemo/internal/vault"
 )
 
 // llmAdapter bridges compact.LLMCaller to reviewer.LLMCaller. The
@@ -67,11 +70,12 @@ type Registry struct {
 	compactorModel string
 }
 
-// userEntry tracks one user's Store plus its background goroutines.
-// workers lets Close wait for them to drain before the Store is
-// actually closed.
+// userEntry tracks one user's Store, optional vault Exporter, and
+// background goroutines. workers lets Close wait for them to drain
+// before the Store is closed.
 type userEntry struct {
 	store   *store.Store
+	vault   *vault.Exporter // nil when vault_path is not configured
 	workers sync.WaitGroup
 }
 
@@ -128,12 +132,38 @@ func (r *Registry) ForUser(username string) (*store.Store, error) {
 	}
 	s.SetWorkspaceRoots(r.cfg.ResolvedWorkspaceRoots())
 	s.SetExtraProjectDirs(r.cfg.ExtraProjectDirs)
-	s.SetSynthesisRoots(r.cfg.ResolvedSynthesisRoots())
 
-	e := &userEntry{store: s}
+	// Build synthesis roots: configured roots plus the vault dir (if
+	// vault is enabled) so human-added vault notes are FTS5-indexed.
+	synthRoots := r.cfg.ResolvedSynthesisRoots()
+	var vaultExp *vault.Exporter
+	if vaultPath := r.cfg.ResolvedVaultPath(home); vaultPath != "" {
+		exp, err := vault.New(s, vaultPath)
+		if err != nil {
+			slog.Warn("vault: exporter creation failed", "path", vaultPath, "err", err)
+		} else {
+			vaultExp = exp
+			synthRoots = append(synthRoots, vaultPath)
+		}
+	}
+	s.SetSynthesisRoots(synthRoots)
+
+	e := &userEntry{store: s, vault: vaultExp}
 	r.stores[username] = e
 	r.startWorkers(username, projectDir, e)
 	return s, nil
+}
+
+// VaultFor returns the vault Exporter for username, or nil when vault is
+// not configured or the user has not yet been initialised. Safe to call
+// concurrently.
+func (r *Registry) VaultFor(username string) *vault.Exporter {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if e, ok := r.stores[username]; ok {
+		return e.vault
+	}
+	return nil
 }
 
 // startWorkers kicks off the per-user ingest / watcher / compactor /
@@ -182,10 +212,136 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 		if err := e.store.IngestSynthesis(); err != nil {
 			logger.Error("synthesis ingest failed", "err", err)
 		}
+		// Initial vault sync: materialise all knowledge-graph entities as
+		// Markdown notes. Runs in this goroutine (after ingest, before
+		// Watch) so the SQLite index is fully populated. mtime-based
+		// skip makes subsequent daemon restarts fast. Watch() starts
+		// after sync completes; the typical sync for a fresh vault is
+		// O(seconds), not O(minutes), so Watch delay is acceptable.
+		if e.vault != nil {
+			logger.Info("vault: initial sync starting")
+			if err := e.vault.Sync(r.baseCtx); err != nil {
+				logger.Warn("vault: initial sync failed", "err", err)
+			}
+		}
 		if err := e.store.Watch(); err != nil {
 			logger.Error("watcher failed", "err", err)
 		}
 	}()
+
+	if e.vault != nil {
+		// Vault periodic sync: materialise new transcript entities as
+		// Markdown every 5 minutes. Does NOT call IngestSynthesis here —
+		// the file watcher below picks up those writes within ~2 seconds.
+		e.workers.Add(1)
+		go func() {
+			defer e.workers.Done()
+			ticker := time.NewTicker(5 * time.Minute)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-r.baseCtx.Done():
+					return
+				case <-ticker.C:
+					if err := e.vault.Sync(r.baseCtx); err != nil {
+						logger.Warn("vault: periodic sync failed", "err", err)
+					}
+				}
+			}
+		}()
+
+		// Vault file watcher: re-indexes synthesis docs near-instantly
+		// when any .md file in the vault dir is created or modified —
+		// whether by vault.Sync() or by a human editor.
+		//
+		// Uses OS-native events (kqueue/inotify/ReadDirectoryChangesW)
+		// so CPU overhead is ~zero when the vault is idle. Changes are
+		// debounced with a 2-second quiet window to batch bursts from
+		// vault.Sync() writing many files into a single IngestSynthesis.
+		//
+		// Falls back gracefully: if fsnotify init fails the goroutine
+		// logs a warning and exits; IngestSynthesis still runs at the
+		// next daemon restart via the initial ingest goroutine.
+		e.workers.Add(1)
+		go func() {
+			defer e.workers.Done()
+			vaultPath := e.vault.Path()
+
+			// Wait for the vault directory to be created by the initial
+			// Sync() which runs in the ingest goroutine concurrently.
+			waitTick := time.NewTicker(500 * time.Millisecond)
+			defer waitTick.Stop()
+			for {
+				if _, err := os.Stat(vaultPath); err == nil {
+					break
+				}
+				select {
+				case <-r.baseCtx.Done():
+					return
+				case <-waitTick.C:
+				}
+			}
+
+			fw, err := fsnotify.NewWatcher()
+			if err != nil {
+				logger.Warn("vault: file watcher init failed", "err", err)
+				return
+			}
+			defer fw.Close()
+
+			// Add vault root and all existing subdirectories.
+			// fsnotify v1.9 does not expose a public WithRecursive option
+			// on all platforms, so we walk and add manually, then
+			// re-add any newly created subdirectory on CREATE events.
+			addVaultDirs := func(root string) {
+				_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+					if err != nil || !d.IsDir() {
+						return nil
+					}
+					_ = fw.Add(p)
+					return nil
+				})
+			}
+			addVaultDirs(vaultPath)
+			logger.Info("vault: file watcher started", "path", vaultPath)
+
+			const quietPeriod = 2 * time.Second
+			debounce := time.NewTimer(quietPeriod)
+			debounce.Stop()
+			defer debounce.Stop()
+
+			for {
+				select {
+				case <-r.baseCtx.Done():
+					return
+				case ev, ok := <-fw.Events:
+					if !ok {
+						return
+					}
+					// Watch newly created subdirectories so notes
+					// written into new sections are also picked up.
+					if ev.Has(fsnotify.Create) {
+						if fi, err := os.Stat(ev.Name); err == nil && fi.IsDir() {
+							_ = fw.Add(ev.Name)
+						}
+					}
+					if strings.HasSuffix(ev.Name, ".md") {
+						debounce.Reset(quietPeriod)
+					}
+				case err, ok := <-fw.Errors:
+					if !ok {
+						return
+					}
+					logger.Warn("vault: watcher error", "err", err)
+				case <-debounce.C:
+					if err := e.store.IngestSynthesis(); err != nil {
+						logger.Warn("vault: synthesis re-ingest failed", "err", err)
+					}
+					logger.Info("vault: synthesis re-ingested from file change")
+				}
+			}
+		}()
+	}
 
 	// Compaction watcher.
 	e.workers.Add(1)

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -44,6 +44,15 @@ type Config struct {
 	// still indexed via WorkspaceRoots + IngestDocs).
 	SynthesisRoots []string `json:"synthesis_roots,omitempty"`
 
+	// VaultPath is the directory where mnemo writes its Markdown knowledge
+	// graph. When set, mnemo continuously exports sessions, decisions,
+	// memories, skills, configs, plans, targets, CI runs, and PRs as
+	// Markdown files compatible with Obsidian and Logseq. Human edits
+	// below the <!-- mnemo:generated --> fence are preserved on re-sync.
+	// Supports ~ for the user's home directory.
+	// When absent or empty, vault export is completely disabled.
+	VaultPath string `json:"vault_path,omitempty"`
+
 	// LinkedInstances declares peer mnemo endpoints to federate with
 	// (🎯T15). Each peer is identified by a https URL and a trusted
 	// peer certificate (either a name resolved under ~/.mnemo/peers/
@@ -208,6 +217,28 @@ func (c Config) ResolvedWorkspaceRoots() []string {
 		return DefaultWorkspaceRoots()
 	}
 	return c.WorkspaceRoots
+}
+
+// ResolvedVaultPath returns VaultPath with ~ expanded using userHome.
+// Returns "" when VaultPath is not set (vault export disabled).
+// userHome is passed in rather than looked up here so ForUser can
+// expand ~ relative to the target user's home directory, not the
+// daemon's own home (relevant on Windows where LocalSystem runs the
+// daemon but a named user's vault path is configured).
+func (c Config) ResolvedVaultPath(userHome string) string {
+	p := c.VaultPath
+	if p == "" {
+		return ""
+	}
+	if userHome != "" {
+		switch {
+		case p == "~":
+			return userHome
+		case strings.HasPrefix(p, "~/"):
+			return filepath.Join(userHome, p[2:])
+		}
+	}
+	return p
 }
 
 // ResolvedSynthesisRoots returns SynthesisRoots with ~ expanded to the

--- a/internal/store/search_merge_test.go
+++ b/internal/store/search_merge_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"testing"
+)
+
+// TestMergeBySourcePercentileInterleaves verifies bug E fix: raw BM25
+// ranks from messages_fts and docs_fts are not directly comparable, so
+// merging by raw rank tends to clump one source above the other. The
+// percentile-based merge interleaves sources so each corpus contributes
+// to the top of the result list in proportion to its own relevance
+// distribution.
+func TestMergeBySourcePercentileInterleaves(t *testing.T) {
+	// Pre-fix behaviour: sorting by raw rank would put all transcripts
+	// (-5..-3) ahead of all vault hits (-2..-1). Post-fix: percentile
+	// rankings tie each source's best/mid/worst, interleaving the slice.
+	in := []SearchResult{
+		{MessageID: 1, Role: "user", Text: "t-best", Rank: -5.0},
+		{MessageID: 2, Role: "user", Text: "t-mid", Rank: -4.0},
+		{MessageID: 3, Role: "user", Text: "t-worst", Rank: -3.0},
+		{MessageID: -1, Role: "vault", Text: "v-best", Rank: -2.0},
+		{MessageID: -2, Role: "vault", Text: "v-mid", Rank: -1.5},
+		{MessageID: -3, Role: "vault", Text: "v-worst", Rank: -1.0},
+	}
+	out := mergeBySourcePercentile(in)
+
+	// Expected order (raw rank breaks percentile ties; transcript -5 beats
+	// vault -2 at percentile 0.0):
+	wantOrder := []string{"t-best", "v-best", "t-mid", "v-mid", "t-worst", "v-worst"}
+	if len(out) != len(wantOrder) {
+		t.Fatalf("len = %d, want %d", len(out), len(wantOrder))
+	}
+	for i, want := range wantOrder {
+		if out[i].Text != want {
+			gotOrder := make([]string, len(out))
+			for j, r := range out {
+				gotOrder[j] = r.Text
+			}
+			t.Errorf("position %d = %q, want %q (full order: %v)",
+				i, out[i].Text, want, gotOrder)
+		}
+	}
+}
+
+// TestMergeBySourcePercentileOnlyOneSource verifies that single-source
+// inputs round-trip unchanged: percentile assignment treats the lone
+// source as one bucket with percentile 0.0 for all entries, and the
+// raw-rank tiebreaker preserves input order.
+func TestMergeBySourcePercentileOnlyOneSource(t *testing.T) {
+	in := []SearchResult{
+		{MessageID: 1, Role: "user", Text: "a", Rank: -3.0},
+		{MessageID: 2, Role: "user", Text: "b", Rank: -2.0},
+		{MessageID: 3, Role: "user", Text: "c", Rank: -1.0},
+	}
+	out := mergeBySourcePercentile(in)
+	for i := range in {
+		if out[i].Text != in[i].Text {
+			t.Errorf("position %d = %q, want %q (no reorder expected)",
+				i, out[i].Text, in[i].Text)
+		}
+	}
+}
+
+// TestMergeBySourcePercentileSingleEach verifies that one-hit-per-source
+// inputs sort by raw rank (since both percentiles are 0.0 and the
+// tiebreaker is raw rank).
+func TestMergeBySourcePercentileSingleEach(t *testing.T) {
+	in := []SearchResult{
+		{MessageID: -1, Role: "vault", Text: "v", Rank: -10.0},
+		{MessageID: 1, Role: "user", Text: "t", Rank: -1.0},
+	}
+	out := mergeBySourcePercentile(in)
+	if out[0].Text != "v" || out[1].Text != "t" {
+		t.Errorf("got [%q, %q], want [v, t] — vault has better raw rank, "+
+			"percentile tie breaks to lower rank", out[0].Text, out[1].Text)
+	}
+}
+
+// TestMergeBySourcePercentileEmpty and TestMergeBySourcePercentileSingle
+// cover the trivial fast paths.
+func TestMergeBySourcePercentileEmpty(t *testing.T) {
+	out := mergeBySourcePercentile(nil)
+	if len(out) != 0 {
+		t.Errorf("nil input must round-trip empty, got len=%d", len(out))
+	}
+}
+
+func TestMergeBySourcePercentileSingle(t *testing.T) {
+	in := []SearchResult{{Role: "user", Text: "only", Rank: -1}}
+	out := mergeBySourcePercentile(in)
+	if len(out) != 1 || out[0].Text != "only" {
+		t.Errorf("single-element input must round-trip, got %v", out)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4084,13 +4084,7 @@ func (s *Store) Search(query string, limit int, sessionType, repoFilter string, 
 		vaultRows.Close()
 	}
 
-	// Sort merged results by BM25 rank (ascending; SQLite FTS5 returns
-	// negative values so lower = better match).
-	if len(results) > 1 {
-		sort.Slice(results, func(i, j int) bool {
-			return results[i].Rank < results[j].Rank
-		})
-	}
+	results = mergeBySourcePercentile(results)
 	if len(results) > limit {
 		results = results[:limit]
 	}
@@ -4115,6 +4109,65 @@ func (s *Store) Search(query string, limit int, sessionType, repoFilter string, 
 	}
 
 	return results, nil
+}
+
+// mergeBySourcePercentile re-orders a mixed slice of transcript and vault
+// search hits so that BM25 ranks are compared on a source-relative scale
+// rather than as raw scores.
+//
+// SQLite FTS5 BM25 scores from messages_fts and docs_fts are NOT directly
+// comparable: BM25 calibrates against the corpus (doc-length distribution
+// and IDF), so a rank of -3.5 from one corpus and -3.5 from the other were
+// computed against different denominators. Sorting by raw rank tends to
+// clump one source above the other regardless of true relevance.
+//
+// Fix: rank each hit by its position within its own source (best=0.0,
+// worst=1.0) and sort the merged slice by that percentile. Raw rank is
+// the tiebreaker so within-source order is preserved. The "vault" role
+// distinguishes vault hits; everything else is treated as a transcript
+// hit.
+func mergeBySourcePercentile(results []SearchResult) []SearchResult {
+	if len(results) <= 1 {
+		return results
+	}
+	percentile := make([]float64, len(results))
+	assignPercentiles := func(matches func(SearchResult) bool) {
+		idxs := make([]int, 0, len(results))
+		for i, r := range results {
+			if matches(r) {
+				idxs = append(idxs, i)
+			}
+		}
+		sort.SliceStable(idxs, func(a, b int) bool {
+			return results[idxs[a]].Rank < results[idxs[b]].Rank
+		})
+		n := len(idxs)
+		for pos, i := range idxs {
+			if n <= 1 {
+				percentile[i] = 0
+				continue
+			}
+			percentile[i] = float64(pos) / float64(n-1)
+		}
+	}
+	assignPercentiles(func(r SearchResult) bool { return r.Role == "vault" })
+	assignPercentiles(func(r SearchResult) bool { return r.Role != "vault" })
+
+	order := make([]int, len(results))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(a, b int) bool {
+		if percentile[order[a]] != percentile[order[b]] {
+			return percentile[order[a]] < percentile[order[b]]
+		}
+		return results[order[a]].Rank < results[order[b]].Rank
+	})
+	sorted := make([]SearchResult, len(results))
+	for i, idx := range order {
+		sorted[i] = results[idx]
+	}
+	return sorted
 }
 
 // fetchContext retrieves messages before or after a given message ID within the same session.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4060,7 +4060,9 @@ func (s *Store) Search(query string, limit int, sessionType, repoFilter string, 
 		ORDER BY rank
 		LIMIT ?
 	`, ftsQuery, limit)
-	if vaultErr == nil {
+	if vaultErr != nil {
+		slog.Warn("vault FTS query failed", "err", vaultErr)
+	} else {
 		for vaultRows.Next() {
 			var docID int64
 			var filePath, content string

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4004,10 +4004,6 @@ func (s *Store) Search(query string, limit int, sessionType, repoFilter string, 
 	}
 	ftsRows.Close()
 
-	if len(hits) == 0 {
-		return nil, nil
-	}
-
 	// Phase 2: enrich hits with message data and apply filters.
 	var results []SearchResult
 	for _, h := range hits {
@@ -4052,10 +4048,61 @@ func (s *Store) Search(query string, limit int, sessionType, repoFilter string, 
 		results = append(results, r)
 	}
 
-	// Fetch context messages for each hit.
-	if (contextBefore > 0 || contextAfter > 0) && len(results) > 0 {
+	// Phase 3: vault annotation hits (human content below the generated fence).
+	// Vault annotations live in the docs table (kind='vault') and are indexed
+	// alongside transcript messages so search surfaces both at once.
+	// repoFilter and sessionType are not applied — annotations are cross-repo.
+	vaultRows, vaultErr := s.db.Query(`
+		SELECT d.id, d.file_path, d.content, f.rank
+		FROM docs d
+		JOIN docs_fts f ON f.rowid = d.id
+		WHERE docs_fts MATCH ? AND d.kind = 'vault'
+		ORDER BY rank
+		LIMIT ?
+	`, ftsQuery, limit)
+	if vaultErr == nil {
+		for vaultRows.Next() {
+			var docID int64
+			var filePath, content string
+			var rank float64
+			if err := vaultRows.Scan(&docID, &filePath, &content, &rank); err != nil {
+				continue
+			}
+			if len(content) > 500 {
+				content = content[:497] + "..."
+			}
+			results = append(results, SearchResult{
+				MessageID: int(-docID), // negative distinguishes from message row IDs
+				SessionID: filePath,
+				Role:      "vault",
+				Text:      content,
+				Rank:      rank,
+			})
+		}
+		vaultRows.Close()
+	}
+
+	// Sort merged results by BM25 rank (ascending; SQLite FTS5 returns
+	// negative values so lower = better match).
+	if len(results) > 1 {
+		sort.Slice(results, func(i, j int) bool {
+			return results[i].Rank < results[j].Rank
+		})
+	}
+	if len(results) > limit {
+		results = results[:limit]
+	}
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	// Fetch context messages for each transcript hit (skip vault entries).
+	if contextBefore > 0 || contextAfter > 0 {
 		for i := range results {
 			r := &results[i]
+			if r.Role == "vault" {
+				continue
+			}
 			if contextBefore > 0 {
 				r.Before = s.fetchContext(r.SessionID, r.MessageID, contextBefore, true, substantiveOnly)
 			}

--- a/internal/store/vault_annotations.go
+++ b/internal/store/vault_annotations.go
@@ -19,25 +19,36 @@ import (
 // must be kept in sync with vault.generatedFence.
 const vaultGeneratedFence = "<!-- mnemo:generated -->"
 
-// belowVaultFence extracts the content below the generated fence in a vault
-// note, trimming leading/trailing whitespace. Returns "" when the file has no
-// fence or no content below it.
-func belowVaultFence(raw string) string {
-	idx := strings.LastIndex(raw, vaultGeneratedFence)
-	if idx < 0 {
-		return ""
+// humanContentOf returns the human-authored portion of a vault Markdown file.
+//
+// Two cases:
+//   - File contains a generated fence (a mnemo-written note): only the content
+//     below the fence is human. Generated blocks above the fence are skipped
+//     to avoid re-ingesting machine output.
+//   - File contains no fence (a user-created standalone .md, e.g. their own
+//     Obsidian/Logseq note dropped into the vault): the whole file is human
+//     content and gets indexed in full.
+//
+// Returns "" when the file is empty or only contains generated content.
+func humanContentOf(raw string) string {
+	if idx := strings.LastIndex(raw, vaultGeneratedFence); idx >= 0 {
+		return strings.TrimSpace(raw[idx+len(vaultGeneratedFence):])
 	}
-	below := strings.TrimSpace(raw[idx+len(vaultGeneratedFence):])
-	return below
+	return strings.TrimSpace(raw)
 }
 
-// IngestVaultAnnotations walks vaultPath and indexes the human-authored
-// content below the <!-- mnemo:generated --> fence in each .md file. Only
-// below-fence content is indexed, so generated blocks (sessions, decisions,
-// plans, …) are never re-ingested — there is no feedback loop.
+// IngestVaultAnnotations walks vaultPath and indexes human-authored content
+// from every .md file:
 //
-// Files with no fence or no human content below the fence are removed from
-// the docs table (kind='vault') so stale rows don't accumulate.
+//   - mnemo-generated notes (with a <!-- mnemo:generated --> fence): only
+//     content BELOW the fence is indexed, so generated blocks (sessions,
+//     decisions, plans, …) are never re-ingested. No feedback loop.
+//   - User-created standalone files (no fence): the whole file is indexed
+//     as human knowledge. This lets users drop their own .md files into the
+//     vault and have them flow into mnemo_search alongside transcripts.
+//
+// Files with no human content are removed from the docs table (kind='vault')
+// so stale rows don't accumulate.
 //
 // Indexed rows use kind='vault' and repo=basename(vaultPath). They appear in
 // SearchDocs(kind="vault") and in the main Search results alongside transcript
@@ -65,7 +76,7 @@ func (s *Store) IngestVaultAnnotations(vaultPath string) error {
 			return nil
 		}
 
-		human := belowVaultFence(string(data))
+		human := humanContentOf(string(data))
 
 		if human == "" {
 			// No human content: remove any previously indexed row.

--- a/internal/store/vault_annotations.go
+++ b/internal/store/vault_annotations.go
@@ -4,6 +4,7 @@
 package store
 
 import (
+	"fmt"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -12,25 +13,21 @@ import (
 	"time"
 )
 
-// vaultGeneratedFencePrefix is the HTML comment prefix that vault.writeNote
-// writes to separate generated content (above) from human annotations (below).
-// Defined here so the store package does not import the vault package.
-const vaultGeneratedFencePrefix = "<!-- mnemo:generated"
+// vaultGeneratedFence is the HTML comment line that vault.writeNote writes
+// to separate generated content (above) from human annotations (below).
+// Duplicated here so the store package does not import the vault package;
+// must be kept in sync with vault.generatedFence.
+const vaultGeneratedFence = "<!-- mnemo:generated -->"
 
 // belowVaultFence extracts the content below the generated fence in a vault
 // note, trimming leading/trailing whitespace. Returns "" when the file has no
 // fence or no content below it.
 func belowVaultFence(raw string) string {
-	idx := strings.LastIndex(raw, vaultGeneratedFencePrefix)
+	idx := strings.LastIndex(raw, vaultGeneratedFence)
 	if idx < 0 {
 		return ""
 	}
-	// Skip to the end of the fence line.
-	lineEnd := strings.IndexByte(raw[idx:], '\n')
-	if lineEnd < 0 {
-		return ""
-	}
-	below := strings.TrimSpace(raw[idx+lineEnd:])
+	below := strings.TrimSpace(raw[idx+len(vaultGeneratedFence):])
 	return below
 }
 
@@ -46,13 +43,19 @@ func belowVaultFence(raw string) string {
 // SearchDocs(kind="vault") and in the main Search results alongside transcript
 // messages.
 func (s *Store) IngestVaultAnnotations(vaultPath string) error {
+	if fi, err := os.Stat(vaultPath); err != nil {
+		return fmt.Errorf("vault: stat %s: %w", vaultPath, err)
+	} else if !fi.IsDir() {
+		return fmt.Errorf("vault: %s is not a directory", vaultPath)
+	}
+
 	s.rwmu.Lock()
 	defer s.rwmu.Unlock()
 
 	vaultRepo := filepath.Base(vaultPath)
 	indexed, skipped, removed := 0, 0, 0
 
-	_ = filepath.WalkDir(vaultPath, func(path string, d fs.DirEntry, err error) error {
+	walkErr := filepath.WalkDir(vaultPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".md") {
 			return nil
 		}
@@ -76,12 +79,19 @@ func (s *Store) IngestVaultAnnotations(vaultPath string) error {
 			return nil
 		}
 
-		hash := contentHash([]byte(human))
-
-		var existingHash string
+		// If an existing row at this file_path is NOT a vault annotation
+		// (e.g. a synthesis doc indexed via IngestDocs), leave it alone —
+		// vault must never clobber a more authoritative doc kind.
+		var existingKind, existingHash string
 		_ = s.db.QueryRow(
-			"SELECT content_hash FROM docs WHERE file_path = ?", path,
-		).Scan(&existingHash)
+			"SELECT kind, content_hash FROM docs WHERE file_path = ?", path,
+		).Scan(&existingKind, &existingHash)
+		if existingKind != "" && existingKind != "vault" {
+			skipped++
+			return nil
+		}
+
+		hash := contentHash([]byte(human))
 		if existingHash == hash {
 			skipped++
 			return nil
@@ -112,6 +122,7 @@ func (s *Store) IngestVaultAnnotations(vaultPath string) error {
 				doc_status   = '',
 				doc_target   = '',
 				doc_source   = ''
+			WHERE docs.kind = 'vault'
 		`, vaultRepo, path, title, human, hash, int64(len(human)), now, now)
 		if err != nil {
 			slog.Error("vault: ingest annotation failed", "file", path, "err", err)
@@ -124,5 +135,5 @@ func (s *Store) IngestVaultAnnotations(vaultPath string) error {
 	slog.Info("vault: annotations ingested",
 		"path", vaultPath,
 		"indexed", indexed, "skipped", skipped, "removed", removed)
-	return nil
+	return walkErr
 }

--- a/internal/store/vault_annotations.go
+++ b/internal/store/vault_annotations.go
@@ -29,10 +29,25 @@ const vaultGeneratedFence = "<!-- mnemo:generated -->"
 //     Obsidian/Logseq note dropped into the vault): the whole file is human
 //     content and gets indexed in full.
 //
+// Fence detection is line-anchored: the fence must be a whole line by
+// itself (modulo trailing whitespace). This avoids treating a user-pasted
+// literal of the fence string (e.g. when quoting mnemo's own docs) as a
+// real fence, which would otherwise hide everything above the pasted copy
+// from indexing.
+//
 // Returns "" when the file is empty or only contains generated content.
 func humanContentOf(raw string) string {
-	if idx := strings.LastIndex(raw, vaultGeneratedFence); idx >= 0 {
-		return strings.TrimSpace(raw[idx+len(vaultGeneratedFence):])
+	end := len(raw)
+	for end > 0 {
+		start := strings.LastIndexByte(raw[:end], '\n') + 1
+		line := strings.TrimRight(raw[start:end], " \t\r")
+		if line == vaultGeneratedFence {
+			return strings.TrimSpace(raw[end:])
+		}
+		if start == 0 {
+			break
+		}
+		end = start - 1
 	}
 	return strings.TrimSpace(raw)
 }

--- a/internal/store/vault_annotations.go
+++ b/internal/store/vault_annotations.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// vaultGeneratedFencePrefix is the HTML comment prefix that vault.writeNote
+// writes to separate generated content (above) from human annotations (below).
+// Defined here so the store package does not import the vault package.
+const vaultGeneratedFencePrefix = "<!-- mnemo:generated"
+
+// belowVaultFence extracts the content below the generated fence in a vault
+// note, trimming leading/trailing whitespace. Returns "" when the file has no
+// fence or no content below it.
+func belowVaultFence(raw string) string {
+	idx := strings.LastIndex(raw, vaultGeneratedFencePrefix)
+	if idx < 0 {
+		return ""
+	}
+	// Skip to the end of the fence line.
+	lineEnd := strings.IndexByte(raw[idx:], '\n')
+	if lineEnd < 0 {
+		return ""
+	}
+	below := strings.TrimSpace(raw[idx+lineEnd:])
+	return below
+}
+
+// IngestVaultAnnotations walks vaultPath and indexes the human-authored
+// content below the <!-- mnemo:generated --> fence in each .md file. Only
+// below-fence content is indexed, so generated blocks (sessions, decisions,
+// plans, …) are never re-ingested — there is no feedback loop.
+//
+// Files with no fence or no human content below the fence are removed from
+// the docs table (kind='vault') so stale rows don't accumulate.
+//
+// Indexed rows use kind='vault' and repo=basename(vaultPath). They appear in
+// SearchDocs(kind="vault") and in the main Search results alongside transcript
+// messages.
+func (s *Store) IngestVaultAnnotations(vaultPath string) error {
+	s.rwmu.Lock()
+	defer s.rwmu.Unlock()
+
+	vaultRepo := filepath.Base(vaultPath)
+	indexed, skipped, removed := 0, 0, 0
+
+	_ = filepath.WalkDir(vaultPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+
+		human := belowVaultFence(string(data))
+
+		if human == "" {
+			// No human content: remove any previously indexed row.
+			if res, err := s.db.Exec(
+				"DELETE FROM docs WHERE file_path = ? AND kind = 'vault'", path,
+			); err == nil {
+				if n, _ := res.RowsAffected(); n > 0 {
+					removed++
+				}
+			}
+			return nil
+		}
+
+		hash := contentHash([]byte(human))
+
+		var existingHash string
+		_ = s.db.QueryRow(
+			"SELECT content_hash FROM docs WHERE file_path = ?", path,
+		).Scan(&existingHash)
+		if existingHash == hash {
+			skipped++
+			return nil
+		}
+
+		rel, _ := filepath.Rel(vaultPath, path)
+		title := extractTitle(human)
+		if title == "" {
+			title = strings.TrimSuffix(rel, ".md")
+		}
+		now := time.Now().Format(time.RFC3339)
+
+		_, err = s.db.Exec(`
+			INSERT INTO docs (repo, file_path, kind, title, content, content_hash,
+				size, mtime, indexed_at, taxonomy, doc_date, doc_status, doc_target, doc_source)
+			VALUES (?, ?, 'vault', ?, ?, ?, ?, ?, ?, '', '', '', '', '')
+			ON CONFLICT(file_path) DO UPDATE SET
+				repo         = excluded.repo,
+				kind         = excluded.kind,
+				title        = excluded.title,
+				content      = excluded.content,
+				content_hash = excluded.content_hash,
+				size         = excluded.size,
+				mtime        = excluded.mtime,
+				indexed_at   = excluded.indexed_at,
+				taxonomy     = '',
+				doc_date     = '',
+				doc_status   = '',
+				doc_target   = '',
+				doc_source   = ''
+		`, vaultRepo, path, title, human, hash, int64(len(human)), now, now)
+		if err != nil {
+			slog.Error("vault: ingest annotation failed", "file", path, "err", err)
+			return nil
+		}
+		indexed++
+		return nil
+	})
+
+	slog.Info("vault: annotations ingested",
+		"path", vaultPath,
+		"indexed", indexed, "skipped", skipped, "removed", removed)
+	return nil
+}

--- a/internal/store/vault_annotations.go
+++ b/internal/store/vault_annotations.go
@@ -66,8 +66,37 @@ func (s *Store) IngestVaultAnnotations(vaultPath string) error {
 	vaultRepo := filepath.Base(vaultPath)
 	indexed, skipped, removed := 0, 0, 0
 
+	// Snapshot existing vault rows so we can prune any whose source file
+	// has been deleted, moved, or now lives outside this vault root (e.g.
+	// after vault_path is reconfigured). Without this, deleting a note
+	// would leave a stale row visible in search.
+	stale := map[string]bool{}
+	if rows, err := s.db.Query(
+		"SELECT file_path FROM docs WHERE kind = 'vault'",
+	); err == nil {
+		for rows.Next() {
+			var p string
+			if rows.Scan(&p) == nil {
+				stale[p] = true
+			}
+		}
+		rows.Close()
+	}
+
 	walkErr := filepath.WalkDir(vaultPath, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".md") {
+		if err != nil {
+			return nil
+		}
+		// Skip hidden dirs (.obsidian/, .git/, .trash/, …) entirely — they
+		// hold tool config and aren't human knowledge. Saves IO + watcher
+		// slots on Linux inotify.
+		if d.IsDir() {
+			if path != vaultPath && strings.HasPrefix(d.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".md") {
 			return nil
 		}
 
@@ -77,6 +106,9 @@ func (s *Store) IngestVaultAnnotations(vaultPath string) error {
 		}
 
 		human := humanContentOf(string(data))
+
+		// This file still exists under the current vault root — don't prune it.
+		delete(stale, path)
 
 		if human == "" {
 			// No human content: remove any previously indexed row.
@@ -142,6 +174,15 @@ func (s *Store) IngestVaultAnnotations(vaultPath string) error {
 		indexed++
 		return nil
 	})
+
+	// Prune rows whose source file no longer exists under this vault root.
+	for p := range stale {
+		if _, err := s.db.Exec(
+			"DELETE FROM docs WHERE file_path = ? AND kind = 'vault'", p,
+		); err == nil {
+			removed++
+		}
+	}
 
 	slog.Info("vault: annotations ingested",
 		"path", vaultPath,

--- a/internal/tools/federated.go
+++ b/internal/tools/federated.go
@@ -62,7 +62,7 @@ func (h *Handler) RegisterFederatedTools(s *mcpserver.MCPServer) {
 				MCPSessionID: req.Header.Get(sessionIDHeader),
 				Username:     UsernameFromContext(ctx),
 			}
-			text, isError, err := h.Call(cc, name, req.GetArguments())
+			text, isError, err := h.Call(ctx, cc, name, req.GetArguments())
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("%s failed: %v", name, err)), nil
 			}

--- a/internal/tools/mcp.go
+++ b/internal/tools/mcp.go
@@ -101,7 +101,7 @@ func (h *Handler) LocalHandler(name string) func(ctx context.Context, req mcp.Ca
 			MCPSessionID: req.Header.Get(sessionIDHeader),
 			Username:     UsernameFromContext(ctx),
 		}
-		text, isError, err := h.Call(cc, name, req.GetArguments())
+		text, isError, err := h.Call(ctx, cc, name, req.GetArguments())
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("%s failed: %v", name, err)), nil
 		}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -7,6 +7,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"path/filepath"
@@ -19,6 +20,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/marcelocantos/mnemo/internal/store"
+	"github.com/marcelocantos/mnemo/internal/vault"
 )
 
 // VaultSyncer is satisfied by *vault.Exporter when vault is configured.
@@ -2074,6 +2076,14 @@ func (h *callHandler) vaultSync() (string, bool, error) {
 	}
 	start := time.Now()
 	if err := h.vault.Sync(h.ctx); err != nil {
+		if errors.Is(err, vault.ErrSyncInFlight) {
+			// Another sync (periodic ticker or initial pass) is already
+			// running. Reporting this honestly is important: a falsely
+			// successful 0s response would mislead callers into thinking
+			// their sync request ran.
+			return fmt.Sprintf("vault sync skipped: another sync is already in flight; this call did not run.\nVault path: %s",
+				h.vault.Path()), false, nil
+		}
 		return fmt.Sprintf("vault sync failed: %v", err), true, nil
 	}
 	return fmt.Sprintf("vault sync complete in %s.\nVault path: %s",

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -654,6 +654,13 @@ func (h *callHandler) search(args map[string]any) (string, bool, error) {
 
 	var b strings.Builder
 	for _, r := range results {
+		// Vault annotation hits use SessionID to carry the file path; render
+		// them as a single "[vault] <path>" header rather than the message
+		// format with empty Project/Timestamp/sessionID fields.
+		if r.Role == "vault" {
+			fmt.Fprintf(&b, ">> [vault] %s\n>> %s\n\n", r.SessionID, r.Text)
+			continue
+		}
 		sid := r.SessionID
 		if len(sid) > 8 {
 			sid = sid[:8]

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -24,8 +24,10 @@ import (
 )
 
 // VaultSyncer is satisfied by *vault.Exporter when vault is configured.
-// Defined here as an interface so the tools package does not import the
-// vault package directly, keeping the dependency graph clean.
+// Defined as an interface so test code can substitute a fake. The tools
+// package does import the vault package solely for vault.ErrSyncInFlight
+// — a one-symbol sentinel needed to distinguish coalesced calls from
+// real errors in the MCP response.
 type VaultSyncer interface {
 	Sync(ctx context.Context) error
 	Path() string

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -64,7 +64,8 @@ func (h *Handler) SetVaultResolver(fn func(string) VaultSyncer) {
 type callHandler struct {
 	mem   store.Backend
 	cc    CallContext
-	vault VaultSyncer // nil when vault is not configured for this user
+	vault VaultSyncer     // nil when vault is not configured for this user
+	ctx   context.Context // request context; honours MCP-caller cancellation
 }
 
 // Definitions returns the MCP tool definitions.
@@ -518,7 +519,7 @@ Vault must be configured via vault_path in ~/.mnemo/config.json.`),
 // header). Most tools ignore it; mnemo_self uses it to bind a Claude
 // Code session to its owning MCP session, which the compactor and
 // mnemo_restore rely on for /clear-boundary context preservation.
-func (h *Handler) Call(cc CallContext, name string, args map[string]any) (string, bool, error) {
+func (h *Handler) Call(ctx context.Context, cc CallContext, name string, args map[string]any) (string, bool, error) {
 	mem, err := h.resolve(cc.Username)
 	if err != nil {
 		return fmt.Sprintf("resolve user %q: %v", cc.Username, err), true, nil
@@ -534,7 +535,7 @@ func (h *Handler) Call(cc CallContext, name string, args map[string]any) (string
 	if h.resolveVault != nil {
 		vs = h.resolveVault(cc.Username)
 	}
-	ch := &callHandler{mem: mem, cc: cc, vault: vs}
+	ch := &callHandler{mem: mem, cc: cc, vault: vs, ctx: ctx}
 	switch name {
 	case "mnemo_search":
 		return ch.search(args)
@@ -2065,7 +2066,7 @@ func (h *callHandler) vaultSync() (string, bool, error) {
 		return vaultNotConfigured, false, nil
 	}
 	start := time.Now()
-	if err := h.vault.Sync(context.Background()); err != nil {
+	if err := h.vault.Sync(h.ctx); err != nil {
 		return fmt.Sprintf("vault sync failed: %v", err), true, nil
 	}
 	return fmt.Sprintf("vault sync complete in %s.\nVault path: %s",

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -5,8 +5,10 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -19,6 +21,14 @@ import (
 	"github.com/marcelocantos/mnemo/internal/store"
 )
 
+// VaultSyncer is satisfied by *vault.Exporter when vault is configured.
+// Defined here as an interface so the tools package does not import the
+// vault package directly, keeping the dependency graph clean.
+type VaultSyncer interface {
+	Sync(ctx context.Context) error
+	Path() string
+}
+
 // Handler handles tool calls, dispatching each incoming call to the
 // per-user Store resolved from the call's Username. The resolver is
 // injected so the tools package does not need to import the
@@ -26,8 +36,9 @@ import (
 // hierarchy in tests and future refactors). seen deduplicates the
 // first-call RecordConnectionOpen per (username, MCP session) pair.
 type Handler struct {
-	resolve func(username string) (store.Backend, error)
-	seen    sync.Map
+	resolve      func(username string) (store.Backend, error)
+	resolveVault func(username string) VaultSyncer // nil when vault disabled
+	seen         sync.Map
 }
 
 // NewHandler creates a tool handler that resolves each call's
@@ -37,6 +48,13 @@ func NewHandler(resolve func(string) (store.Backend, error)) *Handler {
 	return &Handler{resolve: resolve}
 }
 
+// SetVaultResolver configures a per-user vault syncer resolver. Calling
+// this is optional; when not called (or when the resolver returns nil)
+// the vault tools report "vault not configured".
+func (h *Handler) SetVaultResolver(fn func(string) VaultSyncer) {
+	h.resolveVault = fn
+}
+
 // callHandler is the per-call delegate that owns the user-resolved
 // Store for the lifetime of one tool invocation. Every per-tool
 // method is defined on *callHandler so the method bodies read
@@ -44,8 +62,9 @@ func NewHandler(resolve func(string) (store.Backend, error)) *Handler {
 // through every signature. Call() builds the callHandler once and
 // dispatches into the switch.
 type callHandler struct {
-	mem store.Backend
-	cc  CallContext
+	mem   store.Backend
+	cc    CallContext
+	vault VaultSyncer // nil when vault is not configured for this user
 }
 
 // Definitions returns the MCP tool definitions.
@@ -476,6 +495,18 @@ Use this to build a rework diagnosis context: the bullseye_rework tool accepts t
 			mcp.WithString("repo", mcp.Description("Filter by repo name or path fragment (optional).")),
 			mcp.WithNumber("limit", mcp.Description("Max attempts to return (default 20).")),
 		),
+		mcp.NewTool("mnemo_vault_sync",
+			mcp.WithDescription(`Synchronise the vault: write or update Markdown notes for every session, decision, memory, plan, target, CI run, and PR in the knowledge graph, then re-ingest the vault directory so human-added notes and edits are searchable.
+
+Notes whose vault file is already up to date (file mtime > entity timestamp) are skipped, making repeated syncs fast.
+
+Human content added below the <!-- mnemo:generated --> fence in any vault note is preserved across re-syncs and is indexed by mnemo's FTS5 search, feeding back into mnemo's associations.
+
+Vault must be configured via vault_path in ~/.mnemo/config.json.`),
+		),
+		mcp.NewTool("mnemo_vault_status",
+			mcp.WithDescription("Report vault configuration: whether vault is enabled, the vault root path, and a count of notes on disk by section."),
+		),
 	}
 }
 
@@ -498,7 +529,12 @@ func (h *Handler) Call(cc CallContext, name string, args map[string]any) (string
 			mem.RecordConnectionOpen(cc.MCPSessionID, 0, time.Now())
 		}
 	}
-	ch := &callHandler{mem: mem, cc: cc}
+	// Resolve vault syncer for this user (nil when vault not configured).
+	var vs VaultSyncer
+	if h.resolveVault != nil {
+		vs = h.resolveVault(cc.Username)
+	}
+	ch := &callHandler{mem: mem, cc: cc, vault: vs}
 	switch name {
 	case "mnemo_search":
 		return ch.search(args)
@@ -574,6 +610,10 @@ func (h *Handler) Call(cc CallContext, name string, args map[string]any) (string
 		return ch.toolResult(args)
 	case "mnemo_rework_history":
 		return ch.reworkHistory(args)
+	case "mnemo_vault_sync":
+		return ch.vaultSync()
+	case "mnemo_vault_status":
+		return ch.vaultStatus()
 	default:
 		return "", false, fmt.Errorf("unknown tool: %s", name)
 	}
@@ -2015,4 +2055,53 @@ func (h *callHandler) reworkHistory(args map[string]any) (string, bool, error) {
 		b.WriteByte('\n')
 	}
 	return b.String(), false, nil
+}
+
+// vaultNotConfigured is the standard response when vault_path is absent.
+const vaultNotConfigured = "vault not configured. Set vault_path in ~/.mnemo/config.json to enable.\n\nExample:\n  {\"vault_path\": \"~/.mnemo/vault\"}"
+
+func (h *callHandler) vaultSync() (string, bool, error) {
+	if h.vault == nil {
+		return vaultNotConfigured, false, nil
+	}
+	start := time.Now()
+	if err := h.vault.Sync(context.Background()); err != nil {
+		return fmt.Sprintf("vault sync failed: %v", err), true, nil
+	}
+	return fmt.Sprintf("vault sync complete in %s.\nVault path: %s",
+		time.Since(start).Round(time.Millisecond), h.vault.Path()), false, nil
+}
+
+func (h *callHandler) vaultStatus() (string, bool, error) {
+	if h.vault == nil {
+		return vaultNotConfigured, false, nil
+	}
+	vaultPath := h.vault.Path()
+	sections := []string{"sessions", "decisions", "memories", "skills", "configs", "plans", "targets", "ci", "prs", "repos"}
+	var b strings.Builder
+	fmt.Fprintf(&b, "vault path: %s\n\n", vaultPath)
+	b.WriteString("Notes on disk:\n")
+	total := 0
+	for _, sec := range sections {
+		count := countMDFiles(filepath.Join(vaultPath, sec))
+		total += count
+		fmt.Fprintf(&b, "  %-12s %d\n", sec, count)
+	}
+	fmt.Fprintf(&b, "  %-12s %d\n", "total", total)
+	return b.String(), false, nil
+}
+
+// countMDFiles counts *.md files recursively under dir.
+func countMDFiles(dir string) int {
+	count := 0
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() && strings.HasSuffix(d.Name(), ".md") {
+			count++
+		}
+		return nil
+	})
+	return count
 }

--- a/internal/vault/README.md
+++ b/internal/vault/README.md
@@ -71,8 +71,12 @@ brew services restart mnemo
 call `mnemo_vault_status`. It will report the vault path and the number
 of Markdown files written. A freshly populated vault of 200 sessions
 takes under 10 seconds; 5,000 sessions under 2 minutes. Subsequent
-daemon restarts are near-instant because mnemo skips files whose mtime
-is newer than the last message timestamp.
+daemon restarts are near-instant because mnemo embeds the entity
+timestamp in each note and skips files that are already up to date.
+
+mnemo_search results tagged `[vault]` are human annotations — content
+below the `<!-- mnemo:generated -->` fence that was indexed after your
+last save.
 
 Then open the directory in Obsidian (`Open folder as vault`) or Logseq
 (`Add a local graph`). No plugins required — the vault uses only core

--- a/internal/vault/README.md
+++ b/internal/vault/README.md
@@ -1,0 +1,121 @@
+# Vault export (Obsidian / Logseq)
+
+## Why
+
+mnemo's knowledge graph is *wide but shallow*: it captures everything
+automatically but understands nothing. A human knowledge graph is the
+reverse — *deep but narrow*: well-understood, but only what you chose
+to write down.
+
+The vault bridges them. When `vault_path` is set, mnemo continuously
+materialises its SQLite graph as Markdown files. You annotate, connect,
+and extend the notes in Obsidian or Logseq. Those additions are indexed
+by mnemo's FTS5 engine within ~2 seconds of saving — so every
+`mnemo_search` query searches both automated and human content together.
+
+Concrete gains:
+
+- **Context that survives sessions** — decisions, tradeoffs, and
+  lessons learned accumulate in one place, readable without querying
+  mnemo
+- **Serendipitous cross-linking** — annotate a session note in one
+  repo; a future search in a *different* repo surfaces it
+- **Correcting AI blind spots** — mnemo's automated extraction misses
+  nuance. Add context below the fence; it becomes searchable immediately
+- **Human insight amplifies automated signal** — the generated graph
+  grows by itself with every session; you only annotate the parts that
+  matter, with zero maintenance burden on the rest
+
+## What gets exported
+
+```
+<vault_path>/
+├── index.md               — root index (repos + total sessions)
+├── repos/<repo>.md        — per-repo index: recent sessions + decisions
+├── sessions/<repo>/       — one note per session (full conversation)
+├── decisions/<repo>/      — detected proposal + outcome pairs
+├── memories/              — project memory files (globally unique names)
+├── skills/                — skill procedures from ~/.claude/skills/
+├── configs/               — CLAUDE.md project instruction notes
+├── plans/<repo>/          — implementation plans
+├── targets/<repo>/        — convergence targets
+├── ci/<repo>/             — CI run summaries
+└── prs/<repo>/            — pull requests and issues
+```
+
+Each note includes YAML frontmatter (tags, aliases, wikilinks) and a
+`<!-- mnemo:generated -->` fence. Everything above the fence is
+rewritten on each sync; everything below is **yours and is never
+touched**.
+
+## How to enable
+
+Add `vault_path` to `~/.mnemo/config.json`:
+
+```json
+{
+  "vault_path": "~/Documents/mnemo-vault"
+}
+```
+
+`~` expands to your home directory. The directory is created on first
+startup — you don't need to create it manually.
+
+Restart the daemon after changing config:
+
+```bash
+brew services restart mnemo
+```
+
+**Verify it's working** — in any Claude Code session, ask Claude to
+call `mnemo_vault_status`. It will report the vault path and the number
+of Markdown files written. A freshly populated vault of 200 sessions
+takes under 10 seconds; 5,000 sessions under 2 minutes. Subsequent
+daemon restarts are near-instant because mnemo skips files whose mtime
+is newer than the last message timestamp.
+
+Then open the directory in Obsidian (`Open folder as vault`) or Logseq
+(`Add a local graph`). No plugins required — the vault uses only core
+features: YAML frontmatter, `[[wikilinks]]`, and standard Markdown.
+Subsequent syncs run every 5 minutes in the background.
+
+## Human edits
+
+Edit any note freely below the `<!-- mnemo:generated -->` fence:
+
+```markdown
+# My session
+
+*Generated content above — do not edit*
+
+<!-- mnemo:generated -->
+
+## My notes
+
+Worth revisiting — approach has known edge cases with concurrent writes.
+```
+
+mnemo picks up your additions within ~2 seconds (OS-native file
+watcher) and they become searchable via `mnemo_search`.
+
+## Manual sync
+
+In any Claude Code session, ask Claude to call the vault tools:
+
+- `mnemo_vault_sync` — triggers an immediate full sync (writes all
+  changed notes; skips unchanged files)
+- `mnemo_vault_status` — shows vault path and current file count
+
+## Performance
+
+When `vault_path` is **not set**, vault code is entirely inactive — no
+goroutines, no file I/O, zero overhead.
+
+When enabled, the cost is:
+
+- **Initial sync**: scans all indexed entities on startup; mtime-based
+  skipping makes restarts near-instant
+- **Periodic sync**: one `Sync()` call every 5 minutes, writing only
+  changed files
+- **File watcher**: OS-native kqueue/inotify — CPU overhead is ~zero
+  when the vault is idle; fires only on file changes

--- a/internal/vault/README.md
+++ b/internal/vault/README.md
@@ -74,18 +74,16 @@ takes under 10 seconds; 5,000 sessions under 2 minutes. Subsequent
 daemon restarts are near-instant because mnemo embeds the entity
 timestamp in each note and skips files that are already up to date.
 
-mnemo_search results tagged `[vault]` are human annotations — content
-below the `<!-- mnemo:generated -->` fence that was indexed after your
-last save.
-
 Then open the directory in Obsidian (`Open folder as vault`) or Logseq
 (`Add a local graph`). No plugins required — the vault uses only core
 features: YAML frontmatter, `[[wikilinks]]`, and standard Markdown.
 Subsequent syncs run every 5 minutes in the background.
 
-## Human edits
+## Adding human knowledge
 
-Edit any note freely below the `<!-- mnemo:generated -->` fence:
+Two ways to flow content into mnemo's index:
+
+**Annotate generated notes** — edit below the fence:
 
 ```markdown
 # My session
@@ -99,8 +97,15 @@ Edit any note freely below the `<!-- mnemo:generated -->` fence:
 Worth revisiting — approach has known edge cases with concurrent writes.
 ```
 
-mnemo picks up your additions within ~2 seconds (OS-native file
-watcher) and they become searchable via `mnemo_search`.
+**Drop standalone `.md` files anywhere in the vault** — files without
+a `<!-- mnemo:generated -->` fence (your own Obsidian/Logseq notes,
+reading lists, design sketches, …) are indexed in full. mnemo never
+overwrites them; only the directories it creates carry generated content.
+
+Either way, mnemo picks up changes within ~2 seconds (OS-native file
+watcher) and the new content becomes searchable via `mnemo_search`
+results tagged `[vault]`. Deleting a file (or moving it out of the
+vault) removes its index entry on the next sync.
 
 ## Manual sync
 
@@ -117,8 +122,9 @@ goroutines, no file I/O, zero overhead.
 
 When enabled, the cost is:
 
-- **Initial sync**: scans all indexed entities on startup; mtime-based
-  skipping makes restarts near-instant
+- **Initial sync**: scans all indexed entities on startup; an entity
+  timestamp embedded in each note (just above the fence) makes
+  restarts near-instant by skipping unchanged files
 - **Periodic sync**: one `Sync()` call every 5 minutes, writing only
   changed files
 - **File watcher**: OS-native kqueue/inotify — CPU overhead is ~zero

--- a/internal/vault/names.go
+++ b/internal/vault/names.go
@@ -81,6 +81,26 @@ func dateOf(ts string) string {
 	return time.Now().UTC().Format("2006-01-02")
 }
 
+// timeOfDay extracts HH:MM:SS from an RFC3339 timestamp like
+// "2026-05-10T14:23:45Z" → "14:23:45". The session date is shown once in
+// the note header so per-message timestamps only need the time component.
+// Falls back to the full input when the format doesn't match.
+func timeOfDay(ts string) string {
+	if len(ts) >= 19 && ts[10] == 'T' {
+		return ts[11:19]
+	}
+	return ts
+}
+
+// pluralize formats "<n> <noun>" with a trailing s when n != 1. Keeps
+// human-facing counts grammatically correct in repo/index metadata lines.
+func pluralize(n int, noun string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, noun)
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
+}
+
 // shortID returns the first min(8, len(id)) characters of id.
 func shortID(id string) string {
 	if len(id) > 8 {

--- a/internal/vault/names.go
+++ b/internal/vault/names.go
@@ -1,0 +1,230 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package vault
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/marcelocantos/mnemo/internal/store"
+)
+
+var (
+	nonAlphanumRE      = regexp.MustCompile(`[^a-z0-9]+`)
+	usersHomePrefixRE  = regexp.MustCompile(`^users-[^-]+-(.+)$`)
+)
+
+// slugify creates a filename-safe slug from s: lowercase, non-alphanumeric
+// runs replaced with single hyphens, leading/trailing hyphens removed,
+// capped at 60 characters.
+func slugify(s string) string {
+	s = strings.ToLower(s)
+	s = nonAlphanumRE.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	if len(s) > 60 {
+		s = strings.TrimRight(s[:60], "-")
+	}
+	if s == "" {
+		return "untitled"
+	}
+	return s
+}
+
+// shortProjectName returns a human-readable short name from a project path.
+//
+//   - Absolute paths ("/Users/alice/dev/myapp") → last component ("myapp")
+//   - Claude project strings ("-Users-alice-dev-myapp") → strips the home-dir
+//     prefix and one common intermediate segment (dev, documents, work, home)
+//     to expose the meaningful leaf name ("myapp")
+//
+// Unlike slugify, there is no length cap so the full leaf name is preserved.
+func shortProjectName(s string) string {
+	if strings.HasPrefix(s, "/") {
+		base := filepath.Base(s)
+		if base != "" && base != "." && base != "/" {
+			return slugify(base)
+		}
+	}
+	// Normalise without length cap.
+	slug := strings.ToLower(s)
+	slug = nonAlphanumRE.ReplaceAllString(slug, "-")
+	slug = strings.Trim(slug, "-")
+	if slug == "" {
+		return "untitled"
+	}
+	// Strip "users-<username>-" produced by Claude's project-dir encoding.
+	if m := usersHomePrefixRE.FindStringSubmatch(slug); m != nil {
+		rest := m[1]
+		for _, pfx := range []string{"dev-", "documents-", "work-", "home-", "projects-", "code-", "repos-", "src-"} {
+			if strings.HasPrefix(rest, pfx) && len(rest) > len(pfx) {
+				rest = rest[len(pfx):]
+				break
+			}
+		}
+		if rest != "" {
+			return rest
+		}
+	}
+	return slug
+}
+
+// dateOf extracts the YYYY-MM-DD date from an RFC3339 timestamp string.
+// Returns today's UTC date when ts is empty or shorter than 10 chars.
+func dateOf(ts string) string {
+	if len(ts) >= 10 {
+		return ts[:10]
+	}
+	return time.Now().UTC().Format("2006-01-02")
+}
+
+// shortID returns the first min(8, len(id)) characters of id.
+func shortID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}
+
+// sessionPath returns the vault-relative file path for a session note.
+// Format: sessions/<repo-slug>/YYYY-MM-DD-<topic-slug>-<id8>.md
+func sessionPath(info store.SessionInfo) string {
+	repo := repoSlugFor(info)
+	date := dateOf(info.FirstMsg)
+	topic := info.Topic
+	if topic == "" {
+		topic = "session"
+	}
+	name := date + "-" + slugify(topic) + "-" + shortID(info.SessionID)
+	return filepath.Join("sessions", repo, name+".md")
+}
+
+// decisionPath returns the vault-relative file path for a decision note.
+// Format: decisions/<short-repo>/YYYY-MM-DD-<session-id8>.md
+func decisionPath(d store.DecisionInfo) string {
+	repo := decisionRepoSlug(d.Repo)
+	date := dateOf(d.Timestamp)
+	return filepath.Join("decisions", repo, date+"-"+shortID(d.SessionID)+".md")
+}
+
+// memoryPath returns the vault-relative path for a memory note.
+// Format: memories/<short-project>-<name-slug>.md
+//
+// Flat (no subdirectory) so that every file in the vault has a globally
+// unique stem — Obsidian uses the filename as the page title for wikilinks
+// and warns when two files share a title regardless of their directory.
+func memoryPath(m store.MemoryInfo) string {
+	proj := shortProjectName(m.Project)
+	if proj == "" || proj == "untitled" {
+		proj = "unknown"
+	}
+	name := slugify(m.Name)
+	if name == "" || name == "untitled" {
+		name = "memory"
+	}
+	return filepath.Join("memories", proj+"-"+name+".md")
+}
+
+// planPath returns the vault-relative path for a plan note.
+// Format: plans/<short-repo>-<file-base-slug>.md
+//
+// Flat so plan files from different repos with the same base name don't clash.
+func planPath(p store.PlanInfo) string {
+	repo := shortProjectName(p.Repo)
+	if repo == "" || repo == "untitled" {
+		repo = "unknown"
+	}
+	base := strings.TrimSuffix(filepath.Base(p.FilePath), ".md")
+	if base == "" {
+		base = "plan"
+	}
+	return filepath.Join("plans", repo+"-"+slugify(base)+".md")
+}
+
+// targetPath returns the vault-relative path for a convergence target note.
+// Format: targets/<short-repo>/<target-id-slug>.md
+func targetPath(t store.TargetInfo) string {
+	repo := shortProjectName(t.Repo)
+	if repo == "" || repo == "untitled" {
+		repo = "unknown"
+	}
+	id := slugify(t.TargetID)
+	if id == "" || id == "untitled" {
+		id = fmt.Sprintf("target-%d", t.ID)
+	}
+	return filepath.Join("targets", repo, id+".md")
+}
+
+// ciRunPath returns the vault-relative path for a CI run note.
+// Format: ci/<short-repo>/YYYY-MM-DD-<workflow-slug>-<run-id mod 10000>.md
+func ciRunPath(r store.CIRun) string {
+	repo := shortProjectName(r.Repo)
+	if repo == "" || repo == "untitled" {
+		repo = "unknown"
+	}
+	date := dateOf(r.StartedAt)
+	name := fmt.Sprintf("%s-%s-%04d", date, slugify(r.Workflow), r.RunID%10000)
+	return filepath.Join("ci", repo, name+".md")
+}
+
+// prPath returns the vault-relative path for a PR or issue note.
+// Format: prs/<short-repo>/YYYY-MM-DD-<type>-<number>-<title-slug>.md
+func prPath(r store.GitHubActivityResult) string {
+	repo := shortProjectName(r.Repo)
+	if repo == "" || repo == "untitled" {
+		repo = "unknown"
+	}
+	date := dateOf(r.CreatedAt)
+	name := fmt.Sprintf("%s-%s-%d-%s", date, r.Type, r.Number, slugify(r.Title))
+	return filepath.Join("prs", repo, name+".md")
+}
+
+// repoIndexPath returns the vault-relative path for a repo index note.
+// Format: repos/<short-repo>.md
+func repoIndexPath(repo string) string {
+	return filepath.Join("repos", shortProjectName(repo)+".md")
+}
+
+// skillPath returns the vault-relative path for a skill note.
+// Format: skills/<name-slug>.md
+// Flat (global) since skills live in ~/.claude/skills/ with no repo grouping.
+func skillPath(s store.SkillInfo) string {
+	name := slugify(s.Name)
+	if name == "" || name == "untitled" {
+		name = "skill"
+	}
+	return filepath.Join("skills", name+".md")
+}
+
+// configPath returns the vault-relative path for a CLAUDE.md config note.
+// Format: configs/<short-repo>.md
+func configPath(c store.ClaudeConfigInfo) string {
+	repo := shortProjectName(c.Repo)
+	if repo == "" || repo == "untitled" {
+		repo = "global"
+	}
+	return filepath.Join("configs", repo+".md")
+}
+
+// repoSlugFor extracts a human-readable short slug from a SessionInfo's Repo
+// field, falling back to Project then "unknown".
+func repoSlugFor(info store.SessionInfo) string {
+	if info.Repo != "" {
+		return shortProjectName(info.Repo)
+	}
+	if info.Project != "" {
+		return shortProjectName(info.Project)
+	}
+	return "unknown"
+}
+
+// decisionRepoSlug extracts a human-readable short slug for a decision's repo.
+func decisionRepoSlug(repo string) string {
+	if repo == "" {
+		return "unknown"
+	}
+	return shortProjectName(repo)
+}

--- a/internal/vault/note.go
+++ b/internal/vault/note.go
@@ -1,0 +1,535 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package vault
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/marcelocantos/mnemo/internal/store"
+)
+
+// renderSession produces a complete Markdown note for a session.
+// The note includes YAML frontmatter, a metadata header with repo
+// wikilink, and the full conversation formatted as Human/Claude blocks.
+func renderSession(info store.SessionInfo, msgs []store.SessionMessage) string {
+	var b strings.Builder
+
+	// --- YAML frontmatter ---
+	b.WriteString("---\n")
+	writeYAML(&b, "session_id", info.SessionID)
+	writeYAML(&b, "repo", info.Repo)
+	writeYAML(&b, "project", info.Project)
+	writeYAML(&b, "date", dateOf(info.FirstMsg))
+	writeYAML(&b, "first_message", info.FirstMsg)
+	writeYAML(&b, "last_message", info.LastMsg)
+	if info.Topic != "" {
+		writeYAML(&b, "topic", info.Topic)
+	}
+	if info.WorkType != "" {
+		writeYAML(&b, "work_type", info.WorkType)
+	}
+	if info.GitBranch != "" {
+		writeYAML(&b, "git_branch", info.GitBranch)
+	}
+	// Obsidian aliases: lets users find the session by topic without
+	// knowing the session ID; the short ID is always included as fallback.
+	b.WriteString("aliases:\n")
+	if info.Topic != "" {
+		fmt.Fprintf(&b, "  - \"%s\"\n", strings.ReplaceAll(info.Topic, `"`, `\"`))
+	}
+	fmt.Fprintf(&b, "  - \"%s\"\n", shortID(info.SessionID))
+	b.WriteString("tags:\n")
+	b.WriteString("  - session\n")
+	if r := shortProjectName(info.Repo); r != "" && r != "untitled" && r != "unknown" {
+		fmt.Fprintf(&b, "  - %s\n", r)
+	}
+	if info.WorkType != "" {
+		fmt.Fprintf(&b, "  - %s\n", slugify(info.WorkType))
+	}
+	b.WriteString("---\n\n")
+
+	// --- Title ---
+	title := info.Topic
+	if title == "" {
+		title = "Session " + shortID(info.SessionID)
+	}
+	fmt.Fprintf(&b, "# %s\n\n", title)
+
+	// --- Metadata line ---
+	meta := fmt.Sprintf("*`%s` · %s", shortID(info.SessionID), dateOf(info.FirstMsg))
+	if info.Repo != "" {
+		meta += fmt.Sprintf(" · [[repos/%s]]", shortProjectName(info.Repo))
+	}
+	if info.WorkType != "" {
+		meta += fmt.Sprintf(" · %s", info.WorkType)
+	}
+	meta += "*"
+	fmt.Fprintf(&b, "%s\n\n", meta)
+
+	// --- Conversation ---
+	substantive := 0
+	for _, msg := range msgs {
+		if !msg.IsNoise {
+			substantive++
+		}
+	}
+	if substantive > 0 {
+		b.WriteString("## Conversation\n\n")
+		for _, msg := range msgs {
+			if msg.IsNoise {
+				continue
+			}
+			role := "Human"
+			if msg.Role == "assistant" {
+				role = "Claude"
+			}
+			fmt.Fprintf(&b, "---\n\n**%s** · *%s*\n\n%s\n\n", role, msg.Timestamp, msg.Text)
+		}
+	}
+
+	return b.String()
+}
+
+// renderDecision produces a Markdown note for a detected decision.
+func renderDecision(d store.DecisionInfo, sessionRelPath string) string {
+	var b strings.Builder
+
+	b.WriteString("---\n")
+	writeYAML(&b, "session_id", d.SessionID)
+	writeYAML(&b, "repo", d.Repo)
+	writeYAML(&b, "date", dateOf(d.Timestamp))
+	writeYAML(&b, "timestamp", d.Timestamp)
+	b.WriteString("tags:\n")
+	b.WriteString("  - decision\n")
+	if r := shortProjectName(d.Repo); r != "" && r != "untitled" && r != "unknown" {
+		fmt.Fprintf(&b, "  - %s\n", r)
+	}
+	b.WriteString("---\n\n")
+
+	fmt.Fprintf(&b, "# Decision · %s\n\n", dateOf(d.Timestamp))
+
+	if sessionRelPath != "" {
+		link := strings.TrimSuffix(filepath.ToSlash(sessionRelPath), ".md")
+		fmt.Fprintf(&b, "*From [[%s]]*\n\n", link)
+	} else {
+		fmt.Fprintf(&b, "*From session `%s`*\n\n", shortID(d.SessionID))
+	}
+
+	b.WriteString("## Proposal\n\n")
+	b.WriteString(strings.TrimSpace(d.ProposalText))
+	b.WriteString("\n\n")
+
+	b.WriteString("## Outcome\n\n")
+	b.WriteString(strings.TrimSpace(d.ConfirmationText))
+	b.WriteString("\n\n")
+
+	return b.String()
+}
+
+// renderMemory produces a Markdown note for an indexed memory file.
+func renderMemory(m store.MemoryInfo) string {
+	var b strings.Builder
+
+	b.WriteString("---\n")
+	writeYAML(&b, "project", m.Project)
+	writeYAML(&b, "name", m.Name)
+	writeYAML(&b, "memory_type", m.MemoryType)
+	writeYAML(&b, "updated_at", m.UpdatedAt)
+	if m.Description != "" {
+		writeYAML(&b, "description", m.Description)
+	}
+	b.WriteString("tags:\n")
+	b.WriteString("  - memory\n")
+	if r := shortProjectName(m.Project); r != "" && r != "untitled" {
+		fmt.Fprintf(&b, "  - %s\n", r)
+	}
+	if m.MemoryType != "" {
+		fmt.Fprintf(&b, "  - memory-%s\n", slugify(m.MemoryType))
+	}
+	b.WriteString("---\n\n")
+
+	name := m.Name
+	if name == "" {
+		name = "Memory"
+	}
+	fmt.Fprintf(&b, "# %s\n\n", name)
+
+	if m.Project != "" {
+		fmt.Fprintf(&b, "*Project: `%s` · [[repos/%s]]*\n\n", m.Project, shortProjectName(m.Project))
+	}
+
+	b.WriteString(strings.TrimSpace(m.Content))
+	b.WriteString("\n\n")
+
+	return b.String()
+}
+
+// renderPlan produces a Markdown note for an indexed plan file.
+func renderPlan(p store.PlanInfo) string {
+	var b strings.Builder
+
+	b.WriteString("---\n")
+	writeYAML(&b, "repo", p.Repo)
+	writeYAML(&b, "file_path", p.FilePath)
+	writeYAML(&b, "phase", p.Phase)
+	writeYAML(&b, "updated_at", p.UpdatedAt)
+	b.WriteString("tags:\n")
+	b.WriteString("  - plan\n")
+	if r := shortProjectName(p.Repo); r != "" && r != "untitled" {
+		fmt.Fprintf(&b, "  - %s\n", r)
+	}
+	b.WriteString("---\n\n")
+
+	base := strings.TrimSuffix(filepath.Base(p.FilePath), ".md")
+	if base == "" {
+		base = "Plan"
+	}
+	fmt.Fprintf(&b, "# Plan: %s\n\n", base)
+
+	if p.Repo != "" {
+		fmt.Fprintf(&b, "*Repo: [[repos/%s]]", shortProjectName(p.Repo))
+		if p.Phase != "" {
+			fmt.Fprintf(&b, " · Phase: %s", p.Phase)
+		}
+		b.WriteString("*\n\n")
+	}
+
+	b.WriteString(strings.TrimSpace(p.Content))
+	b.WriteString("\n\n")
+
+	return b.String()
+}
+
+// renderTarget produces a Markdown note for a convergence target.
+func renderTarget(t store.TargetInfo) string {
+	var b strings.Builder
+
+	b.WriteString("---\n")
+	writeYAML(&b, "repo", t.Repo)
+	writeYAML(&b, "target_id", t.TargetID)
+	writeYAML(&b, "name", t.Name)
+	writeYAML(&b, "status", t.Status)
+	fmt.Fprintf(&b, "weight: %.1f\n", t.Weight)
+	b.WriteString("tags:\n")
+	b.WriteString("  - target\n")
+	if r := shortProjectName(t.Repo); r != "" && r != "untitled" {
+		fmt.Fprintf(&b, "  - %s\n", r)
+	}
+	if t.Status != "" {
+		fmt.Fprintf(&b, "  - target-%s\n", slugify(t.Status))
+	}
+	b.WriteString("---\n\n")
+
+	fmt.Fprintf(&b, "# %s: %s\n\n", t.TargetID, t.Name)
+
+	fmt.Fprintf(&b, "*Repo: [[repos/%s]] · Status: **%s** · Weight: %.1f*\n\n",
+		shortProjectName(t.Repo), t.Status, t.Weight)
+
+	if t.Description != "" {
+		b.WriteString(strings.TrimSpace(t.Description))
+		b.WriteString("\n\n")
+	}
+
+	return b.String()
+}
+
+// renderCIRun produces a Markdown note for a CI run.
+func renderCIRun(r store.CIRun) string {
+	var b strings.Builder
+
+	b.WriteString("---\n")
+	writeYAML(&b, "repo", r.Repo)
+	fmt.Fprintf(&b, "run_id: %d\n", r.RunID)
+	writeYAML(&b, "workflow", r.Workflow)
+	writeYAML(&b, "branch", r.Branch)
+	writeYAML(&b, "commit_sha", r.CommitSHA)
+	writeYAML(&b, "status", r.Status)
+	writeYAML(&b, "conclusion", r.Conclusion)
+	writeYAML(&b, "started_at", r.StartedAt)
+	writeYAML(&b, "completed_at", r.CompletedAt)
+	writeYAML(&b, "url", r.URL)
+	b.WriteString("tags:\n")
+	b.WriteString("  - ci\n")
+	if repo := shortProjectName(r.Repo); repo != "" && repo != "untitled" {
+		fmt.Fprintf(&b, "  - %s\n", repo)
+	}
+	if r.Conclusion != "" {
+		fmt.Fprintf(&b, "  - ci-%s\n", slugify(r.Conclusion))
+	}
+	b.WriteString("---\n\n")
+
+	label := r.Conclusion
+	if label == "" {
+		label = r.Status
+	}
+	fmt.Fprintf(&b, "# CI: %s (%s)\n\n", r.Workflow, label)
+
+	fmt.Fprintf(&b, "*Repo: [[repos/%s]] · Branch: `%s` · %s*\n\n",
+		shortProjectName(r.Repo), r.Branch, r.StartedAt)
+
+	if r.LogSummary != "" {
+		b.WriteString("## Log summary\n\n")
+		b.WriteString(strings.TrimSpace(r.LogSummary))
+		b.WriteString("\n\n")
+	}
+
+	if r.URL != "" {
+		fmt.Fprintf(&b, "[View run on GitHub](%s)\n\n", r.URL)
+	}
+
+	return b.String()
+}
+
+// renderPR produces a Markdown note for a GitHub PR or issue.
+func renderPR(r store.GitHubActivityResult) string {
+	var b strings.Builder
+
+	b.WriteString("---\n")
+	writeYAML(&b, "repo", r.Repo)
+	writeYAML(&b, "type", r.Type)
+	fmt.Fprintf(&b, "number: %d\n", r.Number)
+	writeYAML(&b, "title", r.Title)
+	writeYAML(&b, "state", r.State)
+	writeYAML(&b, "author", r.Author)
+	writeYAML(&b, "created_at", r.CreatedAt)
+	writeYAML(&b, "updated_at", r.UpdatedAt)
+	if r.MergedAt != "" {
+		writeYAML(&b, "merged_at", r.MergedAt)
+	}
+	writeYAML(&b, "url", r.URL)
+	b.WriteString("tags:\n")
+	if r.Type != "" {
+		fmt.Fprintf(&b, "  - %s\n", r.Type)
+	}
+	if repo := shortProjectName(r.Repo); repo != "" && repo != "untitled" {
+		fmt.Fprintf(&b, "  - %s\n", repo)
+	}
+	if r.Type != "" && r.State != "" {
+		fmt.Fprintf(&b, "  - %s-%s\n", r.Type, slugify(r.State))
+	}
+	b.WriteString("---\n\n")
+
+	kind := "PR"
+	if r.Type == "issue" {
+		kind = "Issue"
+	}
+	fmt.Fprintf(&b, "# %s #%d: %s\n\n", kind, r.Number, r.Title)
+
+	fmt.Fprintf(&b, "*Repo: [[repos/%s]] · %s · by @%s · %s*\n\n",
+		shortProjectName(r.Repo), r.State, r.Author, r.CreatedAt)
+
+	if r.Body != "" {
+		b.WriteString(strings.TrimSpace(r.Body))
+		b.WriteString("\n\n")
+	}
+
+	if r.URL != "" {
+		fmt.Fprintf(&b, "[View on GitHub](%s)\n\n", r.URL)
+	}
+
+	return b.String()
+}
+
+// renderSkill produces a Markdown note for a skill file.
+func renderSkill(s store.SkillInfo) string {
+	var b strings.Builder
+
+	b.WriteString("---\n")
+	writeYAML(&b, "name", s.Name)
+	writeYAML(&b, "file_path", s.FilePath)
+	writeYAML(&b, "updated_at", s.UpdatedAt)
+	if s.Description != "" {
+		writeYAML(&b, "description", s.Description)
+	}
+	b.WriteString("tags:\n")
+	b.WriteString("  - skill\n")
+	b.WriteString("---\n\n")
+
+	name := s.Name
+	if name == "" {
+		name = filepath.Base(s.FilePath)
+	}
+	fmt.Fprintf(&b, "# Skill: %s\n\n", name)
+
+	if s.Description != "" {
+		fmt.Fprintf(&b, "*%s*\n\n", s.Description)
+	}
+
+	b.WriteString(strings.TrimSpace(s.Content))
+	b.WriteString("\n\n")
+
+	return b.String()
+}
+
+// renderConfig produces a Markdown note for a CLAUDE.md config file.
+func renderConfig(c store.ClaudeConfigInfo) string {
+	var b strings.Builder
+
+	b.WriteString("---\n")
+	writeYAML(&b, "repo", c.Repo)
+	writeYAML(&b, "file_path", c.FilePath)
+	writeYAML(&b, "updated_at", c.UpdatedAt)
+	b.WriteString("tags:\n")
+	b.WriteString("  - config\n")
+	b.WriteString("  - claude-md\n")
+	if r := shortProjectName(c.Repo); r != "" && r != "untitled" && r != "global" {
+		fmt.Fprintf(&b, "  - %s\n", r)
+	}
+	b.WriteString("---\n\n")
+
+	title := shortProjectName(c.Repo)
+	if title == "" || title == "untitled" {
+		title = "global"
+	}
+	fmt.Fprintf(&b, "# CLAUDE.md: %s\n\n", title)
+
+	if c.Repo != "" {
+		fmt.Fprintf(&b, "*Repo: [[repos/%s]]*\n\n", shortProjectName(c.Repo))
+	} else {
+		fmt.Fprintf(&b, "*Global config (`~/.claude/CLAUDE.md`)*\n\n")
+	}
+
+	b.WriteString(strings.TrimSpace(c.Content))
+	b.WriteString("\n\n")
+
+	return b.String()
+}
+
+// renderRepoIndex produces the Markdown index note for a single repository.
+func renderRepoIndex(repo store.RepoInfo, sessions []store.SessionInfo, decisions []store.DecisionInfo, sessionPaths map[string]string) string {
+	var b strings.Builder
+
+	b.WriteString("---\n")
+	writeYAML(&b, "repo", repo.Repo)
+	writeYAML(&b, "path", repo.Path)
+	writeYAML(&b, "last_activity", repo.LastActivity)
+	fmt.Fprintf(&b, "sessions: %d\n", repo.Sessions)
+	b.WriteString("tags:\n")
+	b.WriteString("  - repo\n")
+	b.WriteString("  - index\n")
+	if r := shortProjectName(repo.Repo); r != "" && r != "untitled" {
+		fmt.Fprintf(&b, "  - %s\n", r)
+	}
+	b.WriteString("---\n\n")
+
+	fmt.Fprintf(&b, "# %s\n\n", repo.Repo)
+
+	meta := fmt.Sprintf("*Path: `%s` · %d sessions · last active %s*",
+		repo.Path, repo.Sessions, repo.LastActivity)
+	fmt.Fprintf(&b, "%s\n\n", meta)
+
+	if repo.Summary != "" {
+		b.WriteString(repo.Summary)
+		b.WriteString("\n\n")
+	}
+
+	if len(sessions) > 0 {
+		b.WriteString("## Recent sessions\n\n")
+		for _, s := range sessions {
+			p, ok := sessionPaths[s.SessionID]
+			if !ok {
+				p = sessionPath(s)
+			}
+			link := strings.TrimSuffix(filepath.ToSlash(p), ".md")
+			topic := s.Topic
+			if topic == "" {
+				topic = shortID(s.SessionID)
+			}
+			fmt.Fprintf(&b, "- [[%s]] — %s\n", link, topic)
+		}
+		b.WriteString("\n")
+	}
+
+	if len(decisions) > 0 {
+		b.WriteString("## Recent decisions\n\n")
+		for _, d := range decisions {
+			p := strings.TrimSuffix(filepath.ToSlash(decisionPath(d)), ".md")
+			summary := summarize(d.ProposalText, 80)
+			fmt.Fprintf(&b, "- [[%s]] — %s\n", p, summary)
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// renderRootIndex produces the vault root _index.md.
+func renderRootIndex(repos []store.RepoInfo, stats *store.StatsResult) string {
+	var b strings.Builder
+
+	b.WriteString("---\n")
+	b.WriteString("tags:\n")
+	b.WriteString("  - mnemo\n")
+	b.WriteString("  - index\n")
+	b.WriteString("  - vault\n")
+	b.WriteString("---\n\n")
+
+	b.WriteString("# mnemo knowledge vault\n\n")
+	b.WriteString("*Maintained by [mnemo](https://github.com/marcelocantos/mnemo). ")
+	b.WriteString("Add your own notes below the `<!-- mnemo:generated -->` fence — ")
+	b.WriteString("they survive re-syncs and are indexed by mnemo's FTS5 search.*\n\n")
+
+	if stats != nil {
+		fmt.Fprintf(&b, "*%d sessions · %d messages indexed*\n\n",
+			stats.TotalSessions, stats.TotalMessages)
+	}
+
+	if len(repos) > 0 {
+		b.WriteString("## Repositories\n\n")
+		for _, r := range repos {
+			link := strings.TrimSuffix(filepath.ToSlash(repoIndexPath(r.Repo)), ".md")
+			fmt.Fprintf(&b, "- [[%s]] — %d sessions, last active %s\n",
+				link, r.Sessions, r.LastActivity)
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("## Sections\n\n")
+	b.WriteString("- `sessions/` — full session transcripts (one file per session)\n")
+	b.WriteString("- `decisions/` — extracted decisions with proposal + outcome\n")
+	b.WriteString("- `memories/` — project memory files\n")
+	b.WriteString("- `skills/` — reusable skill procedures from `~/.claude/skills/`\n")
+	b.WriteString("- `configs/` — CLAUDE.md project instruction files\n")
+	b.WriteString("- `plans/` — planning documents\n")
+	b.WriteString("- `targets/` — convergence targets\n")
+	b.WriteString("- `ci/` — CI run summaries\n")
+	b.WriteString("- `prs/` — pull requests and issues\n")
+	b.WriteString("- `repos/` — per-repo index notes\n\n")
+
+	return b.String()
+}
+
+// writeYAML appends "key: value\n" to b, quoting value when it contains
+// characters that would break YAML parsing. Empty values are omitted.
+func writeYAML(b *strings.Builder, key, value string) {
+	if value == "" {
+		return
+	}
+	// Quote if the value contains YAML-special characters or leading/trailing
+	// whitespace that would be lost without quoting.
+	needsQuote := strings.ContainsAny(value, ":{}[]|>&*!,'\"#%@`") ||
+		value != strings.TrimSpace(value)
+	if needsQuote {
+		escaped := strings.ReplaceAll(value, `\`, `\\`)
+		escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+		fmt.Fprintf(b, "%s: \"%s\"\n", key, escaped)
+	} else {
+		fmt.Fprintf(b, "%s: %s\n", key, value)
+	}
+}
+
+// summarize truncates s to at most maxLen printable characters, breaking
+// at the last word boundary before the limit.
+func summarize(s string, maxLen int) string {
+	s = strings.Join(strings.Fields(s), " ") // normalise whitespace
+	if len(s) <= maxLen {
+		return s
+	}
+	if idx := strings.LastIndexByte(s[:maxLen], ' '); idx > 0 {
+		return s[:idx] + "..."
+	}
+	return s[:maxLen] + "..."
+}

--- a/internal/vault/note.go
+++ b/internal/vault/note.go
@@ -58,10 +58,10 @@ func renderSession(info store.SessionInfo, msgs []store.SessionMessage) string {
 	}
 	fmt.Fprintf(&b, "# %s\n\n", title)
 
-	// --- Metadata line ---
-	meta := fmt.Sprintf("*`%s` · %s", shortID(info.SessionID), dateOf(info.FirstMsg))
+	// --- Metadata line (human-friendly: date, repo, work type) ---
+	meta := "*" + dateOf(info.FirstMsg)
 	if info.Repo != "" {
-		meta += fmt.Sprintf(" · [[repos/%s]]", shortProjectName(info.Repo))
+		meta += fmt.Sprintf(" · [[repos/%s|%s]]", shortProjectName(info.Repo), shortProjectName(info.Repo))
 	}
 	if info.WorkType != "" {
 		meta += fmt.Sprintf(" · %s", info.WorkType)
@@ -86,7 +86,13 @@ func renderSession(info store.SessionInfo, msgs []store.SessionMessage) string {
 			if msg.Role == "assistant" {
 				role = "Claude"
 			}
-			fmt.Fprintf(&b, "---\n\n**%s** · *%s*\n\n%s\n\n", role, msg.Timestamp, msg.Text)
+			// Use time-of-day only (the session date is already in the
+			// metadata header). Drop the inter-message `---` rule because
+			// the role heading already separates turns visually and `---`
+			// inside Markdown is parsed as a horizontal rule by Obsidian
+			// AND as a YAML frontmatter delimiter when it appears at the
+			// top of a block — confusing readers and tools.
+			fmt.Fprintf(&b, "### %s · %s\n\n%s\n\n", role, timeOfDay(msg.Timestamp), msg.Text)
 		}
 	}
 
@@ -415,10 +421,16 @@ func renderRepoIndex(repo store.RepoInfo, sessions []store.SessionInfo, decision
 	}
 	b.WriteString("---\n\n")
 
-	fmt.Fprintf(&b, "# %s\n\n", repo.Repo)
+	// Title uses the friendly short name; the full path lives in the
+	// metadata line below for traceability.
+	title := shortProjectName(repo.Repo)
+	if title == "" || title == "untitled" {
+		title = repo.Repo
+	}
+	fmt.Fprintf(&b, "# %s\n\n", title)
 
-	meta := fmt.Sprintf("*Path: `%s` · %d sessions · last active %s*",
-		repo.Path, repo.Sessions, repo.LastActivity)
+	meta := fmt.Sprintf("*Path: `%s` · %s · last active %s*",
+		repo.Path, pluralize(repo.Sessions, "session"), dateOf(repo.LastActivity))
 	fmt.Fprintf(&b, "%s\n\n", meta)
 
 	if repo.Summary != "" {
@@ -436,9 +448,9 @@ func renderRepoIndex(repo store.RepoInfo, sessions []store.SessionInfo, decision
 			link := strings.TrimSuffix(filepath.ToSlash(p), ".md")
 			topic := s.Topic
 			if topic == "" {
-				topic = shortID(s.SessionID)
+				topic = "session " + shortID(s.SessionID)
 			}
-			fmt.Fprintf(&b, "- [[%s]] — %s\n", link, topic)
+			fmt.Fprintf(&b, "- %s · [[%s|%s]]\n", dateOf(s.FirstMsg), link, topic)
 		}
 		b.WriteString("\n")
 	}
@@ -448,7 +460,7 @@ func renderRepoIndex(repo store.RepoInfo, sessions []store.SessionInfo, decision
 		for _, d := range decisions {
 			p := strings.TrimSuffix(filepath.ToSlash(decisionPath(d)), ".md")
 			summary := summarize(d.ProposalText, 80)
-			fmt.Fprintf(&b, "- [[%s]] — %s\n", p, summary)
+			fmt.Fprintf(&b, "- %s · [[%s|%s]]\n", dateOf(d.Timestamp), p, summary)
 		}
 		b.WriteString("\n")
 	}
@@ -469,20 +481,25 @@ func renderRootIndex(repos []store.RepoInfo, stats *store.StatsResult) string {
 
 	b.WriteString("# mnemo knowledge vault\n\n")
 	b.WriteString("*Maintained by [mnemo](https://github.com/marcelocantos/mnemo). ")
-	b.WriteString("Add your own notes below the `<!-- mnemo:generated -->` fence — ")
-	b.WriteString("they survive re-syncs and are indexed by mnemo's FTS5 search.*\n\n")
+	b.WriteString("Drop your own `.md` files anywhere here, or annotate below ")
+	b.WriteString("the `<!-- mnemo:generated -->` fence — both flow into ")
+	b.WriteString("`mnemo_search` alongside transcripts.*\n\n")
 
 	if stats != nil {
-		fmt.Fprintf(&b, "*%d sessions · %d messages indexed*\n\n",
-			stats.TotalSessions, stats.TotalMessages)
+		fmt.Fprintf(&b, "*%s · %d messages indexed*\n\n",
+			pluralize(stats.TotalSessions, "session"), stats.TotalMessages)
 	}
 
 	if len(repos) > 0 {
 		b.WriteString("## Repositories\n\n")
 		for _, r := range repos {
 			link := strings.TrimSuffix(filepath.ToSlash(repoIndexPath(r.Repo)), ".md")
-			fmt.Fprintf(&b, "- [[%s]] — %d sessions, last active %s\n",
-				link, r.Sessions, r.LastActivity)
+			name := shortProjectName(r.Repo)
+			if name == "" || name == "untitled" {
+				name = r.Repo
+			}
+			fmt.Fprintf(&b, "- [[%s|%s]] — %s · last active %s\n",
+				link, name, pluralize(r.Sessions, "session"), dateOf(r.LastActivity))
 		}
 		b.WriteString("\n")
 	}

--- a/internal/vault/note.go
+++ b/internal/vault/note.go
@@ -456,7 +456,7 @@ func renderRepoIndex(repo store.RepoInfo, sessions []store.SessionInfo, decision
 	return b.String()
 }
 
-// renderRootIndex produces the vault root _index.md.
+// renderRootIndex produces the vault root index.md.
 func renderRootIndex(repos []store.RepoInfo, stats *store.StatsResult) string {
 	var b strings.Builder
 
@@ -508,13 +508,16 @@ func writeYAML(b *strings.Builder, key, value string) {
 	if value == "" {
 		return
 	}
-	// Quote if the value contains YAML-special characters or leading/trailing
-	// whitespace that would be lost without quoting.
-	needsQuote := strings.ContainsAny(value, ":{}[]|>&*!,'\"#%@`") ||
+	// Quote if value contains YAML-special characters, control chars, or
+	// leading/trailing whitespace that would be lost without quoting.
+	needsQuote := strings.ContainsAny(value, ":{}[]|>&*!,'\"#%@`\n\t\r") ||
 		value != strings.TrimSpace(value)
 	if needsQuote {
 		escaped := strings.ReplaceAll(value, `\`, `\\`)
 		escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+		escaped = strings.ReplaceAll(escaped, "\n", `\n`)
+		escaped = strings.ReplaceAll(escaped, "\r", `\r`)
+		escaped = strings.ReplaceAll(escaped, "\t", `\t`)
 		fmt.Fprintf(b, "%s: \"%s\"\n", key, escaped)
 	} else {
 		fmt.Fprintf(b, "%s: %s\n", key, value)

--- a/internal/vault/note.go
+++ b/internal/vault/note.go
@@ -36,11 +36,14 @@ func renderSession(info store.SessionInfo, msgs []store.SessionMessage) string {
 	}
 	// Obsidian aliases: lets users find the session by topic without
 	// knowing the session ID; the short ID is always included as fallback.
+	// Topics are extracted from conversation text and may contain newlines
+	// or other YAML-breaking characters, so route through yamlEscapeQuoted
+	// (same escape pass as writeYAML).
 	b.WriteString("aliases:\n")
 	if info.Topic != "" {
-		fmt.Fprintf(&b, "  - \"%s\"\n", strings.ReplaceAll(info.Topic, `"`, `\"`))
+		fmt.Fprintf(&b, "  - \"%s\"\n", yamlEscapeQuoted(info.Topic))
 	}
-	fmt.Fprintf(&b, "  - \"%s\"\n", shortID(info.SessionID))
+	fmt.Fprintf(&b, "  - \"%s\"\n", yamlEscapeQuoted(shortID(info.SessionID)))
 	b.WriteString("tags:\n")
 	b.WriteString("  - session\n")
 	if r := shortProjectName(info.Repo); r != "" && r != "untitled" && r != "unknown" {
@@ -530,15 +533,22 @@ func writeYAML(b *strings.Builder, key, value string) {
 	needsQuote := strings.ContainsAny(value, ":{}[]|>&*!,'\"#%@`\n\t\r") ||
 		value != strings.TrimSpace(value)
 	if needsQuote {
-		escaped := strings.ReplaceAll(value, `\`, `\\`)
-		escaped = strings.ReplaceAll(escaped, `"`, `\"`)
-		escaped = strings.ReplaceAll(escaped, "\n", `\n`)
-		escaped = strings.ReplaceAll(escaped, "\r", `\r`)
-		escaped = strings.ReplaceAll(escaped, "\t", `\t`)
-		fmt.Fprintf(b, "%s: \"%s\"\n", key, escaped)
+		fmt.Fprintf(b, "%s: \"%s\"\n", key, yamlEscapeQuoted(value))
 	} else {
 		fmt.Fprintf(b, "%s: %s\n", key, value)
 	}
+}
+
+// yamlEscapeQuoted returns s escaped for use inside a YAML double-quoted
+// scalar. Escapes backslash, double-quote, and the control characters
+// \n/\r/\t that would otherwise break the scalar across lines.
+func yamlEscapeQuoted(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	s = strings.ReplaceAll(s, "\t", `\t`)
+	return s
 }
 
 // summarize truncates s to at most maxLen printable characters, breaking

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -11,14 +11,12 @@
 // and Logseq.
 //
 // The vault is bidirectional: mnemo writes notes on every ingest cycle
-// and adds the vault directory as a SynthesisRoot so that human-added
-// content (new files, annotations below the fence marker) is picked up
-// by the FTS5 index and flows back into mnemo_search and all other
-// query tools.
+// and a dedicated IngestVaultAnnotations pass re-indexes the content
+// below the <!-- mnemo:generated --> fence so human-added annotations
+// appear in mnemo_search results alongside transcript messages.
 //
-// Human edits are preserved across re-syncs via a <!-- mnemo:generated -->
-// fence: generated content lives above the fence, human notes live below
-// and are never overwritten.
+// Human edits are preserved across re-syncs: generated content lives
+// above the fence, human notes live below and are never overwritten.
 //
 // Vault structure:
 //
@@ -145,7 +143,7 @@ func (e *Exporter) syncSessions(ctx context.Context) (map[string]string, error) 
 			continue
 		}
 
-		if err := writeNote(absPath, renderSession(s, msgs)); err != nil {
+		if err := writeNote(absPath, renderSession(s, msgs), s.LastMsg); err != nil {
 			slog.Warn("vault: write session note failed", "path", absPath, "err", err)
 			continue
 		}
@@ -174,7 +172,7 @@ func (e *Exporter) syncDecisions(ctx context.Context, sessionPaths map[string]st
 			skipped++
 			continue
 		}
-		if err := writeNote(absPath, renderDecision(d, sessionPaths[d.SessionID])); err != nil {
+		if err := writeNote(absPath, renderDecision(d, sessionPaths[d.SessionID]), d.Timestamp); err != nil {
 			slog.Warn("vault: write decision note failed", "path", absPath, "err", err)
 			continue
 		}
@@ -202,7 +200,7 @@ func (e *Exporter) syncMemories(ctx context.Context) error {
 			skipped++
 			continue
 		}
-		if err := writeNote(absPath, renderMemory(m)); err != nil {
+		if err := writeNote(absPath, renderMemory(m), m.UpdatedAt); err != nil {
 			slog.Warn("vault: write memory note failed", "path", absPath, "err", err)
 			continue
 		}
@@ -230,7 +228,7 @@ func (e *Exporter) syncPlans(ctx context.Context) error {
 			skipped++
 			continue
 		}
-		if err := writeNote(absPath, renderPlan(p)); err != nil {
+		if err := writeNote(absPath, renderPlan(p), p.UpdatedAt); err != nil {
 			slog.Warn("vault: write plan note failed", "path", absPath, "err", err)
 			continue
 		}
@@ -262,7 +260,7 @@ func (e *Exporter) syncTargets(ctx context.Context) error {
 			skipped++
 			continue
 		}
-		if err := writeNote(absPath, renderTarget(t)); err != nil {
+		if err := writeNote(absPath, renderTarget(t), ""); err != nil {
 			slog.Warn("vault: write target note failed", "path", absPath, "err", err)
 			continue
 		}
@@ -290,7 +288,7 @@ func (e *Exporter) syncCI(ctx context.Context) error {
 			skipped++
 			continue
 		}
-		if err := writeNote(absPath, renderCIRun(r)); err != nil {
+		if err := writeNote(absPath, renderCIRun(r), r.CompletedAt); err != nil {
 			slog.Warn("vault: write CI run note failed", "path", absPath, "err", err)
 			continue
 		}
@@ -318,7 +316,7 @@ func (e *Exporter) syncPRs(ctx context.Context) error {
 			skipped++
 			continue
 		}
-		if err := writeNote(absPath, renderPR(r)); err != nil {
+		if err := writeNote(absPath, renderPR(r), r.UpdatedAt); err != nil {
 			slog.Warn("vault: write PR note failed", "path", absPath, "err", err)
 			continue
 		}
@@ -345,7 +343,7 @@ func (e *Exporter) syncRepoIndices(ctx context.Context, repos []store.RepoInfo, 
 		}
 		content := renderRepoIndex(repo, sessions, decisions, sessionPaths)
 		absPath := filepath.Join(e.path, repoIndexPath(repo.Repo))
-		if err := writeNote(absPath, content); err != nil {
+		if err := writeNote(absPath, content, ""); err != nil {
 			slog.Warn("vault: write repo index failed", "repo", repo.Repo, "err", err)
 		}
 	}
@@ -369,7 +367,7 @@ func (e *Exporter) syncSkills(ctx context.Context) error {
 			skipped++
 			continue
 		}
-		if err := writeNote(absPath, renderSkill(s)); err != nil {
+		if err := writeNote(absPath, renderSkill(s), s.UpdatedAt); err != nil {
 			slog.Warn("vault: write skill note failed", "path", absPath, "err", err)
 			continue
 		}
@@ -397,7 +395,7 @@ func (e *Exporter) syncConfigs(ctx context.Context) error {
 			skipped++
 			continue
 		}
-		if err := writeNote(absPath, renderConfig(c)); err != nil {
+		if err := writeNote(absPath, renderConfig(c), c.UpdatedAt); err != nil {
 			slog.Warn("vault: write config note failed", "path", absPath, "err", err)
 			continue
 		}
@@ -411,39 +409,85 @@ func (e *Exporter) syncConfigs(ctx context.Context) error {
 // syncRootIndex writes the vault root index.md.
 func (e *Exporter) syncRootIndex(repos []store.RepoInfo) error {
 	stats, _ := e.backend.Stats()
-	return writeNote(filepath.Join(e.path, "index.md"), renderRootIndex(repos, stats))
+	return writeNote(filepath.Join(e.path, "index.md"), renderRootIndex(repos, stats), "")
 }
 
+// entityTSComment is the HTML comment prefix written just before the
+// generatedFence to record the entity timestamp used during the last write.
+// needsUpdate reads this back to detect staleness without relying on file
+// mtime (which human editors bump on every save).
+const entityTSComment = "<!-- mnemo:entity_ts "
+
 // needsUpdate returns true when the vault file at absPath does not exist or
-// its modification time is before ts (RFC3339). An empty ts always returns
-// true so that callers that have no reliable timestamp force a write.
+// the entity timestamp recorded in its fence comment is older than ts.
+// An empty ts always returns true (no reliable timestamp → always regenerate).
+//
+// The entity timestamp is embedded as an HTML comment just before the
+// generatedFence marker on every writeNote call. For files that pre-date
+// this mechanism (no comment present) needsUpdate falls back to mtime
+// comparison so they are regenerated once and then carry the new marker.
 func needsUpdate(absPath, ts string) bool {
 	if ts == "" {
 		return true
 	}
-	info, err := os.Stat(absPath)
-	if err != nil {
-		return true // file absent or unreadable
-	}
-	// Parse ts: try nanosecond, then second precision, then date-only.
-	var t time.Time
+	var entityTime time.Time
 	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
 		if parsed, err := time.Parse(layout, ts); err == nil {
-			t = parsed
+			entityTime = parsed
 			break
 		}
 	}
-	if t.IsZero() {
+	if entityTime.IsZero() {
 		return true // unparseable timestamp → always regenerate
 	}
-	return info.ModTime().Before(t)
+
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return true // file absent or unreadable
+	}
+
+	raw := string(data)
+	idx := strings.LastIndex(raw, entityTSComment)
+	if idx < 0 {
+		// No entity timestamp recorded — fall back to mtime so existing
+		// vault files are regenerated once and then carry the new marker.
+		info, err := os.Stat(absPath)
+		if err != nil {
+			return true
+		}
+		return info.ModTime().Before(entityTime)
+	}
+	rest := raw[idx+len(entityTSComment):]
+	end := strings.Index(rest, " -->")
+	if end < 0 {
+		return true
+	}
+	var fileTime time.Time
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
+		if parsed, err := time.Parse(layout, rest[:end]); err == nil {
+			fileTime = parsed
+			break
+		}
+	}
+	if fileTime.IsZero() {
+		return true
+	}
+	return fileTime.Before(entityTime)
 }
 
 // writeNote writes generated content to absPath, preserving any
 // human-added content that follows the generatedFence marker in an
 // existing file. The fence is always written; human content (if any)
 // is appended after it.
-func writeNote(absPath, generated string) error {
+//
+// entityTS, when non-empty, is written as an HTML comment just before
+// the fence so needsUpdate can detect staleness without relying on
+// file mtime (which human editors bump on every save).
+//
+// If the existing file is non-empty but contains no fence (e.g. a
+// pre-existing user file at a colliding path), its entire content is
+// treated as human content and preserved below the fence.
+func writeNote(absPath, generated, entityTS string) error {
 	// Harvest human content from the existing file, if any.
 	human := ""
 	if existing, err := os.ReadFile(absPath); err == nil {
@@ -453,12 +497,19 @@ func writeNote(absPath, generated string) error {
 			if after != "" {
 				human = after
 			}
+		} else if trimmed := strings.TrimSpace(raw); trimmed != "" {
+			// Pre-existing file with no fence: treat entire content as
+			// human content so we don't silently overwrite user files.
+			human = trimmed + "\n"
 		}
 	}
 
 	var out strings.Builder
 	out.WriteString(strings.TrimRight(generated, "\n"))
 	out.WriteString("\n\n")
+	if entityTS != "" {
+		fmt.Fprintf(&out, "%s%s -->\n", entityTSComment, entityTS)
+	}
 	out.WriteString(generatedFence)
 	if human != "" {
 		out.WriteString("\n")

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -652,11 +652,19 @@ func repackagePreexistingContent(content string) string {
 // Returns (body, rest, true) when s begins with "---\n<body>\n---\n" (the
 // closing fence on its own line, trailing whitespace tolerated). Returns
 // ("", s, false) when no leading frontmatter is present.
+//
+// Tolerates CRLF line endings on the opening "---" line for consistency
+// with fenceLineIndex, which already strips trailing \r before comparing.
 func extractLeadingFrontmatter(s string) (body, rest string, ok bool) {
-	if !strings.HasPrefix(s, "---\n") {
+	var after string
+	switch {
+	case strings.HasPrefix(s, "---\n"):
+		after = s[len("---\n"):]
+	case strings.HasPrefix(s, "---\r\n"):
+		after = s[len("---\r\n"):]
+	default:
 		return "", s, false
 	}
-	after := s[len("---\n"):]
 	i := 0
 	for i < len(after) {
 		nl := strings.IndexByte(after[i:], '\n')

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -41,6 +41,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/marcelocantos/mnemo/internal/store"
@@ -52,9 +53,16 @@ import (
 const generatedFence = "<!-- mnemo:generated -->"
 
 // Exporter writes mnemo's knowledge graph as Markdown vault notes.
+//
+// Sync calls are serialised via syncMu: if a Sync is already running when
+// another is invoked, the second returns immediately without rerunning.
+// This prevents the periodic Sync ticker from racing the initial Sync on
+// large vaults and protects writeNote's read-modify-write of fenced files.
 type Exporter struct {
 	backend store.Backend
 	path    string
+	syncMu  sync.Mutex
+	syncing bool
 }
 
 // New creates a new Exporter rooted at path. The directory is created if
@@ -73,10 +81,28 @@ func (e *Exporter) Path() string { return e.path }
 // Sync performs a full vault synchronisation: sessions, decisions, memories,
 // plans, targets, CI runs, PRs, per-repo indices, and the root index.
 //
-// Session notes whose vault file mtime is newer than the session's last
+// Concurrent calls are coalesced: if a Sync is already in flight, the second
+// call returns nil immediately. The work-in-flight goroutine completes the
+// pass for both callers.
+//
+// Session notes whose recorded entity timestamp matches the session's last
 // message timestamp are skipped so that repeated syncs are fast after the
 // initial run.
 func (e *Exporter) Sync(ctx context.Context) error {
+	e.syncMu.Lock()
+	if e.syncing {
+		e.syncMu.Unlock()
+		slog.Info("vault: sync already in flight; skipping")
+		return nil
+	}
+	e.syncing = true
+	e.syncMu.Unlock()
+	defer func() {
+		e.syncMu.Lock()
+		e.syncing = false
+		e.syncMu.Unlock()
+	}()
+
 	slog.Info("vault: sync starting", "path", e.path)
 	start := time.Now()
 

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -36,6 +36,7 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -46,6 +47,12 @@ import (
 
 	"github.com/marcelocantos/mnemo/internal/store"
 )
+
+// ErrSyncInFlight is returned by Sync when another Sync is already running.
+// Periodic and initial-sync callers can ignore this; the human-triggered MCP
+// path checks for it to report honestly that the call did nothing rather
+// than falsely claiming a successful 0s sync.
+var ErrSyncInFlight = errors.New("vault: sync already in flight")
 
 // generatedFence separates mnemo-generated content (above the line) from
 // human-added content (below the line). Re-syncing rewrites everything
@@ -110,8 +117,9 @@ func (e *Exporter) Path() string { return e.path }
 // plans, targets, CI runs, PRs, per-repo indices, and the root index.
 //
 // Concurrent calls are coalesced: if a Sync is already in flight, the second
-// call returns nil immediately. The work-in-flight goroutine completes the
-// pass for both callers.
+// call returns ErrSyncInFlight immediately. The other in-flight goroutine's
+// completion is unrelated to the caller's request, so we surface the skip
+// rather than falsely report success.
 //
 // Session notes whose recorded entity timestamp matches the session's last
 // message timestamp are skipped so that repeated syncs are fast after the
@@ -121,7 +129,7 @@ func (e *Exporter) Sync(ctx context.Context) error {
 	if e.syncing {
 		e.syncMu.Unlock()
 		slog.Info("vault: sync already in flight; skipping")
-		return nil
+		return ErrSyncInFlight
 	}
 	e.syncing = true
 	e.syncMu.Unlock()
@@ -472,6 +480,36 @@ func (e *Exporter) syncRootIndex(repos []store.RepoInfo) error {
 // mtime (which human editors bump on every save).
 const entityTSComment = "<!-- mnemo:entity_ts "
 
+// entityTSCommentSuffix closes the entity-timestamp HTML comment.
+const entityTSCommentSuffix = " -->"
+
+// parseEntityTS returns the recorded entity timestamp from raw, scanning
+// from the end for a line that exactly matches the entity-timestamp comment
+// pattern. Returns ("", false) when no such line exists.
+//
+// Line-anchored matching mirrors fenceLineIndex: a plain LastIndex would
+// also match if the user pasted the literal entityTSComment prefix into
+// their annotations (e.g. quoting mnemo's docs). Restricting to whole
+// lines keeps user-typed instances of the string safely inside human
+// content.
+func parseEntityTS(raw string) (string, bool) {
+	end := len(raw)
+	for end > 0 {
+		start := strings.LastIndexByte(raw[:end], '\n') + 1
+		line := raw[start:end]
+		trimmed := strings.TrimRight(line, " \t\r")
+		if strings.HasPrefix(trimmed, entityTSComment) && strings.HasSuffix(trimmed, entityTSCommentSuffix) {
+			ts := trimmed[len(entityTSComment) : len(trimmed)-len(entityTSCommentSuffix)]
+			return ts, true
+		}
+		if start == 0 {
+			break
+		}
+		end = start - 1
+	}
+	return "", false
+}
+
 // needsUpdate returns true when the vault file at absPath does not exist or
 // the entity timestamp recorded in its fence comment is older than ts.
 // An empty ts always returns true (no reliable timestamp → always regenerate).
@@ -501,8 +539,8 @@ func needsUpdate(absPath, ts string) bool {
 	}
 
 	raw := string(data)
-	idx := strings.LastIndex(raw, entityTSComment)
-	if idx < 0 {
+	tsStr, ok := parseEntityTS(raw)
+	if !ok {
 		// No entity timestamp recorded — fall back to mtime so existing
 		// vault files are regenerated once and then carry the new marker.
 		info, err := os.Stat(absPath)
@@ -511,14 +549,9 @@ func needsUpdate(absPath, ts string) bool {
 		}
 		return info.ModTime().Before(entityTime)
 	}
-	rest := raw[idx+len(entityTSComment):]
-	end := strings.Index(rest, " -->")
-	if end < 0 {
-		return true
-	}
 	var fileTime time.Time
 	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
-		if parsed, err := time.Parse(layout, rest[:end]); err == nil {
+		if parsed, err := time.Parse(layout, tsStr); err == nil {
 			fileTime = parsed
 			break
 		}
@@ -540,7 +573,12 @@ func needsUpdate(absPath, ts string) bool {
 //
 // If the existing file is non-empty but contains no fence (e.g. a
 // pre-existing user file at a colliding path), its entire content is
-// treated as human content and preserved below the fence.
+// treated as human content and preserved below the fence. If that
+// preserved content begins with its own YAML frontmatter block
+// (---\n…\n---\n), the block is repackaged as a fenced yaml code block
+// under a "Preserved frontmatter" heading: Obsidian otherwise renders
+// the second --- pair as literal text in the body. The original keys
+// remain visible and copy-pasteable.
 func writeNote(absPath, generated, entityTS string) error {
 	// Harvest human content from the existing file, if any.
 	human := ""
@@ -554,7 +592,7 @@ func writeNote(absPath, generated, entityTS string) error {
 		} else if trimmed := strings.TrimSpace(raw); trimmed != "" {
 			// Pre-existing file with no fence: treat entire content as
 			// human content so we don't silently overwrite user files.
-			human = trimmed + "\n"
+			human = repackagePreexistingContent(trimmed + "\n")
 		}
 	}
 
@@ -577,6 +615,67 @@ func writeNote(absPath, generated, entityTS string) error {
 		return fmt.Errorf("vault: mkdir %s: %w", filepath.Dir(absPath), err)
 	}
 	return os.WriteFile(absPath, []byte(out.String()), 0o644)
+}
+
+// repackagePreexistingContent prepares a pre-existing user file's content
+// for placement below mnemo's generated fence. If the content begins with
+// its own YAML frontmatter (---\n…\n---\n), the block is extracted and
+// rewritten as a fenced yaml code block under a heading so that Obsidian
+// (which only recognises frontmatter at the very top of a file) does not
+// render the stray --- pair as literal text in the body.
+//
+// Content with no leading frontmatter is returned unchanged.
+func repackagePreexistingContent(content string) string {
+	body, rest, ok := extractLeadingFrontmatter(content)
+	if !ok {
+		return content
+	}
+	var b strings.Builder
+	b.WriteString("## Preserved frontmatter\n\n")
+	b.WriteString("*This file existed before mnemo took over the path; its original ")
+	b.WriteString("YAML frontmatter is preserved below. Copy any keys you want into ")
+	b.WriteString("mnemo's frontmatter above the fence, or delete this block.*\n\n")
+	b.WriteString("```yaml\n")
+	b.WriteString(strings.TrimRight(body, "\n"))
+	b.WriteString("\n```\n\n")
+	rest = strings.TrimLeft(rest, "\n")
+	if rest != "" {
+		b.WriteString(rest)
+		if !strings.HasSuffix(rest, "\n") {
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+// extractLeadingFrontmatter peels a leading YAML frontmatter block from s.
+// Returns (body, rest, true) when s begins with "---\n<body>\n---\n" (the
+// closing fence on its own line, trailing whitespace tolerated). Returns
+// ("", s, false) when no leading frontmatter is present.
+func extractLeadingFrontmatter(s string) (body, rest string, ok bool) {
+	if !strings.HasPrefix(s, "---\n") {
+		return "", s, false
+	}
+	after := s[len("---\n"):]
+	i := 0
+	for i < len(after) {
+		nl := strings.IndexByte(after[i:], '\n')
+		if nl < 0 {
+			// Tolerate a closing "---" with no trailing newline at EOF.
+			trimmed := strings.TrimRight(after[i:], " \t\r")
+			if trimmed == "---" {
+				return after[:i], "", true
+			}
+			return "", s, false
+		}
+		line := after[i : i+nl]
+		trimmed := strings.TrimRight(line, " \t\r")
+		if trimmed == "---" {
+			return after[:i], after[i+nl+1:], true
+		}
+		i += nl + 1
+	}
+	return "", s, false
 }
 
 // readAllMessages fetches all messages for a session, paginating until

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -1,0 +1,493 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+// Package vault writes mnemo's knowledge graph as Markdown notes to a
+// directory compatible with Obsidian and Logseq.
+//
+// When vault_path is set in ~/.mnemo/config.json, mnemo continuously
+// materialises its SQLite knowledge graph into a tree of Markdown files
+// that humans can read, annotate, and extend in any note-taking tool
+// that supports the CommonMark / wiki-link conventions used by Obsidian
+// and Logseq.
+//
+// The vault is bidirectional: mnemo writes notes on every ingest cycle
+// and adds the vault directory as a SynthesisRoot so that human-added
+// content (new files, annotations below the fence marker) is picked up
+// by the FTS5 index and flows back into mnemo_search and all other
+// query tools.
+//
+// Human edits are preserved across re-syncs via a <!-- mnemo:generated -->
+// fence: generated content lives above the fence, human notes live below
+// and are never overwritten.
+//
+// Vault structure:
+//
+//	<vault_path>/
+//	├── index.md               — root index (all repos, total sessions)
+//	├── repos/<repo>.md        — per-repo index with recent sessions + decisions
+//	├── sessions/<repo>/       — one note per session (full conversation)
+//	├── decisions/<repo>/      — one note per extracted decision
+//	├── memories/              — project memory notes (flat, globally unique names)
+//	├── skills/                — skill procedure notes from ~/.claude/skills/
+//	├── configs/               — CLAUDE.md project instruction notes
+//	├── plans/<repo>/          — planning documents
+//	├── targets/<repo>/        — convergence targets
+//	├── ci/<repo>/             — CI run summaries
+//	└── prs/<repo>/            — PR and issue notes
+package vault
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/marcelocantos/mnemo/internal/store"
+)
+
+// generatedFence separates mnemo-generated content (above the line) from
+// human-added content (below the line). Re-syncing rewrites everything
+// above this marker while leaving everything below untouched.
+const generatedFence = "<!-- mnemo:generated -->"
+
+// Exporter writes mnemo's knowledge graph as Markdown vault notes.
+type Exporter struct {
+	backend store.Backend
+	path    string
+}
+
+// New creates a new Exporter rooted at path. The directory is created if
+// it does not exist. path must already be ~ expanded (use
+// Config.ResolvedVaultPath).
+func New(backend store.Backend, path string) (*Exporter, error) {
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		return nil, fmt.Errorf("vault: create root %s: %w", path, err)
+	}
+	return &Exporter{backend: backend, path: path}, nil
+}
+
+// Path returns the vault root directory.
+func (e *Exporter) Path() string { return e.path }
+
+// Sync performs a full vault synchronisation: sessions, decisions, memories,
+// plans, targets, CI runs, PRs, per-repo indices, and the root index.
+//
+// Session notes whose vault file mtime is newer than the session's last
+// message timestamp are skipped so that repeated syncs are fast after the
+// initial run.
+func (e *Exporter) Sync(ctx context.Context) error {
+	slog.Info("vault: sync starting", "path", e.path)
+	start := time.Now()
+
+	// Sessions must be synced first: the path map they produce is needed
+	// by decisions (for back-links) and repo indices (for forward-links).
+	sessionPaths, err := e.syncSessions(ctx)
+	var firstErr error
+	setErr := func(e error) {
+		if e != nil && firstErr == nil {
+			firstErr = e
+		}
+	}
+	setErr(err)
+	setErr(e.syncDecisions(ctx, sessionPaths))
+	setErr(e.syncMemories(ctx))
+	setErr(e.syncPlans(ctx))
+	setErr(e.syncTargets(ctx))
+	setErr(e.syncCI(ctx))
+	setErr(e.syncPRs(ctx))
+	setErr(e.syncSkills(ctx))
+	setErr(e.syncConfigs(ctx))
+	// Repo indices and root index are written last so they reflect the
+	// session paths already materialised above. Fetch repos once and
+	// pass to both so we avoid two identical ListRepos queries.
+	repos, err := e.backend.ListRepos("")
+	setErr(err)
+	setErr(e.syncRepoIndices(ctx, repos, sessionPaths))
+	setErr(e.syncRootIndex(repos))
+
+	slog.Info("vault: sync complete",
+		"elapsed", time.Since(start).Round(time.Millisecond),
+		"err", firstErr)
+	return firstErr
+}
+
+// syncSessions writes a vault note for every session and returns a map of
+// sessionID → vault-relative note path for use by later sync passes.
+func (e *Exporter) syncSessions(ctx context.Context) (map[string]string, error) {
+	sessions, err := e.backend.ListSessions("all", 1, 100000, "", "", "")
+	if err != nil {
+		return nil, fmt.Errorf("vault: list sessions: %w", err)
+	}
+
+	pathMap := make(map[string]string, len(sessions))
+	written, skipped := 0, 0
+
+	for _, s := range sessions {
+		if ctx.Err() != nil {
+			break
+		}
+		relPath := sessionPath(s)
+		pathMap[s.SessionID] = relPath
+		absPath := filepath.Join(e.path, relPath)
+
+		if !needsUpdate(absPath, s.LastMsg) {
+			skipped++
+			continue
+		}
+
+		msgs, err := readAllMessages(e.backend, s.SessionID)
+		if err != nil {
+			slog.Warn("vault: read session messages failed",
+				"session", shortID(s.SessionID), "err", err)
+			continue
+		}
+
+		if err := writeNote(absPath, renderSession(s, msgs)); err != nil {
+			slog.Warn("vault: write session note failed", "path", absPath, "err", err)
+			continue
+		}
+		written++
+	}
+
+	slog.Info("vault: sessions synced", "written", written, "skipped", skipped)
+	return pathMap, nil
+}
+
+// syncDecisions writes a vault note for every detected decision.
+func (e *Exporter) syncDecisions(ctx context.Context, sessionPaths map[string]string) error {
+	// days=36500 effectively means "all time".
+	decisions, err := e.backend.SearchDecisions("", "", 36500, 100000)
+	if err != nil {
+		return fmt.Errorf("vault: search decisions: %w", err)
+	}
+
+	written, skipped := 0, 0
+	for _, d := range decisions {
+		if ctx.Err() != nil {
+			break
+		}
+		absPath := filepath.Join(e.path, decisionPath(d))
+		if !needsUpdate(absPath, d.Timestamp) {
+			skipped++
+			continue
+		}
+		if err := writeNote(absPath, renderDecision(d, sessionPaths[d.SessionID])); err != nil {
+			slog.Warn("vault: write decision note failed", "path", absPath, "err", err)
+			continue
+		}
+		written++
+	}
+
+	slog.Info("vault: decisions synced", "written", written, "skipped", skipped)
+	return nil
+}
+
+// syncMemories writes a vault note for every indexed memory file.
+func (e *Exporter) syncMemories(ctx context.Context) error {
+	memories, err := e.backend.SearchMemories("", "", "", 100000)
+	if err != nil {
+		return fmt.Errorf("vault: search memories: %w", err)
+	}
+
+	written, skipped := 0, 0
+	for _, m := range memories {
+		if ctx.Err() != nil {
+			break
+		}
+		absPath := filepath.Join(e.path, memoryPath(m))
+		if !needsUpdate(absPath, m.UpdatedAt) {
+			skipped++
+			continue
+		}
+		if err := writeNote(absPath, renderMemory(m)); err != nil {
+			slog.Warn("vault: write memory note failed", "path", absPath, "err", err)
+			continue
+		}
+		written++
+	}
+
+	slog.Info("vault: memories synced", "written", written, "skipped", skipped)
+	return nil
+}
+
+// syncPlans writes a vault note for every indexed plan.
+func (e *Exporter) syncPlans(ctx context.Context) error {
+	plans, err := e.backend.SearchPlans("", "", 100000)
+	if err != nil {
+		return fmt.Errorf("vault: search plans: %w", err)
+	}
+
+	written, skipped := 0, 0
+	for _, p := range plans {
+		if ctx.Err() != nil {
+			break
+		}
+		absPath := filepath.Join(e.path, planPath(p))
+		if !needsUpdate(absPath, p.UpdatedAt) {
+			skipped++
+			continue
+		}
+		if err := writeNote(absPath, renderPlan(p)); err != nil {
+			slog.Warn("vault: write plan note failed", "path", absPath, "err", err)
+			continue
+		}
+		written++
+	}
+
+	slog.Info("vault: plans synced", "written", written, "skipped", skipped)
+	return nil
+}
+
+// syncTargets writes a vault note for every indexed convergence target.
+func (e *Exporter) syncTargets(ctx context.Context) error {
+	targets, err := e.backend.SearchTargets("", "", "", 100000)
+	if err != nil {
+		return fmt.Errorf("vault: search targets: %w", err)
+	}
+
+	written, skipped := 0, 0
+	for _, t := range targets {
+		if ctx.Err() != nil {
+			break
+		}
+		absPath := filepath.Join(e.path, targetPath(t))
+		// Targets carry no reliable last-modified timestamp. Notes are
+		// written once and not refreshed until the file is deleted.
+		// targetPath encodes the target ID, not the status, so a status
+		// change does not rename the file — human annotations survive.
+		if _, err := os.Stat(absPath); err == nil {
+			skipped++
+			continue
+		}
+		if err := writeNote(absPath, renderTarget(t)); err != nil {
+			slog.Warn("vault: write target note failed", "path", absPath, "err", err)
+			continue
+		}
+		written++
+	}
+
+	slog.Info("vault: targets synced", "written", written, "skipped", skipped)
+	return nil
+}
+
+// syncCI writes a vault note for every indexed CI run.
+func (e *Exporter) syncCI(ctx context.Context) error {
+	runs, err := e.backend.SearchCI("", "", "", 36500, 100000)
+	if err != nil {
+		return fmt.Errorf("vault: search CI runs: %w", err)
+	}
+
+	written, skipped := 0, 0
+	for _, r := range runs {
+		if ctx.Err() != nil {
+			break
+		}
+		absPath := filepath.Join(e.path, ciRunPath(r))
+		if !needsUpdate(absPath, r.CompletedAt) {
+			skipped++
+			continue
+		}
+		if err := writeNote(absPath, renderCIRun(r)); err != nil {
+			slog.Warn("vault: write CI run note failed", "path", absPath, "err", err)
+			continue
+		}
+		written++
+	}
+
+	slog.Info("vault: CI runs synced", "written", written, "skipped", skipped)
+	return nil
+}
+
+// syncPRs writes a vault note for every indexed PR and issue.
+func (e *Exporter) syncPRs(ctx context.Context) error {
+	prs, err := e.backend.SearchGitHubActivity("", "", "", "", "all", 36500, 100000)
+	if err != nil {
+		return fmt.Errorf("vault: search PRs: %w", err)
+	}
+
+	written, skipped := 0, 0
+	for _, r := range prs {
+		if ctx.Err() != nil {
+			break
+		}
+		absPath := filepath.Join(e.path, prPath(r))
+		if !needsUpdate(absPath, r.UpdatedAt) {
+			skipped++
+			continue
+		}
+		if err := writeNote(absPath, renderPR(r)); err != nil {
+			slog.Warn("vault: write PR note failed", "path", absPath, "err", err)
+			continue
+		}
+		written++
+	}
+
+	slog.Info("vault: PRs/issues synced", "written", written, "skipped", skipped)
+	return nil
+}
+
+// syncRepoIndices writes a per-repo index note for every known repository.
+func (e *Exporter) syncRepoIndices(ctx context.Context, repos []store.RepoInfo, sessionPaths map[string]string) error {
+	for _, repo := range repos {
+		if ctx.Err() != nil {
+			break
+		}
+		sessions, err := e.backend.ListSessions("interactive", 1, 20, "", repo.Repo, "")
+		if err != nil {
+			slog.Warn("vault: list sessions for repo index failed", "repo", repo.Repo, "err", err)
+		}
+		decisions, err := e.backend.SearchDecisions("", repo.Repo, 36500, 20)
+		if err != nil {
+			slog.Warn("vault: search decisions for repo index failed", "repo", repo.Repo, "err", err)
+		}
+		content := renderRepoIndex(repo, sessions, decisions, sessionPaths)
+		absPath := filepath.Join(e.path, repoIndexPath(repo.Repo))
+		if err := writeNote(absPath, content); err != nil {
+			slog.Warn("vault: write repo index failed", "repo", repo.Repo, "err", err)
+		}
+	}
+	return nil
+}
+
+// syncSkills writes a vault note for every indexed skill file.
+func (e *Exporter) syncSkills(ctx context.Context) error {
+	skills, err := e.backend.SearchSkills("", 100000)
+	if err != nil {
+		return fmt.Errorf("vault: search skills: %w", err)
+	}
+
+	written, skipped := 0, 0
+	for _, s := range skills {
+		if ctx.Err() != nil {
+			break
+		}
+		absPath := filepath.Join(e.path, skillPath(s))
+		if !needsUpdate(absPath, s.UpdatedAt) {
+			skipped++
+			continue
+		}
+		if err := writeNote(absPath, renderSkill(s)); err != nil {
+			slog.Warn("vault: write skill note failed", "path", absPath, "err", err)
+			continue
+		}
+		written++
+	}
+
+	slog.Info("vault: skills synced", "written", written, "skipped", skipped)
+	return nil
+}
+
+// syncConfigs writes a vault note for every indexed CLAUDE.md config file.
+func (e *Exporter) syncConfigs(ctx context.Context) error {
+	configs, err := e.backend.SearchClaudeConfigs("", "", 100000)
+	if err != nil {
+		return fmt.Errorf("vault: search configs: %w", err)
+	}
+
+	written, skipped := 0, 0
+	for _, c := range configs {
+		if ctx.Err() != nil {
+			break
+		}
+		absPath := filepath.Join(e.path, configPath(c))
+		if !needsUpdate(absPath, c.UpdatedAt) {
+			skipped++
+			continue
+		}
+		if err := writeNote(absPath, renderConfig(c)); err != nil {
+			slog.Warn("vault: write config note failed", "path", absPath, "err", err)
+			continue
+		}
+		written++
+	}
+
+	slog.Info("vault: configs synced", "written", written, "skipped", skipped)
+	return nil
+}
+
+// syncRootIndex writes the vault root index.md.
+func (e *Exporter) syncRootIndex(repos []store.RepoInfo) error {
+	stats, _ := e.backend.Stats()
+	return writeNote(filepath.Join(e.path, "index.md"), renderRootIndex(repos, stats))
+}
+
+// needsUpdate returns true when the vault file at absPath does not exist or
+// its modification time is before ts (RFC3339). An empty ts always returns
+// true so that callers that have no reliable timestamp force a write.
+func needsUpdate(absPath, ts string) bool {
+	if ts == "" {
+		return true
+	}
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return true // file absent or unreadable
+	}
+	// Parse ts: try nanosecond, then second precision, then date-only.
+	var t time.Time
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
+		if parsed, err := time.Parse(layout, ts); err == nil {
+			t = parsed
+			break
+		}
+	}
+	if t.IsZero() {
+		return true // unparseable timestamp → always regenerate
+	}
+	return info.ModTime().Before(t)
+}
+
+// writeNote writes generated content to absPath, preserving any
+// human-added content that follows the generatedFence marker in an
+// existing file. The fence is always written; human content (if any)
+// is appended after it.
+func writeNote(absPath, generated string) error {
+	// Harvest human content from the existing file, if any.
+	human := ""
+	if existing, err := os.ReadFile(absPath); err == nil {
+		raw := string(existing)
+		if idx := strings.LastIndex(raw, generatedFence); idx >= 0 {
+			after := strings.TrimLeft(raw[idx+len(generatedFence):], "\n")
+			if after != "" {
+				human = after
+			}
+		}
+	}
+
+	var out strings.Builder
+	out.WriteString(strings.TrimRight(generated, "\n"))
+	out.WriteString("\n\n")
+	out.WriteString(generatedFence)
+	if human != "" {
+		out.WriteString("\n")
+		out.WriteString(human)
+	}
+	if !strings.HasSuffix(out.String(), "\n") {
+		out.WriteString("\n")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		return fmt.Errorf("vault: mkdir %s: %w", filepath.Dir(absPath), err)
+	}
+	return os.WriteFile(absPath, []byte(out.String()), 0o644)
+}
+
+// readAllMessages fetches all messages for a session, paginating until
+// the backend returns fewer than pageSize results.
+func readAllMessages(backend store.Backend, sessionID string) ([]store.SessionMessage, error) {
+	const pageSize = 500
+	var all []store.SessionMessage
+	for offset := 0; ; offset += pageSize {
+		page, err := backend.ReadSession(sessionID, "", offset, pageSize)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, page...)
+		if len(page) < pageSize {
+			break
+		}
+	}
+	return all, nil
+}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -52,6 +52,34 @@ import (
 // above this marker while leaving everything below untouched.
 const generatedFence = "<!-- mnemo:generated -->"
 
+// fenceLineIndex returns the byte offset of the line break ending the LAST
+// line that exactly equals the generated fence (modulo trailing whitespace),
+// or -1 when no such line exists.
+//
+// Line-anchored matching avoids a subtle data-loss bug: a plain LastIndex
+// of the fence string would also match if the user pasted the literal fence
+// into their annotations (e.g. quoting mnemo's docs). Detecting the fence
+// only on its own line keeps user-typed instances of the string safely
+// inside human content.
+func fenceLineIndex(raw string) int {
+	end := len(raw)
+	// Walk backwards line by line.
+	for end > 0 {
+		start := strings.LastIndexByte(raw[:end], '\n') + 1 // 0 if no earlier newline
+		line := raw[start:end]
+		// Strip a trailing CR + spaces/tabs (but not the leading content).
+		trimmed := strings.TrimRight(line, " \t\r")
+		if trimmed == generatedFence {
+			return end // offset of (or just past) the line's terminating newline
+		}
+		if start == 0 {
+			break
+		}
+		end = start - 1 // step over the '\n'
+	}
+	return -1
+}
+
 // Exporter writes mnemo's knowledge graph as Markdown vault notes.
 //
 // Sync calls are serialised via syncMu: if a Sync is already running when
@@ -518,8 +546,8 @@ func writeNote(absPath, generated, entityTS string) error {
 	human := ""
 	if existing, err := os.ReadFile(absPath); err == nil {
 		raw := string(existing)
-		if idx := strings.LastIndex(raw, generatedFence); idx >= 0 {
-			after := strings.TrimLeft(raw[idx+len(generatedFence):], "\n")
+		if idx := fenceLineIndex(raw); idx >= 0 {
+			after := strings.TrimLeft(raw[idx:], "\n")
 			if after != "" {
 				human = after
 			}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -492,13 +492,21 @@ const entityTSCommentSuffix = " -->"
 // their annotations (e.g. quoting mnemo's docs). Restricting to whole
 // lines keeps user-typed instances of the string safely inside human
 // content.
+//
+// The length guard is required because entityTSComment ends with a space
+// and entityTSCommentSuffix starts with one — for the degenerate input
+// "<!-- mnemo:entity_ts -->" the prefix and suffix share that space, so
+// HasPrefix+HasSuffix both pass but the substring between them is
+// negative-length. Without the guard, slicing would panic.
 func parseEntityTS(raw string) (string, bool) {
 	end := len(raw)
 	for end > 0 {
 		start := strings.LastIndexByte(raw[:end], '\n') + 1
 		line := raw[start:end]
 		trimmed := strings.TrimRight(line, " \t\r")
-		if strings.HasPrefix(trimmed, entityTSComment) && strings.HasSuffix(trimmed, entityTSCommentSuffix) {
+		if strings.HasPrefix(trimmed, entityTSComment) &&
+			strings.HasSuffix(trimmed, entityTSCommentSuffix) &&
+			len(trimmed) >= len(entityTSComment)+len(entityTSCommentSuffix) {
 			ts := trimmed[len(entityTSComment) : len(trimmed)-len(entityTSCommentSuffix)]
 			return ts, true
 		}

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -500,6 +501,140 @@ func TestWriteNotePreservesPreExistingContent(t *testing.T) {
 	userIdx := strings.Index(s, "My Notes")
 	if userIdx < fenceIdx {
 		t.Error("pre-existing content must appear after fence")
+	}
+}
+
+// TestWriteNoteRepackagesPreExistingFrontmatter verifies bug B fix:
+// a pre-existing user file whose content begins with its own YAML
+// frontmatter block must NOT produce a double --- fence below mnemo's
+// generated frontmatter. Obsidian only treats the first --- pair as
+// frontmatter and renders the second as literal text, which is ugly.
+// The user's frontmatter is preserved as a yaml code block under a
+// "Preserved frontmatter" heading.
+func TestWriteNoteRepackagesPreExistingFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "existing.md")
+	preExisting := "---\ntitle: User's note\ntags: [todo]\n---\n\n# My Notes\n\nBody.\n"
+	if err := os.WriteFile(path, []byte(preExisting), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	generated := "---\nrepo: mnemo\n---\n\n# Generated\n"
+	if err := writeNote(path, generated, ""); err != nil {
+		t.Fatalf("writeNote: %v", err)
+	}
+	raw, _ := os.ReadFile(path)
+	s := string(raw)
+
+	// Exactly one frontmatter fence pair: mnemo's. The user's --- pair
+	// must have been repackaged.
+	if got := strings.Count(s, "\n---\n"); got > 1 {
+		// One leading "---\n" + one closing "\n---\n" expected from
+		// mnemo's frontmatter only.
+		t.Errorf("expected single frontmatter block, got %d \"---\" lines in:\n%s", got, s)
+	}
+
+	// User's body must be preserved.
+	if !strings.Contains(s, "# My Notes") || !strings.Contains(s, "Body.") {
+		t.Error("user body must survive repackaging")
+	}
+
+	// User's frontmatter must appear in a yaml code block.
+	if !strings.Contains(s, "## Preserved frontmatter") {
+		t.Error("missing 'Preserved frontmatter' section heading")
+	}
+	if !strings.Contains(s, "```yaml\ntitle: User's note") {
+		t.Errorf("user frontmatter must be in a yaml code block, got:\n%s", s)
+	}
+
+	// All of it must appear AFTER the generated fence.
+	fenceIdx := strings.Index(s, generatedFence)
+	preservedIdx := strings.Index(s, "## Preserved frontmatter")
+	if preservedIdx < fenceIdx {
+		t.Error("preserved frontmatter must appear after the fence")
+	}
+}
+
+// TestExtractLeadingFrontmatter covers the helper directly: present,
+// absent, and malformed (no closing ---) frontmatter cases.
+func TestExtractLeadingFrontmatter(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		wantBody string
+		wantRest string
+		wantOK   bool
+	}{
+		{"present", "---\nkey: value\n---\nbody\n", "key: value\n", "body\n", true},
+		{"present-no-trailing-newline", "---\nkey: value\n---", "key: value\n", "", true},
+		{"absent", "no frontmatter here\n", "", "no frontmatter here\n", false},
+		{"empty", "", "", "", false},
+		{"only-opening", "---\nkey: value\n", "", "---\nkey: value\n", false},
+		{"empty-body", "---\n---\nbody\n", "", "body\n", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			body, rest, ok := extractLeadingFrontmatter(c.in)
+			if ok != c.wantOK {
+				t.Errorf("ok = %v, want %v", ok, c.wantOK)
+			}
+			if body != c.wantBody {
+				t.Errorf("body = %q, want %q", body, c.wantBody)
+			}
+			if rest != c.wantRest {
+				t.Errorf("rest = %q, want %q", rest, c.wantRest)
+			}
+		})
+	}
+}
+
+// TestParseEntityTSLineAnchored verifies bug C fix: the entity timestamp
+// must be located via a per-line scan rather than plain LastIndex, so a
+// user pasting the literal entityTSComment string into their annotations
+// doesn't poison the parse. Mirrors the line-anchored fence detection
+// added in the fifth-pass commit.
+func TestParseEntityTSLineAnchored(t *testing.T) {
+	cases := []struct {
+		name   string
+		raw    string
+		wantTS string
+		wantOK bool
+	}{
+		{
+			name:   "valid-line-anchored",
+			raw:    "preamble\n<!-- mnemo:entity_ts 2026-05-10T10:00:00Z -->\n" + generatedFence + "\n",
+			wantTS: "2026-05-10T10:00:00Z",
+			wantOK: true,
+		},
+		{
+			name: "inline-string-in-prose-not-matched",
+			// User wrote a paragraph that includes the literal comment prefix
+			// inline (no newline before it). The whole-line check must skip it.
+			raw:    "see how the marker `<!-- mnemo:entity_ts FAKE -->` is parsed\nbody only, no real marker\n",
+			wantOK: false,
+		},
+		{
+			name:   "last-line-anchored-wins-over-earlier-inline",
+			raw:    "quoted `<!-- mnemo:entity_ts INLINE -->` here\n<!-- mnemo:entity_ts 2026-05-11T00:00:00Z -->\n" + generatedFence + "\n",
+			wantTS: "2026-05-11T00:00:00Z",
+			wantOK: true,
+		},
+		{
+			name:   "missing",
+			raw:    "no marker at all\n",
+			wantOK: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ts, ok := parseEntityTS(c.raw)
+			if ok != c.wantOK {
+				t.Errorf("ok = %v, want %v", ok, c.wantOK)
+			}
+			if ts != c.wantTS {
+				t.Errorf("ts = %q, want %q", ts, c.wantTS)
+			}
+		})
 	}
 }
 
@@ -1038,18 +1173,30 @@ func TestVaultSyncCoalescesConcurrentCalls(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	// Run two Syncs concurrently. Both must complete without error and
-	// without corrupting the vault state.
+	// Run two Syncs concurrently. One must complete cleanly; the other
+	// must return ErrSyncInFlight (coalesced — see bug D fix). Surfacing
+	// the skip honestly is the whole point: a silent nil would mislead
+	// MCP callers into thinking their sync request ran.
 	errs := make(chan error, 2)
 	for range 2 {
 		go func() {
 			errs <- exp.Sync(context.Background())
 		}()
 	}
+	var nilCount, inFlightCount int
 	for range 2 {
-		if err := <-errs; err != nil {
+		switch err := <-errs; {
+		case err == nil:
+			nilCount++
+		case errors.Is(err, ErrSyncInFlight):
+			inFlightCount++
+		default:
 			t.Errorf("concurrent Sync failed: %v", err)
 		}
+	}
+	if nilCount != 1 || inFlightCount != 1 {
+		t.Errorf("expected exactly one nil and one ErrSyncInFlight, got nil=%d inFlight=%d",
+			nilCount, inFlightCount)
 	}
 
 	// Vault state must be consistent (fence present, file readable).

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -725,10 +725,10 @@ func TestBidirectionalSync(t *testing.T) {
 		summary := fmt.Sprintf("%d results:", len(results))
 		for _, r := range results {
 			n := len(r.Text)
-		if n > 50 {
-			n = 50
-		}
-		summary += fmt.Sprintf(" [%s]%q", r.Role, r.Text[:n])
+			if n > 50 {
+				n = 50
+			}
+			summary += fmt.Sprintf(" [%s]%q", r.Role, r.Text[:n])
 		}
 		t.Errorf("vault annotation not found in search results; %s", summary)
 	}
@@ -739,6 +739,113 @@ func TestBidirectionalSync(t *testing.T) {
 		if r.Role == "vault" && strings.Contains(r.Text, "session_id:") {
 			t.Error("generated frontmatter re-indexed as vault annotation — feedback loop!")
 		}
+	}
+
+	// Removing the annotation and re-ingesting should drop the row.
+	if err := os.WriteFile(noteFile, raw, 0o644); err != nil {
+		t.Fatalf("rewrite without annotation: %v", err)
+	}
+	if err := s.IngestVaultAnnotations(vaultDir); err != nil {
+		t.Fatalf("IngestVaultAnnotations after removal: %v", err)
+	}
+	results, err = s.Search("unique annotation bidir feature", 10, "all", "", 0, 0, false)
+	if err != nil {
+		t.Fatalf("Search after removal: %v", err)
+	}
+	for _, r := range results {
+		if r.Role == "vault" && strings.Contains(r.Text, "unique annotation") {
+			t.Error("annotation row should be removed after content deletion")
+		}
+	}
+}
+
+// TestVaultOnlySearch verifies Phase 3 vault hits surface even when the
+// transcript FTS produces zero hits — regression test for the early-return
+// that previously short-circuited before Phase 3 ran.
+func TestVaultOnlySearch(t *testing.T) {
+	projDir := t.TempDir()
+	storetest.WriteJSONL(t, projDir, "-Users-alice-dev-myapp", "sess-vo-01", []map[string]any{
+		storetest.MetaMsg("user", "completely different transcript content",
+			"2026-05-10T10:00:00Z", "/Users/alice/dev/myapp", "main"),
+	})
+	s := storetest.NewStore(t, projDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	vaultDir := t.TempDir()
+	exp, err := New(s, vaultDir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	sessionFiles, _ := filepath.Glob(filepath.Join(vaultDir, "sessions", "*", "*.md"))
+	if len(sessionFiles) == 0 {
+		t.Fatal("no session files")
+	}
+	raw, _ := os.ReadFile(sessionFiles[0])
+	annotated := string(raw) + "\nzymurgist-quibble-paradigm\n"
+	os.WriteFile(sessionFiles[0], []byte(annotated), 0o644)
+	if err := s.IngestVaultAnnotations(vaultDir); err != nil {
+		t.Fatalf("IngestVaultAnnotations: %v", err)
+	}
+
+	// Search for a term that only appears in the annotation, not in any message.
+	results, err := s.Search("zymurgist quibble paradigm", 10, "all", "", 0, 0, false)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("vault-only search returned zero results; Phase 3 must run when Phase 2 is empty")
+	}
+	if results[0].Role != "vault" {
+		t.Errorf("expected first result Role=vault, got %q", results[0].Role)
+	}
+}
+
+// TestVaultSyncCoalescesConcurrentCalls verifies that two concurrent
+// Sync() calls don't both run a full pass — the second returns
+// immediately while the first completes. This protects writeNote's
+// read-modify-write of fenced files from interleaved racing writes.
+func TestVaultSyncCoalescesConcurrentCalls(t *testing.T) {
+	projDir := t.TempDir()
+	storetest.WriteJSONL(t, projDir, "-Users-alice-dev-myapp", "sess-coal-01", []map[string]any{
+		storetest.MetaMsg("user", "hi", "2026-05-10T10:00:00Z",
+			"/Users/alice/dev/myapp", "main"),
+	})
+	s := storetest.NewStore(t, projDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	vaultDir := t.TempDir()
+	exp, err := New(s, vaultDir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Run two Syncs concurrently. Both must complete without error and
+	// without corrupting the vault state.
+	errs := make(chan error, 2)
+	for range 2 {
+		go func() {
+			errs <- exp.Sync(context.Background())
+		}()
+	}
+	for range 2 {
+		if err := <-errs; err != nil {
+			t.Errorf("concurrent Sync failed: %v", err)
+		}
+	}
+
+	// Vault state must be consistent (fence present, file readable).
+	sessionFiles, _ := filepath.Glob(filepath.Join(vaultDir, "sessions", "*", "*.md"))
+	if len(sessionFiles) == 0 {
+		t.Fatal("no session files after concurrent Sync")
+	}
+	raw, _ := os.ReadFile(sessionFiles[0])
+	if c := strings.Count(string(raw), generatedFence); c != 1 {
+		t.Errorf("expected 1 fence after concurrent Sync, got %d", c)
 	}
 }
 

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -628,6 +628,28 @@ func TestParseEntityTSLineAnchored(t *testing.T) {
 			raw:    "no marker at all\n",
 			wantOK: false,
 		},
+		{
+			// Degenerate input: prefix ends with a space, suffix starts
+			// with a space; on the literal "<!-- mnemo:entity_ts -->" line
+			// they share that space. HasPrefix+HasSuffix both pass, but
+			// the substring between them is negative-length. Without the
+			// length guard, slicing would panic — a user pasting this
+			// literal into their annotations would crash the next sync.
+			name:   "prefix-suffix-overlap-no-timestamp",
+			raw:    "<!-- mnemo:entity_ts -->\n",
+			wantOK: false,
+		},
+		{
+			// Adjacent prefix+suffix with zero-width timestamp slot
+			// ("<!-- mnemo:entity_ts  -->" — two spaces). Both fences
+			// match; the slot between them is empty but well-formed.
+			// Treat as a valid match with an empty timestamp; needsUpdate
+			// will fail to parse it and fall through to "regenerate".
+			name:   "prefix-suffix-empty-timestamp",
+			raw:    "<!-- mnemo:entity_ts  -->\n",
+			wantTS: "",
+			wantOK: true,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -294,9 +294,9 @@ func TestRenderSessionFrontmatter(t *testing.T) {
 		{"- session\n", "session tag"},
 		{"- feature\n", "feature tag"},
 		{"# test session\n", "title heading"},
-		{"[[repos/mnemo]]", "repo wikilink"},
-		{"**Human**", "Human role marker"},
-		{"**Claude**", "Claude role marker"},
+		{"[[repos/mnemo", "repo wikilink"},
+		{"### Human", "Human role marker"},
+		{"### Claude", "Claude role marker"},
 		{"Hello", "user message text"},
 		{"Hi there", "assistant message text"},
 	}
@@ -364,10 +364,10 @@ func TestRenderRootIndex(t *testing.T) {
 	}
 	note := renderRootIndex(repos, nil)
 
-	if !strings.Contains(note, "[[repos/mnemo]]") {
+	if !strings.Contains(note, "[[repos/mnemo") {
 		t.Error("missing mnemo repo wikilink")
 	}
-	if !strings.Contains(note, "[[repos/other-repo]]") {
+	if !strings.Contains(note, "[[repos/other-repo") {
 		t.Error("missing other-repo wikilink")
 	}
 	if !strings.Contains(note, "42 sessions") {
@@ -801,6 +801,46 @@ func TestVaultOnlySearch(t *testing.T) {
 	}
 	if results[0].Role != "vault" {
 		t.Errorf("expected first result Role=vault, got %q", results[0].Role)
+	}
+}
+
+// TestUserCreatedFileIsIndexed verifies that a standalone .md file dropped
+// into the vault by a user (no <!-- mnemo:generated --> fence) is indexed
+// in full — this is the "humans can add new files to enhance mnemo's
+// knowledge" half of bidirectional sync.
+func TestUserCreatedFileIsIndexed(t *testing.T) {
+	projDir := t.TempDir()
+	s := storetest.NewStore(t, projDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	vaultDir := t.TempDir()
+
+	// User drops their own note into the vault (no fence — entirely human content).
+	userFile := filepath.Join(vaultDir, "my-thoughts.md")
+	body := "# Brainstorm\n\nIdeas about distributed consensus protocols and Byzantine generals.\n"
+	if err := os.WriteFile(userFile, []byte(body), 0o644); err != nil {
+		t.Fatalf("write user file: %v", err)
+	}
+
+	if err := s.IngestVaultAnnotations(vaultDir); err != nil {
+		t.Fatalf("IngestVaultAnnotations: %v", err)
+	}
+
+	// User's note must be findable via mnemo_search.
+	results, err := s.Search("Byzantine generals consensus", 10, "all", "", 0, 0, false)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	found := false
+	for _, r := range results {
+		if r.Role == "vault" && strings.Contains(r.Text, "Byzantine") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("user-created standalone file not found in search; %d results", len(results))
 	}
 }
 

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -844,6 +844,80 @@ func TestUserCreatedFileIsIndexed(t *testing.T) {
 	}
 }
 
+// TestVaultDeletionPrunesRow verifies that deleting a vault .md file
+// removes its row from the docs table on the next ingest pass — without
+// this, search would return content from files the user has removed.
+func TestVaultDeletionPrunesRow(t *testing.T) {
+	projDir := t.TempDir()
+	s := storetest.NewStore(t, projDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	vaultDir := t.TempDir()
+
+	notePath := filepath.Join(vaultDir, "ephemeral.md")
+	body := "# Ephemeral\n\nThis content references the rare term flibbertigibbet.\n"
+	if err := os.WriteFile(notePath, []byte(body), 0o644); err != nil {
+		t.Fatalf("write note: %v", err)
+	}
+	if err := s.IngestVaultAnnotations(vaultDir); err != nil {
+		t.Fatalf("first ingest: %v", err)
+	}
+
+	// Sanity: searchable before deletion.
+	results, _ := s.Search("flibbertigibbet", 10, "all", "", 0, 0, false)
+	if len(results) == 0 {
+		t.Fatal("expected search to find note before deletion")
+	}
+
+	// Delete the file and re-ingest.
+	if err := os.Remove(notePath); err != nil {
+		t.Fatalf("remove note: %v", err)
+	}
+	if err := s.IngestVaultAnnotations(vaultDir); err != nil {
+		t.Fatalf("post-deletion ingest: %v", err)
+	}
+
+	results, _ = s.Search("flibbertigibbet", 10, "all", "", 0, 0, false)
+	for _, r := range results {
+		if r.Role == "vault" {
+			t.Errorf("deleted file still surfaces in search: %q", r.Text)
+		}
+	}
+}
+
+// TestVaultSkipsHiddenDirs verifies that .obsidian/, .git/ etc. are not
+// scanned (avoids inotify exhaustion on Linux + skips tool config churn).
+func TestVaultSkipsHiddenDirs(t *testing.T) {
+	projDir := t.TempDir()
+	s := storetest.NewStore(t, projDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	vaultDir := t.TempDir()
+
+	// Plant a .md file inside an Obsidian config dir — must NOT be indexed.
+	hidden := filepath.Join(vaultDir, ".obsidian")
+	if err := os.MkdirAll(hidden, 0o755); err != nil {
+		t.Fatalf("mkdir hidden: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hidden, "plugin-config.md"),
+		[]byte("zibblefrotz-config-internal\n"), 0o644); err != nil {
+		t.Fatalf("write hidden file: %v", err)
+	}
+
+	if err := s.IngestVaultAnnotations(vaultDir); err != nil {
+		t.Fatalf("IngestVaultAnnotations: %v", err)
+	}
+
+	results, _ := s.Search("zibblefrotz config internal", 10, "all", "", 0, 0, false)
+	for _, r := range results {
+		if r.Role == "vault" {
+			t.Errorf("hidden dir content leaked into search: %q", r.Text)
+		}
+	}
+}
+
 // TestVaultSyncCoalescesConcurrentCalls verifies that two concurrent
 // Sync() calls don't both run a full pass — the second returns
 // immediately while the first completes. This protects writeNote's

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -176,7 +177,7 @@ func TestWriteNoteFencePreservesHumanContent(t *testing.T) {
 	path := filepath.Join(dir, "test.md")
 
 	// Initial write.
-	if err := writeNote(path, "# Generated\n\nGenerated v1."); err != nil {
+	if err := writeNote(path, "# Generated\n\nGenerated v1.", ""); err != nil {
 		t.Fatalf("initial writeNote: %v", err)
 	}
 
@@ -186,7 +187,7 @@ func TestWriteNoteFencePreservesHumanContent(t *testing.T) {
 	os.WriteFile(path, []byte(withHuman), 0o644)
 
 	// Re-sync with updated generated content.
-	if err := writeNote(path, "# Generated\n\nGenerated v2."); err != nil {
+	if err := writeNote(path, "# Generated\n\nGenerated v2.", ""); err != nil {
 		t.Fatalf("re-sync writeNote: %v", err)
 	}
 
@@ -221,7 +222,7 @@ func TestWriteNoteFenceNoCascade(t *testing.T) {
 	path := filepath.Join(dir, "test.md")
 
 	for i := 0; i < 3; i++ {
-		if err := writeNote(path, "# Generated"); err != nil {
+		if err := writeNote(path, "# Generated", ""); err != nil {
 			t.Fatalf("writeNote run %d: %v", i, err)
 		}
 	}
@@ -238,7 +239,7 @@ func TestWriteNoteNoFenceNoHuman(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "note.md")
 
-	if err := writeNote(path, "# Title\n\nContent."); err != nil {
+	if err := writeNote(path, "# Title\n\nContent.", ""); err != nil {
 		t.Fatalf("writeNote: %v", err)
 	}
 
@@ -258,7 +259,7 @@ func TestWriteNoteNoFenceNoHuman(t *testing.T) {
 func TestWriteNoteCreatesParentDirs(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "a", "b", "c", "note.md")
-	if err := writeNote(path, "hello"); err != nil {
+	if err := writeNote(path, "hello", ""); err != nil {
 		t.Fatalf("writeNote with deep path: %v", err)
 	}
 	if _, err := os.Stat(path); err != nil {
@@ -429,10 +430,100 @@ func TestNeedsUpdateEmptyTS(t *testing.T) {
 func TestNeedsUpdateFreshFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "f.md")
-	os.WriteFile(path, []byte("x"), 0o644)
-	// File was just created; any past timestamp should not need update.
-	if needsUpdate(path, "2020-01-01T00:00:00Z") {
-		t.Error("fresh file with old timestamp should not need update")
+	const ts = "2020-01-01T00:00:00Z"
+	// Write via writeNote so the entity_ts comment is embedded.
+	if err := writeNote(path, "content", ts); err != nil {
+		t.Fatalf("writeNote: %v", err)
+	}
+	// Same timestamp → no update needed.
+	if needsUpdate(path, ts) {
+		t.Error("file with same entity timestamp should not need update")
+	}
+	// Older entity timestamp → no update needed.
+	if needsUpdate(path, "2019-01-01T00:00:00Z") {
+		t.Error("file with newer recorded timestamp should not need update")
+	}
+	// Newer entity timestamp → update needed.
+	if !needsUpdate(path, "2026-01-01T00:00:00Z") {
+		t.Error("file with older recorded timestamp should need update")
+	}
+}
+
+func TestNeedsUpdateHumanEditDoesNotSuppressRegeneration(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.md")
+	const entityTS = "2020-01-01T00:00:00Z"
+	if err := writeNote(path, "generated", entityTS); err != nil {
+		t.Fatalf("writeNote: %v", err)
+	}
+	// Simulate human touching the file — bump mtime to now.
+	raw, _ := os.ReadFile(path)
+	os.WriteFile(path, raw, 0o644)
+
+	// Entity timestamp recorded in file is still 2020; a newer entity_ts
+	// must trigger regeneration regardless of file mtime.
+	if !needsUpdate(path, "2026-01-01T00:00:00Z") {
+		t.Error("newer entity timestamp should trigger update even after human edit")
+	}
+	// But same entity timestamp must NOT trigger regeneration.
+	if needsUpdate(path, entityTS) {
+		t.Error("same entity timestamp should not trigger update after human edit")
+	}
+}
+
+func TestWriteNotePreservesPreExistingContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "existing.md")
+	// Pre-existing file with no fence (e.g. user's own Obsidian note).
+	preExisting := "# My Notes\n\nThis is my content.\n"
+	os.WriteFile(path, []byte(preExisting), 0o644)
+
+	if err := writeNote(path, "# Generated", ""); err != nil {
+		t.Fatalf("writeNote: %v", err)
+	}
+	raw, _ := os.ReadFile(path)
+	s := string(raw)
+	if !strings.Contains(s, "My Notes") {
+		t.Error("pre-existing content must be preserved as human content")
+	}
+	if !strings.Contains(s, "This is my content") {
+		t.Error("pre-existing content body must survive writeNote")
+	}
+	if !strings.Contains(s, "# Generated") {
+		t.Error("generated content must be written")
+	}
+	if !strings.Contains(s, generatedFence) {
+		t.Error("fence must be present")
+	}
+	// Pre-existing content must appear after the fence.
+	fenceIdx := strings.Index(s, generatedFence)
+	userIdx := strings.Index(s, "My Notes")
+	if userIdx < fenceIdx {
+		t.Error("pre-existing content must appear after fence")
+	}
+}
+
+func TestWriteYAMLNewlineEscaping(t *testing.T) {
+	var b strings.Builder
+	writeYAML(&b, "title", "Bug: crash\nin handler")
+	got := b.String()
+	if strings.Contains(got, "\n  ") {
+		t.Errorf("newline must be escaped, got literal newline in: %q", got)
+	}
+	if !strings.Contains(got, `\n`) {
+		t.Errorf("expected \\n escape sequence, got: %q", got)
+	}
+}
+
+func TestWriteYAMLTabEscaping(t *testing.T) {
+	var b strings.Builder
+	writeYAML(&b, "key", "val\twith\ttabs")
+	got := b.String()
+	if strings.ContainsRune(got, '\t') {
+		t.Errorf("tab must be escaped, got literal tab in: %q", got)
+	}
+	if !strings.Contains(got, `\t`) {
+		t.Errorf("expected \\t escape sequence, got: %q", got)
 	}
 }
 
@@ -574,3 +665,80 @@ func TestExporterSyncCreatesFiles(t *testing.T) {
 		}
 	}
 }
+
+// TestBidirectionalSync verifies that human annotations below the fence are
+// indexed by IngestVaultAnnotations and returned by mnemo_search, while
+// generated content above the fence is not re-indexed as a vault annotation.
+func TestBidirectionalSync(t *testing.T) {
+	projDir := t.TempDir()
+	storetest.WriteJSONL(t, projDir, "-Users-alice-dev-myapp", "sess-bidir-01", []map[string]any{
+		storetest.MetaMsg("user", "hello bidir", "2026-05-10T10:00:00Z",
+			"/Users/alice/dev/myapp", "main"),
+		storetest.Msg("assistant", "bidir response", "2026-05-10T10:00:01Z"),
+	})
+
+	s := storetest.NewStore(t, projDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	vaultDir := t.TempDir()
+	exp, err := New(s, vaultDir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	// Locate the generated session note and add a human annotation below the fence.
+	sessionFiles, _ := filepath.Glob(filepath.Join(vaultDir, "sessions", "*", "*.md"))
+	if len(sessionFiles) == 0 {
+		t.Fatal("no session files generated")
+	}
+	noteFile := sessionFiles[0]
+	raw, _ := os.ReadFile(noteFile)
+	annotation := "\n## My note\n\nThis is my unique annotation about the bidir feature.\n"
+	annotated := string(raw) + annotation
+	if err := os.WriteFile(noteFile, []byte(annotated), 0o644); err != nil {
+		t.Fatalf("write annotation: %v", err)
+	}
+
+	// IngestVaultAnnotations should index the below-fence content.
+	if err := s.IngestVaultAnnotations(vaultDir); err != nil {
+		t.Fatalf("IngestVaultAnnotations: %v", err)
+	}
+
+	// Verify the annotation is found by Search.
+	results, err := s.Search("unique annotation bidir feature", 10, "all", "", 0, 0, false)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	found := false
+	for _, r := range results {
+		if r.Role == "vault" && strings.Contains(r.Text, "unique annotation") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		summary := fmt.Sprintf("%d results:", len(results))
+		for _, r := range results {
+			n := len(r.Text)
+		if n > 50 {
+			n = 50
+		}
+		summary += fmt.Sprintf(" [%s]%q", r.Role, r.Text[:n])
+		}
+		t.Errorf("vault annotation not found in search results; %s", summary)
+	}
+
+	// Generated content above the fence must NOT appear as a vault annotation
+	// (no feedback loop). Check that no vault result contains the session header.
+	for _, r := range results {
+		if r.Role == "vault" && strings.Contains(r.Text, "session_id:") {
+			t.Error("generated frontmatter re-indexed as vault annotation — feedback loop!")
+		}
+	}
+}
+

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -613,6 +613,57 @@ func TestRenderSessionAliases(t *testing.T) {
 	}
 }
 
+// TestRenderSessionAliasesNewlineEscaping verifies that topics containing
+// newlines/tabs/quotes do not break the YAML aliases array. Topics are
+// extracted from conversation text and may contain any character.
+func TestRenderSessionAliasesNewlineEscaping(t *testing.T) {
+	info := store.SessionInfo{
+		SessionID: "abc123def456",
+		Topic:     "first line\nsecond line\twith\ttabs and \"quotes\"",
+		FirstMsg:  "2026-05-10T10:00:00Z",
+	}
+	note := renderSession(info, nil)
+
+	// Extract aliases block (between "aliases:\n" and the next key/end of frontmatter).
+	aliasIdx := strings.Index(note, "aliases:\n")
+	if aliasIdx < 0 {
+		t.Fatal("session note missing aliases frontmatter")
+	}
+	rest := note[aliasIdx+len("aliases:\n"):]
+	tagsIdx := strings.Index(rest, "tags:")
+	if tagsIdx < 0 {
+		t.Fatal("session note missing tags frontmatter")
+	}
+	aliasBlock := rest[:tagsIdx]
+
+	// Every line in the alias block must be a list item ("  - \"...\"").
+	// A raw newline in the topic would split the alias across multiple lines,
+	// producing a malformed entry like `  - "first line` followed by a bare
+	// `second line"` line.
+	for _, line := range strings.Split(strings.TrimRight(aliasBlock, "\n"), "\n") {
+		if !strings.HasPrefix(line, "  - \"") || !strings.HasSuffix(line, "\"") {
+			t.Errorf("alias line not properly quoted: %q", line)
+		}
+	}
+
+	// Escape sequences must be present (not literal control chars).
+	if strings.Contains(aliasBlock, "\n  - \"second") {
+		t.Error("topic newline not escaped — alias array is malformed")
+	}
+	if strings.ContainsRune(aliasBlock, '\t') {
+		t.Error("topic tab not escaped — alias array contains literal tab")
+	}
+	if !strings.Contains(aliasBlock, `\n`) {
+		t.Errorf("expected \\n escape in alias, got: %q", aliasBlock)
+	}
+	if !strings.Contains(aliasBlock, `\t`) {
+		t.Errorf("expected \\t escape in alias, got: %q", aliasBlock)
+	}
+	if !strings.Contains(aliasBlock, `\"quotes\"`) {
+		t.Errorf("expected \\\" escape for embedded quotes, got: %q", aliasBlock)
+	}
+}
+
 // ---- Exporter.Sync integration ----------------------------------------------
 
 // TestExporterSyncCreatesFiles verifies that Sync writes the expected vault

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1,0 +1,576 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package vault
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/marcelocantos/mnemo/internal/store"
+	"github.com/marcelocantos/mnemo/internal/storetest"
+)
+
+// ---- slugify ----------------------------------------------------------------
+
+func TestSlugify(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Hello World", "hello-world"},
+		{"vault feature implementation", "vault-feature-implementation"},
+		{"  leading and trailing  ", "leading-and-trailing"},
+		{"special!@#$chars", "special-chars"},
+		{"already-slug", "already-slug"},
+		{"", "untitled"},
+		{strings.Repeat("a", 100), strings.Repeat("a", 60)},
+		{"ends-with-special!!!!!", "ends-with-special"},
+	}
+	for _, c := range cases {
+		got := slugify(c.in)
+		if got != c.want {
+			t.Errorf("slugify(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// ---- dateOf -----------------------------------------------------------------
+
+func TestDateOf(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"2026-05-10T14:23:45Z", "2026-05-10"},
+		{"2026-05-10T14:23:45.123Z", "2026-05-10"},
+		{"2026-05-10", "2026-05-10"},
+	}
+	for _, c := range cases {
+		got := dateOf(c.in)
+		if got != c.want {
+			t.Errorf("dateOf(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDateOfEmpty(t *testing.T) {
+	// Empty input returns today's date; just check it's YYYY-MM-DD shaped.
+	got := dateOf("")
+	if len(got) != 10 || got[4] != '-' || got[7] != '-' {
+		t.Errorf("dateOf(\"\") = %q, want YYYY-MM-DD", got)
+	}
+}
+
+// ---- shortID ----------------------------------------------------------------
+
+func TestShortID(t *testing.T) {
+	if got := shortID("abc123def456"); got != "abc123de" {
+		t.Errorf("shortID long: %q", got)
+	}
+	if got := shortID("abc"); got != "abc" {
+		t.Errorf("shortID short: %q", got)
+	}
+}
+
+// ---- shortProjectName -------------------------------------------------------
+
+func TestShortProjectName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"/Users/navnita/dev/mnemo", "mnemo"},
+		{"/Users/navnita/dev/riot-mind", "riot-mind"},
+		{"-Users-navnita-dev-mnemo", "mnemo"},
+		{"-Users-navnita-dev-thittam", "thittam"},
+		{"-Users-navnita-documents-writing-the-apothecary-diaries", "writing-the-apothecary-diaries"},
+		{"-Users-alice-work-myapp", "myapp"},
+		{"-Users-navnita", "users-navnita"}, // root home project, no stripping
+		{"simple-name", "simple-name"},
+	}
+	for _, c := range cases {
+		got := shortProjectName(c.in)
+		if got != c.want {
+			t.Errorf("shortProjectName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// ---- path generation --------------------------------------------------------
+
+func TestSessionPath(t *testing.T) {
+	info := store.SessionInfo{
+		SessionID: "abc123def456789x",
+		Repo:      "mnemo",
+		Topic:     "vault feature",
+		FirstMsg:  "2026-05-10T14:23:45Z",
+	}
+	got := sessionPath(info)
+	if !strings.HasPrefix(got, "sessions/mnemo/") {
+		t.Errorf("expected sessions/mnemo/ prefix, got %q", got)
+	}
+	if !strings.Contains(got, "2026-05-10") {
+		t.Errorf("expected date in path, got %q", got)
+	}
+	if !strings.Contains(got, "vault-feature") {
+		t.Errorf("expected topic slug in path, got %q", got)
+	}
+	if !strings.Contains(got, "abc123de") {
+		t.Errorf("expected short session ID in path, got %q", got)
+	}
+	if !strings.HasSuffix(got, ".md") {
+		t.Errorf("expected .md suffix, got %q", got)
+	}
+}
+
+func TestSessionPathNoRepo(t *testing.T) {
+	info := store.SessionInfo{
+		SessionID: "abc123def456789x",
+		Project:   "-Users-alice-dev-myapp",
+		FirstMsg:  "2026-05-10T14:23:45Z",
+	}
+	got := sessionPath(info)
+	if !strings.HasPrefix(got, "sessions/") {
+		t.Errorf("expected sessions/ prefix, got %q", got)
+	}
+}
+
+func TestDecisionPath(t *testing.T) {
+	d := store.DecisionInfo{
+		SessionID: "sess1234abcd",
+		Repo:      "my-repo",
+		Timestamp: "2026-05-10T10:00:00Z",
+	}
+	got := decisionPath(d)
+	if !strings.HasPrefix(got, "decisions/my-repo/") {
+		t.Errorf("expected decisions/my-repo/ prefix, got %q", got)
+	}
+	if !strings.Contains(got, "2026-05-10") {
+		t.Errorf("expected date, got %q", got)
+	}
+	if !strings.Contains(got, "sess1234") {
+		t.Errorf("expected session ID prefix, got %q", got)
+	}
+}
+
+func TestMemoryPath(t *testing.T) {
+	m := store.MemoryInfo{
+		Project: "-Users-alice-dev-myapp",
+		Name:    "My Memory",
+	}
+	got := memoryPath(m)
+	if !strings.HasPrefix(got, "memories/") {
+		t.Errorf("expected memories/ prefix, got %q", got)
+	}
+	if !strings.Contains(got, "my-memory") {
+		t.Errorf("expected name slug, got %q", got)
+	}
+}
+
+func TestRepoIndexPath(t *testing.T) {
+	got := repoIndexPath("My Repo")
+	if got != filepath.Join("repos", "my-repo.md") {
+		t.Errorf("repoIndexPath = %q, want repos/my-repo.md", got)
+	}
+}
+
+// ---- writeNote fence preservation -------------------------------------------
+
+func TestWriteNoteFencePreservesHumanContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.md")
+
+	// Initial write.
+	if err := writeNote(path, "# Generated\n\nGenerated v1."); err != nil {
+		t.Fatalf("initial writeNote: %v", err)
+	}
+
+	// Simulate human adding content below the fence.
+	raw, _ := os.ReadFile(path)
+	withHuman := string(raw) + "\n## My notes\n\nHuman wrote this.\n"
+	os.WriteFile(path, []byte(withHuman), 0o644)
+
+	// Re-sync with updated generated content.
+	if err := writeNote(path, "# Generated\n\nGenerated v2."); err != nil {
+		t.Fatalf("re-sync writeNote: %v", err)
+	}
+
+	final, _ := os.ReadFile(path)
+	s := string(final)
+
+	if !strings.Contains(s, "Generated v2") {
+		t.Error("re-sync should update generated content")
+	}
+	if strings.Contains(s, "Generated v1") {
+		t.Error("old generated content should be replaced")
+	}
+	if !strings.Contains(s, "Human wrote this") {
+		t.Error("re-sync should preserve human content")
+	}
+	if !strings.Contains(s, generatedFence) {
+		t.Error("fence marker must be present")
+	}
+
+	// Human content must appear after the fence.
+	fenceIdx := strings.Index(s, generatedFence)
+	humanIdx := strings.Index(s, "Human wrote this")
+	if humanIdx < fenceIdx {
+		t.Error("human content must appear after the fence marker")
+	}
+}
+
+// TestWriteNoteFenceNoCascade verifies that repeated re-syncs without human
+// edits do not accumulate multiple fence markers (the stacked-fence bug).
+func TestWriteNoteFenceNoCascade(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.md")
+
+	for i := 0; i < 3; i++ {
+		if err := writeNote(path, "# Generated"); err != nil {
+			t.Fatalf("writeNote run %d: %v", i, err)
+		}
+	}
+
+	raw, _ := os.ReadFile(path)
+	s := string(raw)
+	count := strings.Count(s, generatedFence)
+	if count != 1 {
+		t.Errorf("expected exactly 1 fence after 3 syncs, got %d\ncontent:\n%s", count, s)
+	}
+}
+
+func TestWriteNoteNoFenceNoHuman(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "note.md")
+
+	if err := writeNote(path, "# Title\n\nContent."); err != nil {
+		t.Fatalf("writeNote: %v", err)
+	}
+
+	raw, _ := os.ReadFile(path)
+	s := string(raw)
+	if !strings.Contains(s, "# Title") {
+		t.Error("title missing")
+	}
+	if !strings.Contains(s, generatedFence) {
+		t.Error("fence must always be written")
+	}
+	if !strings.HasSuffix(s, "\n") {
+		t.Error("file must end with newline")
+	}
+}
+
+func TestWriteNoteCreatesParentDirs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a", "b", "c", "note.md")
+	if err := writeNote(path, "hello"); err != nil {
+		t.Fatalf("writeNote with deep path: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("file not created: %v", err)
+	}
+}
+
+// ---- renderSession ----------------------------------------------------------
+
+func TestRenderSessionFrontmatter(t *testing.T) {
+	info := store.SessionInfo{
+		SessionID: "abc123def456",
+		Repo:      "mnemo",
+		Topic:     "test session",
+		WorkType:  "feature",
+		FirstMsg:  "2026-05-10T10:00:00Z",
+		LastMsg:   "2026-05-10T11:00:00Z",
+	}
+	msgs := []store.SessionMessage{
+		{Role: "user", Text: "Hello", Timestamp: "2026-05-10T10:00:00Z"},
+		{Role: "assistant", Text: "Hi there", Timestamp: "2026-05-10T10:00:01Z"},
+	}
+	note := renderSession(info, msgs)
+
+	checks := []struct {
+		want string
+		desc string
+	}{
+		{"session_id: abc123def456", "session_id in frontmatter"},
+		{"repo: mnemo", "repo in frontmatter"},
+		{"work_type: feature", "work_type in frontmatter"},
+		{"- session\n", "session tag"},
+		{"- feature\n", "feature tag"},
+		{"# test session\n", "title heading"},
+		{"[[repos/mnemo]]", "repo wikilink"},
+		{"**Human**", "Human role marker"},
+		{"**Claude**", "Claude role marker"},
+		{"Hello", "user message text"},
+		{"Hi there", "assistant message text"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(note, c.want) {
+			t.Errorf("renderSession: missing %s (%q not found)", c.desc, c.want)
+		}
+	}
+}
+
+func TestRenderSessionNoiseFiltered(t *testing.T) {
+	info := store.SessionInfo{
+		SessionID: "abc123",
+		FirstMsg:  "2026-05-10T10:00:00Z",
+	}
+	msgs := []store.SessionMessage{
+		{Role: "user", Text: "Real message", IsNoise: false},
+		{Role: "user", Text: "Noise message", IsNoise: true},
+	}
+	note := renderSession(info, msgs)
+	if strings.Contains(note, "Noise message") {
+		t.Error("noise messages should be filtered from session note")
+	}
+	if !strings.Contains(note, "Real message") {
+		t.Error("real messages must appear in note")
+	}
+}
+
+// ---- renderDecision ---------------------------------------------------------
+
+func TestRenderDecision(t *testing.T) {
+	d := store.DecisionInfo{
+		SessionID:        "sess9999",
+		Repo:             "myrepo",
+		Timestamp:        "2026-05-10T12:00:00Z",
+		ProposalText:     "We should use FTS5.",
+		ConfirmationText: "Agreed, FTS5 it is.",
+	}
+	relPath := "sessions/myrepo/2026-05-10-session-sess9999.md"
+	note := renderDecision(d, relPath)
+
+	if !strings.Contains(note, "session_id: sess9999") {
+		t.Error("missing session_id")
+	}
+	if !strings.Contains(note, "# Decision") {
+		t.Error("missing decision title")
+	}
+	if !strings.Contains(note, "[[sessions/myrepo/2026-05-10-session-sess9999]]") {
+		t.Error("missing session wikilink")
+	}
+	if !strings.Contains(note, "We should use FTS5") {
+		t.Error("missing proposal text")
+	}
+	if !strings.Contains(note, "Agreed, FTS5 it is") {
+		t.Error("missing confirmation text")
+	}
+}
+
+// ---- renderRootIndex --------------------------------------------------------
+
+func TestRenderRootIndex(t *testing.T) {
+	repos := []store.RepoInfo{
+		{Repo: "mnemo", Sessions: 42, LastActivity: "2026-05-10"},
+		{Repo: "other-repo", Sessions: 10, LastActivity: "2026-05-09"},
+	}
+	note := renderRootIndex(repos, nil)
+
+	if !strings.Contains(note, "[[repos/mnemo]]") {
+		t.Error("missing mnemo repo wikilink")
+	}
+	if !strings.Contains(note, "[[repos/other-repo]]") {
+		t.Error("missing other-repo wikilink")
+	}
+	if !strings.Contains(note, "42 sessions") {
+		t.Error("missing session count")
+	}
+}
+
+// ---- writeYAML --------------------------------------------------------------
+
+func TestWriteYAMLQuoting(t *testing.T) {
+	var b strings.Builder
+	writeYAML(&b, "key", "value: with colon")
+	got := b.String()
+	if !strings.Contains(got, `"value: with colon"`) {
+		t.Errorf("expected quoted value, got %q", got)
+	}
+}
+
+func TestWriteYAMLEmpty(t *testing.T) {
+	var b strings.Builder
+	writeYAML(&b, "key", "")
+	if b.String() != "" {
+		t.Errorf("empty value should produce no output, got %q", b.String())
+	}
+}
+
+// ---- summarize --------------------------------------------------------------
+
+func TestSummarize(t *testing.T) {
+	if got := summarize("short", 80); got != "short" {
+		t.Errorf("short string changed: %q", got)
+	}
+	long := strings.Repeat("word ", 20)
+	s := summarize(long, 20)
+	if len(s) > 23 { // 20 + "..."
+		t.Errorf("summarize exceeded maxLen: %q", s)
+	}
+	if !strings.HasSuffix(s, "...") {
+		t.Errorf("summarize should end with ellipsis: %q", s)
+	}
+}
+
+// ---- needsUpdate ------------------------------------------------------------
+
+func TestNeedsUpdateNoFile(t *testing.T) {
+	if !needsUpdate("/nonexistent/path/file.md", "2026-05-10T10:00:00Z") {
+		t.Error("missing file should need update")
+	}
+}
+
+func TestNeedsUpdateEmptyTS(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.md")
+	os.WriteFile(path, []byte("x"), 0o644)
+	if !needsUpdate(path, "") {
+		t.Error("empty timestamp should always need update")
+	}
+}
+
+func TestNeedsUpdateFreshFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.md")
+	os.WriteFile(path, []byte("x"), 0o644)
+	// File was just created; any past timestamp should not need update.
+	if needsUpdate(path, "2020-01-01T00:00:00Z") {
+		t.Error("fresh file with old timestamp should not need update")
+	}
+}
+
+// ---- skillPath / configPath -------------------------------------------------
+
+func TestSkillPath(t *testing.T) {
+	s := store.SkillInfo{Name: "My Skill", FilePath: "/home/user/.claude/skills/my-skill.md"}
+	got := skillPath(s)
+	if got != filepath.Join("skills", "my-skill.md") {
+		t.Errorf("skillPath = %q, want skills/my-skill.md", got)
+	}
+}
+
+func TestConfigPath(t *testing.T) {
+	c := store.ClaudeConfigInfo{Repo: "-Users-alice-dev-myapp", FilePath: "/Users/alice/dev/myapp/CLAUDE.md"}
+	got := configPath(c)
+	if got != filepath.Join("configs", "myapp.md") {
+		t.Errorf("configPath = %q, want configs/myapp.md", got)
+	}
+}
+
+// ---- renderSkill / renderConfig ---------------------------------------------
+
+func TestRenderSkill(t *testing.T) {
+	s := store.SkillInfo{
+		Name:        "commit",
+		FilePath:    "/home/user/.claude/skills/commit.md",
+		Description: "Generate conventional commit messages",
+		Content:     "## Usage\n\nRun /commit to generate a commit message.",
+		UpdatedAt:   "2026-05-10T10:00:00Z",
+	}
+	note := renderSkill(s)
+	checks := []struct{ want, desc string }{
+		{"name: commit", "name in frontmatter"},
+		{"- skill", "skill tag"},
+		{"# Skill: commit", "title heading"},
+		{"Generate conventional commit messages", "description"},
+		{"## Usage", "content included"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(note, c.want) {
+			t.Errorf("renderSkill: missing %s (%q not found)", c.desc, c.want)
+		}
+	}
+}
+
+func TestRenderConfig(t *testing.T) {
+	c := store.ClaudeConfigInfo{
+		Repo:      "mnemo",
+		FilePath:  "/Users/alice/dev/mnemo/CLAUDE.md",
+		Content:   "# mnemo\n\nBuild with go build -tags sqlite_fts5.",
+		UpdatedAt: "2026-05-10T10:00:00Z",
+	}
+	note := renderConfig(c)
+	checks := []struct{ want, desc string }{
+		{"repo: mnemo", "repo in frontmatter"},
+		{"- config", "config tag"},
+		{"- claude-md", "claude-md tag"},
+		{"# CLAUDE.md: mnemo", "title heading"},
+		{"[[repos/mnemo]]", "repo wikilink"},
+		{"go build -tags sqlite_fts5", "content included"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(note, c.want) {
+			t.Errorf("renderConfig: missing %s (%q not found)", c.desc, c.want)
+		}
+	}
+}
+
+// ---- session aliases --------------------------------------------------------
+
+func TestRenderSessionAliases(t *testing.T) {
+	info := store.SessionInfo{
+		SessionID: "abc123def456",
+		Topic:     "my feature topic",
+		FirstMsg:  "2026-05-10T10:00:00Z",
+	}
+	note := renderSession(info, nil)
+	if !strings.Contains(note, "aliases:") {
+		t.Error("session note missing aliases frontmatter")
+	}
+	if !strings.Contains(note, `"my feature topic"`) {
+		t.Error("session note missing topic alias")
+	}
+	if !strings.Contains(note, `"abc123de"`) {
+		t.Error("session note missing short-ID alias")
+	}
+}
+
+// ---- Exporter.Sync integration ----------------------------------------------
+
+// TestExporterSyncCreatesFiles verifies that Sync writes the expected vault
+// files when the store has been populated with a minimal transcript fixture.
+func TestExporterSyncCreatesFiles(t *testing.T) {
+	projDir := t.TempDir()
+	storetest.WriteJSONL(t, projDir, "-Users-alice-dev-myapp", "sess-vault-01", []map[string]any{
+		storetest.MetaMsg("user", "hello vault", "2026-05-10T10:00:00Z",
+			"/Users/alice/dev/myapp", "main"),
+		storetest.Msg("assistant", "vault response", "2026-05-10T10:00:01Z"),
+	})
+
+	s := storetest.NewStore(t, projDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	vaultDir := t.TempDir()
+	exp, err := New(s, vaultDir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	// Root index must exist.
+	if _, err := os.Stat(filepath.Join(vaultDir, "index.md")); err != nil {
+		t.Errorf("index.md missing: %v", err)
+	}
+	// Session note must exist under sessions/<repo-short>/.
+	sessions, _ := filepath.Glob(filepath.Join(vaultDir, "sessions", "*", "*.md"))
+	if len(sessions) == 0 {
+		t.Error("expected at least one session note")
+	}
+	// Repo index note must exist.
+	repos, _ := filepath.Glob(filepath.Join(vaultDir, "repos", "*.md"))
+	if len(repos) == 0 {
+		t.Error("expected at least one repo index note")
+	}
+	// Second Sync must be idempotent (all skipped, no errors).
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("second Sync: %v", err)
+	}
+	// After idempotent re-sync, fence must appear exactly once per file.
+	for _, p := range sessions {
+		raw, _ := os.ReadFile(p)
+		if c := strings.Count(string(raw), generatedFence); c != 1 {
+			t.Errorf("%s: expected 1 fence, got %d", p, c)
+		}
+	}
+}

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -571,6 +571,10 @@ func TestExtractLeadingFrontmatter(t *testing.T) {
 		{"empty", "", "", "", false},
 		{"only-opening", "---\nkey: value\n", "", "---\nkey: value\n", false},
 		{"empty-body", "---\n---\nbody\n", "", "body\n", true},
+		// CRLF on opening fence is tolerated for consistency with
+		// fenceLineIndex. Inner lines are LF-terminated (the trailing \r
+		// would be stripped by TrimRight on the closing-fence line check).
+		{"crlf-opening", "---\r\nkey: value\n---\nbody\n", "key: value\n", "body\n", true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -1173,10 +1177,15 @@ func TestVaultSyncCoalescesConcurrentCalls(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	// Run two Syncs concurrently. One must complete cleanly; the other
-	// must return ErrSyncInFlight (coalesced — see bug D fix). Surfacing
-	// the skip honestly is the whole point: a silent nil would mislead
-	// MCP callers into thinking their sync request ran.
+	// Run two Syncs concurrently. Each must return either nil (ran
+	// cleanly) or ErrSyncInFlight (coalesced — bug D fix). At least one
+	// nil must be observed (the work actually happened) and at most one
+	// nil is possible because the second call is gated on syncing. The
+	// exact (1 nil, 1 inFlight) split is timing-dependent — on a very
+	// fast empty store the two goroutines can run sequentially without
+	// overlap, producing two nils. That's still correct behaviour, just
+	// not exercising the coalescing path; TestSyncReturnsErrSyncInFlight-
+	// WhenBusy below covers the sentinel deterministically.
 	errs := make(chan error, 2)
 	for range 2 {
 		go func() {
@@ -1194,8 +1203,8 @@ func TestVaultSyncCoalescesConcurrentCalls(t *testing.T) {
 			t.Errorf("concurrent Sync failed: %v", err)
 		}
 	}
-	if nilCount != 1 || inFlightCount != 1 {
-		t.Errorf("expected exactly one nil and one ErrSyncInFlight, got nil=%d inFlight=%d",
+	if nilCount < 1 || nilCount+inFlightCount != 2 {
+		t.Errorf("expected at least one nil and total of 2 results, got nil=%d inFlight=%d",
 			nilCount, inFlightCount)
 	}
 
@@ -1207,6 +1216,27 @@ func TestVaultSyncCoalescesConcurrentCalls(t *testing.T) {
 	raw, _ := os.ReadFile(sessionFiles[0])
 	if c := strings.Count(string(raw), generatedFence); c != 1 {
 		t.Errorf("expected 1 fence after concurrent Sync, got %d", c)
+	}
+}
+
+// TestSyncReturnsErrSyncInFlightWhenBusy deterministically verifies the
+// coalescing sentinel: when syncing is already true (simulating an
+// in-flight Sync on another goroutine), a fresh Sync call must return
+// ErrSyncInFlight without doing any work. The concurrent test above is
+// timing-dependent; this one is not.
+func TestSyncReturnsErrSyncInFlightWhenBusy(t *testing.T) {
+	exp, err := New(nil, t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	exp.syncMu.Lock()
+	exp.syncing = true
+	exp.syncMu.Unlock()
+	// nil backend would panic if Sync proceeded into work — its return of
+	// ErrSyncInFlight before touching the backend is what we're asserting.
+	got := exp.Sync(context.Background())
+	if !errors.Is(got, ErrSyncInFlight) {
+		t.Fatalf("Sync = %v, want ErrSyncInFlight", got)
 	}
 }
 

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -844,6 +844,55 @@ func TestUserCreatedFileIsIndexed(t *testing.T) {
 	}
 }
 
+// TestFenceLineIndexLineAnchored verifies that a literal occurrence of
+// the fence string inside the user's annotation (e.g. when documenting
+// mnemo) is NOT treated as a fence — only an exact line match counts.
+// Without line anchoring, vault.writeNote would silently drop any content
+// between the real fence and the user-typed literal on next sync.
+func TestFenceLineIndexLineAnchored(t *testing.T) {
+	raw := "above\n" +
+		"<!-- mnemo:generated -->\n" +
+		"real human content\n" +
+		"And here's how the fence looks inline: `<!-- mnemo:generated -->`\n" +
+		"more human content\n"
+	idx := fenceLineIndex(raw)
+	if idx < 0 {
+		t.Fatal("expected to find the real fence line")
+	}
+	below := strings.TrimLeft(raw[idx:], "\n")
+	if !strings.Contains(below, "real human content") {
+		t.Errorf("missing 'real human content' below fence; got: %q", below)
+	}
+	if !strings.Contains(below, "more human content") {
+		t.Errorf("missing 'more human content' — inline literal incorrectly treated as fence; got: %q", below)
+	}
+}
+
+func TestWriteNotePreservesContentWithInlineFenceLiteral(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "note.md")
+	if err := writeNote(path, "# Generated v1", ""); err != nil {
+		t.Fatalf("initial write: %v", err)
+	}
+	// Human appends content that includes the fence string inline.
+	raw, _ := os.ReadFile(path)
+	annotated := string(raw) + "\nMy notes:\n\n- the fence is `<!-- mnemo:generated -->`\n- and this line must survive\n"
+	if err := os.WriteFile(path, []byte(annotated), 0o644); err != nil {
+		t.Fatalf("annotate: %v", err)
+	}
+	// Re-sync.
+	if err := writeNote(path, "# Generated v2", ""); err != nil {
+		t.Fatalf("re-sync: %v", err)
+	}
+	final, _ := os.ReadFile(path)
+	if !strings.Contains(string(final), "this line must survive") {
+		t.Errorf("content after inline fence literal was dropped: %s", final)
+	}
+	if !strings.Contains(string(final), "Generated v2") {
+		t.Error("re-sync didn't update generated content")
+	}
+}
+
 // TestVaultDeletionPrunesRow verifies that deleting a vault .md file
 // removes its row from the docs table on the next ingest pass — without
 // this, search would return content from files the user has removed.

--- a/main.go
+++ b/main.go
@@ -543,6 +543,17 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	)
 	handler := tools.NewHandler(resolve)
 
+	// Wire the per-user vault syncer resolver so mnemo_vault_sync and
+	// mnemo_vault_status work. Returns nil when vault is not configured
+	// for the requested user; the tool handlers gracefully report this.
+	handler.SetVaultResolver(func(username string) tools.VaultSyncer {
+		v := reg.VaultFor(username)
+		if v == nil {
+			return nil // avoid (*vault.Exporter)(nil) wrapped in interface
+		}
+		return v
+	})
+
 	// Build a federation client if linked_instances are configured —
 	// this owns one persistent http.Client per peer and is shared
 	// across every fan-out tool registration. Failure to construct


### PR DESCRIPTION
## What this does

Adds `internal/vault` — an opt-in export layer that continuously materialises mnemo's SQLite knowledge graph as Markdown files inside a directory you point at Obsidian or Logseq.

**Zero impact when disabled.** If `vault_path` is absent from `~/.mnemo/config.json`, no goroutines start, no files are written, no overhead.

## Enable it

```json
{ "vault_path": "~/Documents/mnemo-vault" }
```

```bash
brew services restart mnemo
```

Open the directory in Obsidian (`Open folder as vault`) or Logseq (`Add a local graph`). No plugins required. Verify with `mnemo_vault_status` from any Claude Code session.

## Why: merging automated and human knowledge graphs

mnemo's automated graph is *wide but shallow* — everything captured, nothing understood. Human knowledge graphs are *deep but narrow* — well-understood, but only what you chose to write down.

The vault bridges them. mnemo writes the structure; you annotate the meaning; both sides become searchable together via FTS5. Concrete gains:

- Decisions, tradeoffs, and lessons accumulate in one readable place outside the tool
- An annotation on a session in one repo surfaces in future searches across other repos
- Human corrections to AI-extracted decisions become searchable within ~2 seconds
- Human insight compounds on automated signal with zero maintenance burden — annotate only what matters

## What gets exported

| Directory | Contents |
|---|---|
| `sessions/<repo>/` | Full session transcripts (one note per session) |
| `decisions/<repo>/` | Detected proposal + outcome pairs |
| `memories/` | Project memory files (flat, globally unique names) |
| `skills/` | Skill procedures from `~/.claude/skills/` |
| `configs/` | CLAUDE.md project instruction notes |
| `plans/<repo>/` | Implementation plans |
| `targets/<repo>/` | Convergence targets |
| `ci/<repo>/` | CI run summaries |
| `prs/<repo>/` | Pull requests and issues |
| `repos/<repo>.md` | Per-repo index (recent sessions + decisions) |
| `index.md` | Root index (all repos, total stats) |

## Bidirectional

The vault directory is added as a `SynthesisRoot`. Human edits to any `.md` file are picked up by an OS-native file watcher (kqueue/inotify), debounced over a 2-second quiet window, and indexed by mnemo's FTS5 engine — making them searchable via all `mnemo_*` query tools.

Human content lives **below** the `<!-- mnemo:generated -->` fence and is **never overwritten**. Generated content above the fence is rewritten on each sync. `strings.LastIndex` prevents fence accumulation across repeated syncs.

## Obsidian + Logseq compatibility

- YAML frontmatter with `tags`, `aliases` (session topic + short ID)
- Globally unique flat filenames for memories (`<proj>-<name>.md`) — eliminates duplicate page-title warnings
- `shortProjectName()` strips `users-<username>-dev-` prefixes → human-readable folder names
- Wikilinks in `[[path/to/note]]` format compatible with both tools
- `index.md` root (not `_index.md`, which Logseq treats oddly)
- No plugins required

## New MCP tools

- `mnemo_vault_sync` — trigger an immediate full sync from any session
- `mnemo_vault_status` — show vault path and per-section note counts

## Tests

30 tests in `internal/vault`: path generators for every entity type, fence preservation (no cascading accumulation), all render functions, session aliases, global config edge case, end-to-end `Exporter.Sync` via `storetest` fixtures with idempotency assertion.

Pre-existing failures in `internal/store` (`TestUsageReconciledMixedSource` and related) are unrelated — present on master before this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)