### PR TITLE
fix: green CI on master — TestUsage* time rot + vault path assertions on Windows

### DIFF
--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2055,21 +2055,39 @@ func assistantWithUsage(ts string, model string, input, output, cacheRead, cache
 	}
 }
 
-// now returns the current time formatted for JSONL timestamps.
+// testAnchor is the per-process reference midnight (UTC) for date-bound
+// test fixtures. Anchored 3 days before "today" so all fixtures land
+// comfortably inside the 30-day recency window queried by Usage tests.
+// Stable within a single test run; advances day-by-day across runs so
+// the fixtures never rot out of the window.
+var testAnchor = time.Now().UTC().Truncate(24 * time.Hour).AddDate(0, 0, -3)
+
+// now returns testAnchor at 10:00:00 UTC formatted for JSONL timestamps.
 func now() string {
-	return "2026-04-09T10:00:00Z"
+	return nowAt(0, 10, 0, 0)
 }
 
-// nowPlus returns a timestamp offset by the given minutes.
+// nowPlus returns testAnchor at 10:00:00 + minutes UTC.
 func nowPlus(minutes int) string {
-	return "2026-04-09T10:" + padMinutes(minutes) + ":00Z"
+	return nowAt(0, 10, minutes, 0)
 }
 
-func padMinutes(m int) string {
-	if m < 10 {
-		return "0" + string(rune('0'+m))
-	}
-	return string(rune('0'+m/10)) + string(rune('0'+m%10))
+// nowAt returns testAnchor + dayOffset days, at h:m:s UTC, as RFC3339.
+// dayOffset and any of h/m/s may overflow (e.g. m=60) and time.Time
+// normalises them.
+func nowAt(dayOffset, h, m, s int) string {
+	return testAnchor.
+		AddDate(0, 0, dayOffset).
+		Add(time.Duration(h)*time.Hour +
+			time.Duration(m)*time.Minute +
+			time.Duration(s)*time.Second).
+		Format(time.RFC3339)
+}
+
+// nowDate returns testAnchor + dayOffset days as YYYY-MM-DD (for
+// UpsertReconciledCost date keys and source-map lookups).
+func nowDate(dayOffset int) string {
+	return testAnchor.AddDate(0, 0, dayOffset).Format("2006-01-02")
 }
 
 // msgWithUUID creates a user/assistant message entry with a uuid field.
@@ -2155,20 +2173,20 @@ func TestUsageGroupBySession(t *testing.T) {
 	// Two sessions with different models and token counts.
 	writeJSONL(t, projectDir, "proj", "sess-A", []map[string]any{
 		{
-			"type": "system", "timestamp": "2026-04-09T10:00:00Z",
+			"type": "system", "timestamp": nowAt(0, 10, 0, 0),
 			"cwd": "/Users/dev/work/github.com/acme/app", "version": "2.1.81",
 			"message": map[string]any{"content": "init"},
 		},
-		assistantWithUsage("2026-04-09T10:00:05Z", "claude-sonnet-4-5", 1000, 100, 500, 50),
-		assistantWithUsage("2026-04-09T10:01:00Z", "claude-sonnet-4-5", 2000, 200, 800, 100),
+		assistantWithUsage(nowAt(0, 10, 0, 5), "claude-sonnet-4-5", 1000, 100, 500, 50),
+		assistantWithUsage(nowAt(0, 10, 1, 0), "claude-sonnet-4-5", 2000, 200, 800, 100),
 	})
 	writeJSONL(t, projectDir, "proj", "sess-B", []map[string]any{
 		{
-			"type": "system", "timestamp": "2026-04-10T08:00:00Z",
+			"type": "system", "timestamp": nowAt(1, 8, 0, 0),
 			"cwd": "/Users/dev/work/github.com/acme/app", "version": "2.1.81",
 			"message": map[string]any{"content": "init"},
 		},
-		assistantWithUsage("2026-04-10T08:00:05Z", "claude-opus-4-5", 5000, 500, 2000, 200),
+		assistantWithUsage(nowAt(1, 8, 0, 5), "claude-opus-4-5", 5000, 500, 2000, 200),
 	})
 
 	s := newTestStore(t, projectDir)
@@ -2217,15 +2235,15 @@ func TestUsageGroupByBlock(t *testing.T) {
 	// Block 2: 16:00 → start at 16:00 UTC (15:01 is >5h from 10:00)
 	writeJSONL(t, projectDir, "proj", "sess-blocks", []map[string]any{
 		{
-			"type": "system", "timestamp": "2026-04-09T10:00:00Z",
+			"type": "system", "timestamp": nowAt(0, 10, 0, 0),
 			"cwd": "/Users/dev/work/github.com/acme/app", "version": "2.1.81",
 			"message": map[string]any{"content": "init"},
 		},
-		assistantWithUsage("2026-04-09T10:00:05Z", "claude-sonnet-4-5", 1000, 100, 0, 0),
-		assistantWithUsage("2026-04-09T11:00:00Z", "claude-sonnet-4-5", 2000, 200, 0, 0),
-		assistantWithUsage("2026-04-09T14:30:00Z", "claude-sonnet-4-5", 500, 50, 0, 0),
+		assistantWithUsage(nowAt(0, 10, 0, 5), "claude-sonnet-4-5", 1000, 100, 0, 0),
+		assistantWithUsage(nowAt(0, 11, 0, 0), "claude-sonnet-4-5", 2000, 200, 0, 0),
+		assistantWithUsage(nowAt(0, 14, 30, 0), "claude-sonnet-4-5", 500, 50, 0, 0),
 		// This message is >5h from the block start (10:00 + 5h = 15:00); starts a new block.
-		assistantWithUsage("2026-04-09T16:00:00Z", "claude-sonnet-4-5", 3000, 300, 0, 0),
+		assistantWithUsage(nowAt(0, 16, 0, 0), "claude-sonnet-4-5", 3000, 300, 0, 0),
 	})
 
 	s := newTestStore(t, projectDir)
@@ -2274,8 +2292,11 @@ func TestUsageGroupByBlock(t *testing.T) {
 		ts, err := time.Parse(time.RFC3339Nano, result.Freshness)
 		if err != nil {
 			t.Errorf("freshness not RFC3339Nano: %q (%v)", result.Freshness, err)
-		} else if want := time.Date(2026, 4, 9, 16, 0, 0, 0, time.UTC); !ts.Equal(want) {
-			t.Errorf("freshness = %s, want %s", ts.Format(time.RFC3339), want.Format(time.RFC3339))
+		} else {
+			want, _ := time.Parse(time.RFC3339, nowAt(0, 16, 0, 0))
+			if !ts.Equal(want) {
+				t.Errorf("freshness = %s, want %s", ts.Format(time.RFC3339), want.Format(time.RFC3339))
+			}
 		}
 	}
 }
@@ -2371,11 +2392,11 @@ func TestUsageReconciledCosts(t *testing.T) {
 
 	writeJSONL(t, projectDir, "proj", "sess-reconc", []map[string]any{
 		{
-			"type": "system", "timestamp": "2026-04-09T10:00:00Z",
+			"type": "system", "timestamp": nowAt(0, 10, 0, 0),
 			"cwd": "/Users/dev/work/github.com/acme/app", "version": "2.1.81",
 			"message": map[string]any{"content": "init"},
 		},
-		assistantWithUsage("2026-04-09T10:00:05Z", "claude-sonnet-4-5", 1000, 100, 0, 0),
+		assistantWithUsage(nowAt(0, 10, 0, 5), "claude-sonnet-4-5", 1000, 100, 0, 0),
 	})
 
 	s := newTestStore(t, projectDir)
@@ -2396,7 +2417,7 @@ func TestUsageReconciledCosts(t *testing.T) {
 	}
 
 	// Insert a reconciled cost for that date.
-	if err := s.UpsertReconciledCost("2026-04-09", 99.99); err != nil {
+	if err := s.UpsertReconciledCost(nowDate(0), 99.99); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2422,15 +2443,15 @@ func TestUsageReconciledCosts(t *testing.T) {
 func TestUsageReconciledMixedSource(t *testing.T) {
 	projectDir := t.TempDir()
 
-	// Two days of activity.
+	// Two days of activity (day -1 = "yesterday relative to fixtures", day 0 = "today").
 	writeJSONL(t, projectDir, "proj", "sess-mixed", []map[string]any{
 		{
-			"type": "system", "timestamp": "2026-04-08T09:00:00Z",
+			"type": "system", "timestamp": nowAt(-1, 9, 0, 0),
 			"cwd": "/Users/dev/work/github.com/acme/app", "version": "2.1.81",
 			"message": map[string]any{"content": "init"},
 		},
-		assistantWithUsage("2026-04-08T09:00:05Z", "claude-sonnet-4-5", 100, 10, 0, 0),
-		assistantWithUsage("2026-04-09T10:00:05Z", "claude-sonnet-4-5", 200, 20, 0, 0),
+		assistantWithUsage(nowAt(-1, 9, 0, 5), "claude-sonnet-4-5", 100, 10, 0, 0),
+		assistantWithUsage(nowAt(0, 10, 0, 5), "claude-sonnet-4-5", 200, 20, 0, 0),
 	})
 
 	s := newTestStore(t, projectDir)
@@ -2438,8 +2459,8 @@ func TestUsageReconciledMixedSource(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Reconcile only Apr 9, leave Apr 8 as estimated.
-	if err := s.UpsertReconciledCost("2026-04-09", 50.0); err != nil {
+	// Reconcile only the "today" fixture day; leave the previous day as estimated.
+	if err := s.UpsertReconciledCost(nowDate(0), 50.0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2453,11 +2474,12 @@ func TestUsageReconciledMixedSource(t *testing.T) {
 	for _, r := range result.Rows {
 		sourceMap[r.Period] = r.Source
 	}
-	if sourceMap["2026-04-09"] != "reconciled" {
-		t.Errorf("2026-04-09: expected reconciled, got %q", sourceMap["2026-04-09"])
+	reconciledDay, estimatedDay := nowDate(0), nowDate(-1)
+	if sourceMap[reconciledDay] != "reconciled" {
+		t.Errorf("%s: expected reconciled, got %q", reconciledDay, sourceMap[reconciledDay])
 	}
-	if sourceMap["2026-04-08"] != "estimated" {
-		t.Errorf("2026-04-08: expected estimated, got %q", sourceMap["2026-04-08"])
+	if sourceMap[estimatedDay] != "estimated" {
+		t.Errorf("%s: expected estimated, got %q", estimatedDay, sourceMap[estimatedDay])
 	}
 	// Total should be "mixed" since it spans both types.
 	if result.Total.Source != "mixed" {

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -102,7 +102,7 @@ func TestSessionPath(t *testing.T) {
 		Topic:     "vault feature",
 		FirstMsg:  "2026-05-10T14:23:45Z",
 	}
-	got := sessionPath(info)
+	got := filepath.ToSlash(sessionPath(info))
 	if !strings.HasPrefix(got, "sessions/mnemo/") {
 		t.Errorf("expected sessions/mnemo/ prefix, got %q", got)
 	}
@@ -126,7 +126,7 @@ func TestSessionPathNoRepo(t *testing.T) {
 		Project:   "-Users-alice-dev-myapp",
 		FirstMsg:  "2026-05-10T14:23:45Z",
 	}
-	got := sessionPath(info)
+	got := filepath.ToSlash(sessionPath(info))
 	if !strings.HasPrefix(got, "sessions/") {
 		t.Errorf("expected sessions/ prefix, got %q", got)
 	}
@@ -138,7 +138,7 @@ func TestDecisionPath(t *testing.T) {
 		Repo:      "my-repo",
 		Timestamp: "2026-05-10T10:00:00Z",
 	}
-	got := decisionPath(d)
+	got := filepath.ToSlash(decisionPath(d))
 	if !strings.HasPrefix(got, "decisions/my-repo/") {
 		t.Errorf("expected decisions/my-repo/ prefix, got %q", got)
 	}
@@ -155,7 +155,7 @@ func TestMemoryPath(t *testing.T) {
 		Project: "-Users-alice-dev-myapp",
 		Name:    "My Memory",
 	}
-	got := memoryPath(m)
+	got := filepath.ToSlash(memoryPath(m))
 	if !strings.HasPrefix(got, "memories/") {
 		t.Errorf("expected memories/ prefix, got %q", got)
 	}


### PR DESCRIPTION
## Summary

Two test-only fixes that together restore green master CI on both ubuntu-latest and windows-latest.

### Fix 1 — time rot in `TestUsage*` (5 tests in `internal/store`)

- Replaces hardcoded `2026-04-08/09/10` fixture dates with helpers anchored to today (UTC) at run time.
- `now()` no longer lies — it returns an actual `time.Now()`-derived RFC3339 string.
- New helpers: `nowAt(dayOffset, h, m, s)` for relative timestamps and `nowDate(dayOffset)` for `UpsertReconciledCost` date keys.

Five tests query `s.Usage(UsageParams{Days: 30, ...})` — a 30-day recency window from `time.Now()`. The fixtures hardcoded April 9 timestamps that started falling outside the window on master roughly 30 days after they were authored. The `now()` helper's name was the trap: it returned a stable string instead of the actual current time, so the bug was invisible at compile time but guaranteed to surface a month later.

Tests fixed: `TestUsageHourlyRate`, `TestUsageGroupBySession`, `TestUsageGroupByBlock`, `TestUsageReconciledCosts`, `TestUsageReconciledMixedSource`.

`TestUsageSinceUntil*` intentionally pin explicit date bounds (testing the override path) — left as-is. Same for the audit-log date test at line 1632.

After #72 merged, `TestUsageGroupByBlock` gained a new freshness assertion (`time.Date(2026, 4, 9, 16, 0, 0, 0, time.UTC)`); rebased and updated to compute the expected value via `nowAt(0, 16, 0, 0)`.

### Fix 2 — Windows path assertions in `internal/vault` (4 tests)

`TestSessionPath`, `TestSessionPathNoRepo`, `TestDecisionPath`, `TestMemoryPath` assert forward-slash prefixes (`"sessions/mnemo/"` etc.) against the raw output of `filepath.Join`, which uses backslashes on Windows. Production code is fine — `renderRepoIndex`/`renderSession`/etc. in `note.go` already call `filepath.ToSlash` before emitting wikilinks, so the actual vault output on Windows is correct. Only the tests' raw-path assertions break.

Fix is one `filepath.ToSlash(...)` at each `got :=` site.

## Test plan

- [x] `go test -tags sqlite_fts5 -count=1 -run TestUsage ./internal/store/...` — all green locally
- [x] `go test -tags sqlite_fts5 -count=1 ./internal/vault/...` — all green locally
- [x] `go test -tags sqlite_fts5 -count=1 ./...` — full suite green locally
- [x] `go vet -tags sqlite_fts5 ./...` — clean
- [ ] CI passes on ubuntu-latest
- [ ] CI passes on windows-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)