### PR TITLE
feat: mnemo_config MCP tool with hot-reload of vault_path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ user. Good moments to reach for mnemo:
 - `mnemo_discover_patterns` — Analyze transcript history to find workaround patterns suggesting missing features. Detects direct JSONL reads, transcript dir greps, repeated query shapes, and recurring searches.
 - `mnemo_images` — Search images captured from transcripts. Inline base64 and file-path image references are extracted at ingest, stored as BLOBs with width/height/MIME metadata, and described by AI using surrounding conversation context. Searchable via FTS5 on descriptions. Requires ANTHROPIC_API_KEY for description generation.
 - `mnemo_rework_history` — Return prior rework attempts for a bullseye target, ordered most-recent first. Sourced from compaction spans where the target appeared in targets_active or targets_progressed. Returns session_id, timestamp, repo, progress note, prose summary, and open threads. Feed output as `mnemo_history` to `bullseye_rework` to avoid repeating prior failed approaches.
+- `mnemo_config` — Read or update mnemo's runtime configuration (`~/.mnemo/config.json`) without restarting the daemon. `op=read` returns the current config + resolved paths; `op=write` with a `patch` object merges and persists. Hot-reload covers `vault_path`, `workspace_roots`, `extra_project_dirs`, `synthesis_roots`; `linked_instances` is persisted but requires a restart.
 
 ## Code Structure
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,10 @@ Export your knowledge graph as Markdown notes compatible with Obsidian
 and Logseq. Human annotations sync back into mnemo's FTS5 search within
 ~2 seconds. Zero overhead when disabled.
 
-Add to `~/.mnemo/config.json` and restart the daemon:
+Add to `~/.mnemo/config.json` and restart the daemon — or, with a
+running daemon, ask any MCP client to call `mnemo_config` with
+`op=write` and `patch={"vault_path": "~/Documents/mnemo-vault"}` and
+the change is adopted in-process:
 
 ```json
 {
@@ -286,6 +289,12 @@ Full setup guide: [`internal/vault/README.md`](internal/vault/README.md)
 |---|---|
 | `mnemo_vault_sync` | Trigger an immediate vault sync (writes all changed notes to `vault_path`) |
 | `mnemo_vault_status` | Show vault path and current Markdown file count |
+
+### Runtime configuration
+
+| Tool | Description |
+|---|---|
+| `mnemo_config` | Read or update `~/.mnemo/config.json` without restarting the daemon. `op=read` returns the current effective config; `op=write` with a JSON `patch` merges, validates, persists, and hot-reloads. `vault_path`, `workspace_roots`, `extra_project_dirs`, and `synthesis_roots` are applied live; `linked_instances` is persisted but requires a restart. |
 
 For full parameter documentation, see [`agents-guide.md`](agents-guide.md)
 or run `mnemo --help-agent`.

--- a/agents-guide.md
+++ b/agents-guide.md
@@ -466,6 +466,33 @@ Parameters:
 - `context_before` — context messages before the match (default 3)
 - `context_after` — context messages after the match (default 3)
 
+### mnemo_config
+
+Read or update mnemo's runtime configuration (`~/.mnemo/config.json`)
+without restarting the daemon. Use this to flip `vault_path` on or off,
+add a new workspace root, or rotate `synthesis_roots` from the same
+agent that just told you what to change.
+
+Parameters:
+- `op` — `"read"` (default) or `"write"`
+- `patch` — for `op=write`, a JSON object with the keys to update.
+  Same shape as `~/.mnemo/config.json`. Only keys present in the patch
+  are modified; unspecified keys retain their current value. Set a
+  field to its zero value (empty string for `vault_path`, empty array
+  for the slices) to clear it.
+
+Hot-reload coverage:
+- `vault_path` — applied live. Old vault workers stop, a fresh
+  exporter is built at the new path, and an initial sync starts in the
+  background. Set to `""` to disable vault export entirely.
+- `workspace_roots`, `extra_project_dirs`, `synthesis_roots` — applied
+  live; subsequent ingest passes pick up the new roots.
+- `linked_instances` — persisted but requires a daemon restart (the
+  federation client is wired once at startup).
+
+The write response lists which fields changed, which were adopted live,
+and which require a restart.
+
 ## Federation across linked instances
 
 If `~/.mnemo/config.json` declares `linked_instances`, 16 read-shaped

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -314,18 +314,23 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 // mnemo_config tool can stop just those goroutines when vault_path
 // changes without disturbing transcript ingest or the compactor.
 //
+// Returns the vault sub-context so callers wanting to spawn additional
+// vault-scoped goroutines (e.g. the post-reload initial sync) can tie
+// them to the same cancellation as the periodic-sync/watcher pair.
+// Returns nil when e.vault is nil (no workers started).
+//
 // PRECONDITION: caller MUST hold r.mu. ForUser owns it via its defer
 // for the entire Store-construction path; swapVault re-acquires it
 // after building the new exporter. Re-acquiring inside this function
 // would self-deadlock the ForUser path.
 //
-// No-op when e.vault is nil. The vault pointer is captured locally so a
-// concurrent hot-swap that replaces e.vault does not race with the
-// goroutines already running against the previous exporter.
-func (r *Registry) startVaultWorkers(username string, e *userEntry) {
+// The vault pointer is captured locally so a concurrent hot-swap that
+// replaces e.vault does not race with the goroutines already running
+// against the previous exporter.
+func (r *Registry) startVaultWorkers(username string, e *userEntry) context.Context {
 	vp := e.vault
 	if vp == nil {
-		return
+		return nil
 	}
 	vctx, vcancel := context.WithCancel(r.baseCtx)
 	e.vaultCancel = vcancel
@@ -428,6 +433,8 @@ func (r *Registry) startVaultWorkers(username string, e *userEntry) {
 			}
 		}
 	}()
+
+	return vctx
 }
 
 // CurrentConfig returns a snapshot of the live Config. Safe to call
@@ -587,11 +594,15 @@ func (r *Registry) swapVault(username string, e *userEntry, newPath string) erro
 	}
 	r.mu.Lock()
 	e.vault = exp
-	r.startVaultWorkers(username, e)
+	vctx := r.startVaultWorkers(username, e)
 	// Track the post-reload initial sync under vaultWorkers so a
 	// subsequent swap waits for it (no two syncs against the same
 	// exporter racing through writeNote) and Close blocks on its
-	// completion before closing the Store.
+	// completion before closing the Store. Bound to vctx (not
+	// r.baseCtx) so cascaded reloads (A→B→C) abort the in-flight
+	// B-sync via oldCancel() at the next swap instead of forcing C
+	// to block on B-sync's natural completion against a path the
+	// user has already moved away from.
 	e.vaultWorkers.Add(1)
 	r.mu.Unlock()
 
@@ -599,7 +610,7 @@ func (r *Registry) swapVault(username string, e *userEntry, newPath string) erro
 
 	go func() {
 		defer e.vaultWorkers.Done()
-		if err := exp.Sync(r.baseCtx); err != nil && !errors.Is(err, vault.ErrSyncInFlight) {
+		if err := exp.Sync(vctx); err != nil && !errors.Is(err, vault.ErrSyncInFlight) {
 			logger.Warn("vault: post-reload sync failed", "err", err)
 		}
 	}()
@@ -625,6 +636,13 @@ func stringSlicesEqual(a, b []string) bool {
 	return true
 }
 
+// linkedInstancesEqual compares element-by-element with ==. All
+// LinkedInstance fields must remain comparable for this to work: adding
+// a slice field would surface as a compile error (caught), but adding a
+// map field would compile and panic at runtime when both sides are
+// non-nil. If LinkedInstance ever gains a non-comparable field, switch
+// to reflect.DeepEqual on the element (or slices.EqualFunc with an
+// explicit comparator updated alongside the struct).
 func linkedInstancesEqual(a, b []store.LinkedInstance) bool {
 	if len(a) != len(b) {
 		return false
@@ -639,7 +657,18 @@ func linkedInstancesEqual(a, b []store.LinkedInstance) bool {
 
 // Close cancels every worker context and closes every Store. Safe to
 // call once.
+//
+// Acquires reloadMu before r.mu so that an in-flight swapVault — which
+// drops r.mu between teardown and the post-Wait re-entry that spawns
+// new vault workers — cannot interleave with Close. Without this guard
+// Close could observe vaultWorkers at zero, return from Wait, and then
+// see swapVault's re-entry Add() new workers against a Store that
+// Close is about to close (closed-DB log noise on shutdown, and a
+// WaitGroup contract that depends on Wait's previous return value
+// being final).
 func (r *Registry) Close() {
+	r.reloadMu.Lock()
+	defer r.reloadMu.Unlock()
 	r.mu.Lock()
 	r.cancel()
 	entries := make([]*userEntry, 0, len(r.stores))

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -454,6 +454,14 @@ type ReloadReport struct {
 	// applied in-process (currently: "linked_instances"). These will
 	// take effect only after the daemon is restarted.
 	RequiresRestart []string
+	// Warnings lists per-user adoption failures that happened despite
+	// the config write itself succeeding. The classic case: vault.New
+	// fails because the new vault_path points at a regular file (not
+	// a directory). The config-on-disk is the new value, the old
+	// vault workers are torn down, but the new exporter never came
+	// up. Surfacing this here lets the MCP caller see the divergence
+	// instead of believing the field was cleanly adopted.
+	Warnings []string
 }
 
 // Reload swaps the Registry's active config for newCfg and adopts the
@@ -518,10 +526,20 @@ func (r *Registry) Reload(newCfg store.Config) ReloadReport {
 	}
 	if old.VaultPath != newCfg.VaultPath {
 		report.Changed = append(report.Changed, "vault_path")
+		anyFailure := false
 		for username, e := range entries {
-			r.swapVault(username, e, newCfg.ResolvedVaultPath(e.homeDir))
+			if err := r.swapVault(username, e, newCfg.ResolvedVaultPath(e.homeDir)); err != nil {
+				report.Warnings = append(report.Warnings,
+					fmt.Sprintf("vault_path: user %q: %v", username, err))
+				anyFailure = true
+			}
 		}
-		report.Adopted = append(report.Adopted, "vault_path")
+		// Even one failure means at least one Store does not have
+		// the new vault active; refrain from claiming live adoption
+		// in that case. The warning carries the detail.
+		if !anyFailure {
+			report.Adopted = append(report.Adopted, "vault_path")
+		}
 	}
 	if !linkedInstancesEqual(old.LinkedInstances, newCfg.LinkedInstances) {
 		report.Changed = append(report.Changed, "linked_instances")
@@ -541,7 +559,7 @@ func (r *Registry) Reload(newCfg store.Config) ReloadReport {
 // concurrent reloads could clear each other's vaultCancel funcs and
 // leave the entry with stale workers running against an abandoned
 // exporter.
-func (r *Registry) swapVault(username string, e *userEntry, newPath string) {
+func (r *Registry) swapVault(username string, e *userEntry, newPath string) error {
 	logger := slog.Default().With("user", username)
 
 	r.mu.Lock()
@@ -559,13 +577,13 @@ func (r *Registry) swapVault(username string, e *userEntry, newPath string) {
 
 	if newPath == "" {
 		logger.Info("vault: disabled by reload (vault_path cleared)")
-		return
+		return nil
 	}
 
 	exp, err := vault.New(e.store, newPath)
 	if err != nil {
 		logger.Warn("vault: exporter creation failed on reload", "path", newPath, "err", err)
-		return
+		return fmt.Errorf("vault.New(%q): %w", newPath, err)
 	}
 	r.mu.Lock()
 	e.vault = exp
@@ -585,6 +603,7 @@ func (r *Registry) swapVault(username string, e *userEntry, newPath string) {
 			logger.Warn("vault: post-reload sync failed", "err", err)
 		}
 	}()
+	return nil
 }
 
 func safePath(v *vault.Exporter) string {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -62,7 +62,14 @@ func (a llmAdapter) Call(ctx context.Context, sys, user string) (reviewer.LLMRes
 // Store instance. Registry.Close waits for every user's workers to
 // drain and closes every Store.
 type Registry struct {
-	mu             sync.Mutex
+	mu sync.Mutex
+	// reloadMu serializes Reload calls. Holding it across the entire
+	// Reload flow (snapshot → adopt → swap) prevents two concurrent
+	// reloads from racing through swapVault and orphaning workers /
+	// leaving the registry with two live exporters per user. mu is
+	// still acquired in fine-grained sections inside Reload; reloadMu
+	// is the coarse-grained guard.
+	reloadMu       sync.Mutex
 	baseCtx        context.Context
 	cancel         context.CancelFunc
 	stores         map[string]*userEntry
@@ -225,13 +232,21 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 		// immediately and live JSONL ingestion is not delayed. The SQLite
 		// index is fully populated at this point (all Ingest* calls above
 		// have completed), so the sync goroutine reads a consistent snapshot.
+		//
+		// Tracked under vaultWorkers (not workers) so a concurrent
+		// mnemo_config vault_path swap waits for it to drain before
+		// starting the new exporter, guaranteeing the old exporter
+		// finishes writing to the old path before workers spin up
+		// against the new one.
 		r.mu.Lock()
 		vp := e.vault
+		if vp != nil {
+			e.vaultWorkers.Add(1)
+		}
 		r.mu.Unlock()
 		if vp != nil {
-			e.workers.Add(1)
 			go func() {
-				defer e.workers.Done()
+				defer e.vaultWorkers.Done()
 				logger.Info("vault: initial sync starting")
 				if err := vp.Sync(r.baseCtx); err != nil && !errors.Is(err, vault.ErrSyncInFlight) {
 					logger.Warn("vault: initial sync failed", "err", err)
@@ -299,19 +314,21 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 // mnemo_config tool can stop just those goroutines when vault_path
 // changes without disturbing transcript ingest or the compactor.
 //
+// PRECONDITION: caller MUST hold r.mu. ForUser owns it via its defer
+// for the entire Store-construction path; swapVault re-acquires it
+// after building the new exporter. Re-acquiring inside this function
+// would self-deadlock the ForUser path.
+//
 // No-op when e.vault is nil. The vault pointer is captured locally so a
 // concurrent hot-swap that replaces e.vault does not race with the
 // goroutines already running against the previous exporter.
 func (r *Registry) startVaultWorkers(username string, e *userEntry) {
-	r.mu.Lock()
 	vp := e.vault
 	if vp == nil {
-		r.mu.Unlock()
 		return
 	}
 	vctx, vcancel := context.WithCancel(r.baseCtx)
 	e.vaultCancel = vcancel
-	r.mu.Unlock()
 
 	logger := slog.Default().With("user", username)
 
@@ -458,6 +475,15 @@ type ReloadReport struct {
 //     mid-run swap would need to tear down and rebuild every fan-out
 //     handler, which is out of scope for this tool.
 func (r *Registry) Reload(newCfg store.Config) ReloadReport {
+	// Serialize reloads end-to-end. Two concurrent Reload calls would
+	// otherwise both pass through the swapVault stages, with one
+	// racing the other's vaultCancel/vault assignment under r.mu and
+	// the result depending on goroutine interleavings. The MCP entry
+	// point is the only caller in practice (single agent), but
+	// nothing in the type signature enforces that, so guard it here.
+	r.reloadMu.Lock()
+	defer r.reloadMu.Unlock()
+
 	r.mu.Lock()
 	old := r.cfg
 	r.cfg = newCfg
@@ -510,6 +536,11 @@ func (r *Registry) Reload(newCfg store.Config) ReloadReport {
 // will simply build one and start workers. Logs warnings rather than
 // returning errors — partial success (e.g. the exporter built but a
 // later sync failed) should not roll back the on-disk config.
+//
+// Reload serializes calls to swapVault via reloadMu; without that, two
+// concurrent reloads could clear each other's vaultCancel funcs and
+// leave the entry with stale workers running against an abandoned
+// exporter.
 func (r *Registry) swapVault(username string, e *userEntry, newPath string) {
 	logger := slog.Default().With("user", username)
 
@@ -538,15 +569,18 @@ func (r *Registry) swapVault(username string, e *userEntry, newPath string) {
 	}
 	r.mu.Lock()
 	e.vault = exp
+	r.startVaultWorkers(username, e)
+	// Track the post-reload initial sync under vaultWorkers so a
+	// subsequent swap waits for it (no two syncs against the same
+	// exporter racing through writeNote) and Close blocks on its
+	// completion before closing the Store.
+	e.vaultWorkers.Add(1)
 	r.mu.Unlock()
 
-	r.startVaultWorkers(username, e)
 	logger.Info("vault: workers restarted with new path", "path", newPath)
 
-	// Kick off an initial sync against the new path so notes appear
-	// without waiting for the 5-minute ticker. Detached from the
-	// caller's request context so the MCP call returns promptly.
 	go func() {
+		defer e.vaultWorkers.Done()
 		if err := exp.Sync(r.baseCtx); err != nil && !errors.Is(err, vault.ErrSyncInFlight) {
 			logger.Warn("vault: post-reload sync failed", "err", err)
 		}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -74,10 +74,20 @@ type Registry struct {
 // userEntry tracks one user's Store, optional vault Exporter, and
 // background goroutines. workers lets Close wait for them to drain
 // before the Store is closed.
+//
+// Vault workers are tracked separately (vaultCancel + vaultWorkers) so
+// the mnemo_config tool can hot-swap vault_path: cancel the old vault
+// sub-context, wait for its goroutines to drain, then start fresh ones
+// against the new vault path. Non-vault workers (ingest, compactor, CI
+// poller, reconciler) all continue uninterrupted, since the Store and
+// transcript ingest pipeline are unaffected by a vault path change.
 type userEntry struct {
-	store   *store.Store
-	vault   *vault.Exporter // nil when vault_path is not configured
-	workers sync.WaitGroup
+	store        *store.Store
+	vault        *vault.Exporter // nil when vault_path is not configured
+	workers      sync.WaitGroup
+	vaultCancel  context.CancelFunc // cancels the vault sub-context; nil when vault disabled
+	vaultWorkers sync.WaitGroup     // tracks only vault goroutines, so reload can wait for them
+	homeDir      string             // remembered for Reload's ~/ expansion
 }
 
 // NewRegistry builds an empty Registry. The baseCtx is cancelled on
@@ -146,7 +156,7 @@ func (r *Registry) ForUser(username string) (*store.Store, error) {
 	}
 	s.SetSynthesisRoots(synthRoots)
 
-	e := &userEntry{store: s, vault: vaultExp}
+	e := &userEntry{store: s, vault: vaultExp, homeDir: home}
 	r.stores[username] = e
 	r.startWorkers(username, projectDir, e)
 	return s, nil
@@ -215,12 +225,15 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 		// immediately and live JSONL ingestion is not delayed. The SQLite
 		// index is fully populated at this point (all Ingest* calls above
 		// have completed), so the sync goroutine reads a consistent snapshot.
-		if e.vault != nil {
+		r.mu.Lock()
+		vp := e.vault
+		r.mu.Unlock()
+		if vp != nil {
 			e.workers.Add(1)
 			go func() {
 				defer e.workers.Done()
 				logger.Info("vault: initial sync starting")
-				if err := e.vault.Sync(r.baseCtx); err != nil && !errors.Is(err, vault.ErrSyncInFlight) {
+				if err := vp.Sync(r.baseCtx); err != nil && !errors.Is(err, vault.ErrSyncInFlight) {
 					logger.Warn("vault: initial sync failed", "err", err)
 				}
 			}()
@@ -230,104 +243,7 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 		}
 	}()
 
-	if e.vault != nil {
-		// Vault periodic sync: materialise new transcript entities as
-		// Markdown every 5 minutes. Does NOT call IngestSynthesis here —
-		// the file watcher below picks up those writes within ~2 seconds.
-		e.workers.Add(1)
-		go func() {
-			defer e.workers.Done()
-			ticker := time.NewTicker(5 * time.Minute)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-r.baseCtx.Done():
-					return
-				case <-ticker.C:
-					if err := e.vault.Sync(r.baseCtx); err != nil && !errors.Is(err, vault.ErrSyncInFlight) {
-						logger.Warn("vault: periodic sync failed", "err", err)
-					}
-				}
-			}
-		}()
-
-		// Vault file watcher: re-indexes human annotations (content below the
-		// <!-- mnemo:generated --> fence) within ~2 seconds of any .md save.
-		// IngestVaultAnnotations extracts only below-fence content, so
-		// generated blocks are never re-ingested and there is no feedback loop.
-		e.workers.Add(1)
-		go func() {
-			defer e.workers.Done()
-			vaultPath := e.vault.Path()
-			// vault.New already called os.MkdirAll; the directory exists.
-
-			fw, err := fsnotify.NewWatcher()
-			if err != nil {
-				logger.Warn("vault: file watcher init failed", "err", err)
-				return
-			}
-			defer fw.Close()
-
-			// Add vault root and all existing subdirectories.
-			// fsnotify v1.9 does not expose a public WithRecursive option
-			// on all platforms, so we walk and add manually, then
-			// re-add any newly created subdirectory on CREATE events.
-			// Hidden dirs (.obsidian/, .git/, .trash/) are skipped to
-			// avoid wasting inotify slots on Linux and to skip Obsidian
-			// internal-state churn that has no signal for mnemo.
-			addVaultDirs := func(root string) {
-				_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
-					if err != nil || !d.IsDir() {
-						return nil
-					}
-					if p != root && strings.HasPrefix(d.Name(), ".") {
-						return filepath.SkipDir
-					}
-					_ = fw.Add(p)
-					return nil
-				})
-			}
-			addVaultDirs(vaultPath)
-			logger.Info("vault: file watcher started", "path", vaultPath)
-
-			const quietPeriod = 2 * time.Second
-			debounce := time.NewTimer(quietPeriod)
-			debounce.Stop()
-			defer debounce.Stop()
-
-			for {
-				select {
-				case <-r.baseCtx.Done():
-					return
-				case ev, ok := <-fw.Events:
-					if !ok {
-						return
-					}
-					// Watch newly created non-hidden subdirectories so notes
-					// written into new sections are also picked up.
-					if ev.Has(fsnotify.Create) {
-						if fi, err := os.Stat(ev.Name); err == nil && fi.IsDir() &&
-							!strings.HasPrefix(filepath.Base(ev.Name), ".") {
-							_ = fw.Add(ev.Name)
-						}
-					}
-					if strings.HasSuffix(ev.Name, ".md") {
-						debounce.Reset(quietPeriod)
-					}
-				case err, ok := <-fw.Errors:
-					if !ok {
-						return
-					}
-					logger.Warn("vault: watcher error", "err", err)
-				case <-debounce.C:
-					if err := e.store.IngestVaultAnnotations(vaultPath); err != nil {
-						logger.Warn("vault: annotation ingest failed", "err", err)
-					}
-					logger.Info("vault: annotations indexed from file change")
-				}
-			}
-		}()
-	}
+	r.startVaultWorkers(username, e)
 
 	// Compaction watcher.
 	e.workers.Add(1)
@@ -378,6 +294,296 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 	}()
 }
 
+// startVaultWorkers launches the per-user vault periodic-sync and
+// file-watcher goroutines under a vault-specific sub-context, so the
+// mnemo_config tool can stop just those goroutines when vault_path
+// changes without disturbing transcript ingest or the compactor.
+//
+// No-op when e.vault is nil. The vault pointer is captured locally so a
+// concurrent hot-swap that replaces e.vault does not race with the
+// goroutines already running against the previous exporter.
+func (r *Registry) startVaultWorkers(username string, e *userEntry) {
+	r.mu.Lock()
+	vp := e.vault
+	if vp == nil {
+		r.mu.Unlock()
+		return
+	}
+	vctx, vcancel := context.WithCancel(r.baseCtx)
+	e.vaultCancel = vcancel
+	r.mu.Unlock()
+
+	logger := slog.Default().With("user", username)
+
+	// Vault periodic sync: materialise new transcript entities as
+	// Markdown every 5 minutes. Does NOT call IngestSynthesis here —
+	// the file watcher below picks up those writes within ~2 seconds.
+	e.vaultWorkers.Add(1)
+	go func() {
+		defer e.vaultWorkers.Done()
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-vctx.Done():
+				return
+			case <-ticker.C:
+				if err := vp.Sync(vctx); err != nil && !errors.Is(err, vault.ErrSyncInFlight) {
+					logger.Warn("vault: periodic sync failed", "err", err)
+				}
+			}
+		}
+	}()
+
+	// Vault file watcher: re-indexes human annotations (content below the
+	// <!-- mnemo:generated --> fence) within ~2 seconds of any .md save.
+	// IngestVaultAnnotations extracts only below-fence content, so
+	// generated blocks are never re-ingested and there is no feedback loop.
+	e.vaultWorkers.Add(1)
+	go func() {
+		defer e.vaultWorkers.Done()
+		vaultPath := vp.Path()
+		// vault.New already called os.MkdirAll; the directory exists.
+
+		fw, err := fsnotify.NewWatcher()
+		if err != nil {
+			logger.Warn("vault: file watcher init failed", "err", err)
+			return
+		}
+		defer fw.Close()
+
+		// Add vault root and all existing subdirectories.
+		// fsnotify v1.9 does not expose a public WithRecursive option
+		// on all platforms, so we walk and add manually, then
+		// re-add any newly created subdirectory on CREATE events.
+		// Hidden dirs (.obsidian/, .git/, .trash/) are skipped to
+		// avoid wasting inotify slots on Linux and to skip Obsidian
+		// internal-state churn that has no signal for mnemo.
+		addVaultDirs := func(root string) {
+			_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+				if err != nil || !d.IsDir() {
+					return nil
+				}
+				if p != root && strings.HasPrefix(d.Name(), ".") {
+					return filepath.SkipDir
+				}
+				_ = fw.Add(p)
+				return nil
+			})
+		}
+		addVaultDirs(vaultPath)
+		logger.Info("vault: file watcher started", "path", vaultPath)
+
+		const quietPeriod = 2 * time.Second
+		debounce := time.NewTimer(quietPeriod)
+		debounce.Stop()
+		defer debounce.Stop()
+
+		for {
+			select {
+			case <-vctx.Done():
+				return
+			case ev, ok := <-fw.Events:
+				if !ok {
+					return
+				}
+				// Watch newly created non-hidden subdirectories so notes
+				// written into new sections are also picked up.
+				if ev.Has(fsnotify.Create) {
+					if fi, err := os.Stat(ev.Name); err == nil && fi.IsDir() &&
+						!strings.HasPrefix(filepath.Base(ev.Name), ".") {
+						_ = fw.Add(ev.Name)
+					}
+				}
+				if strings.HasSuffix(ev.Name, ".md") {
+					debounce.Reset(quietPeriod)
+				}
+			case err, ok := <-fw.Errors:
+				if !ok {
+					return
+				}
+				logger.Warn("vault: watcher error", "err", err)
+			case <-debounce.C:
+				if err := e.store.IngestVaultAnnotations(vaultPath); err != nil {
+					logger.Warn("vault: annotation ingest failed", "err", err)
+				}
+				logger.Info("vault: annotations indexed from file change")
+			}
+		}
+	}()
+}
+
+// CurrentConfig returns a snapshot of the live Config. Safe to call
+// concurrently.
+func (r *Registry) CurrentConfig() store.Config {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.cfg
+}
+
+// ReloadReport summarises what changed during a Reload call and which
+// of those changes were adopted in-process versus deferred to the next
+// daemon restart. The MCP tool surfaces this verbatim so the caller
+// (most often a Claude Code agent on behalf of the user) can see at a
+// glance whether the running daemon already reflects the new config.
+type ReloadReport struct {
+	// Changed lists the JSON keys whose values differ between the
+	// previous and incoming Config (e.g. "vault_path").
+	Changed []string
+	// Adopted lists keys whose new values were applied to the running
+	// daemon without a restart (a subset of Changed).
+	Adopted []string
+	// RequiresRestart lists keys whose values changed but cannot be
+	// applied in-process (currently: "linked_instances"). These will
+	// take effect only after the daemon is restarted.
+	RequiresRestart []string
+}
+
+// Reload swaps the Registry's active config for newCfg and adopts the
+// changes across every already-initialised per-user entry. The caller
+// is responsible for having validated newCfg (mnemo_config delegates to
+// store.WriteConfig, which runs the same validation as LoadConfig).
+//
+// Adoption per field:
+//   - workspace_roots, extra_project_dirs, synthesis_roots — applied
+//     via the matching Store setters. New ingest passes will pick up
+//     the new roots; already-indexed content is untouched.
+//   - vault_path — the per-user vault sub-context is cancelled, its
+//     goroutines drain, and fresh vault workers are started against
+//     the new path (or vault is fully disabled if the new path is
+//     empty). The initial sync against the new vault is kicked off in
+//     the background; this call returns once the swap is complete.
+//   - linked_instances — flagged as requires-restart. Federation peers
+//     are wired up at startup against a process-wide http.Client; a
+//     mid-run swap would need to tear down and rebuild every fan-out
+//     handler, which is out of scope for this tool.
+func (r *Registry) Reload(newCfg store.Config) ReloadReport {
+	r.mu.Lock()
+	old := r.cfg
+	r.cfg = newCfg
+	entries := make(map[string]*userEntry, len(r.stores))
+	for u, e := range r.stores {
+		entries[u] = e
+	}
+	r.mu.Unlock()
+
+	report := ReloadReport{}
+
+	if !stringSlicesEqual(old.WorkspaceRoots, newCfg.WorkspaceRoots) {
+		report.Changed = append(report.Changed, "workspace_roots")
+		for _, e := range entries {
+			e.store.SetWorkspaceRoots(newCfg.ResolvedWorkspaceRoots())
+		}
+		report.Adopted = append(report.Adopted, "workspace_roots")
+	}
+	if !stringSlicesEqual(old.ExtraProjectDirs, newCfg.ExtraProjectDirs) {
+		report.Changed = append(report.Changed, "extra_project_dirs")
+		for _, e := range entries {
+			e.store.SetExtraProjectDirs(newCfg.ExtraProjectDirs)
+		}
+		report.Adopted = append(report.Adopted, "extra_project_dirs")
+	}
+	if !stringSlicesEqual(old.SynthesisRoots, newCfg.SynthesisRoots) {
+		report.Changed = append(report.Changed, "synthesis_roots")
+		for _, e := range entries {
+			e.store.SetSynthesisRoots(newCfg.ResolvedSynthesisRoots())
+		}
+		report.Adopted = append(report.Adopted, "synthesis_roots")
+	}
+	if old.VaultPath != newCfg.VaultPath {
+		report.Changed = append(report.Changed, "vault_path")
+		for username, e := range entries {
+			r.swapVault(username, e, newCfg.ResolvedVaultPath(e.homeDir))
+		}
+		report.Adopted = append(report.Adopted, "vault_path")
+	}
+	if !linkedInstancesEqual(old.LinkedInstances, newCfg.LinkedInstances) {
+		report.Changed = append(report.Changed, "linked_instances")
+		report.RequiresRestart = append(report.RequiresRestart, "linked_instances")
+	}
+	return report
+}
+
+// swapVault tears down e's current vault workers, swaps in a fresh
+// Exporter at newPath (or nil when newPath is ""), and starts new vault
+// workers. Safe to call on a userEntry that currently has no vault: it
+// will simply build one and start workers. Logs warnings rather than
+// returning errors — partial success (e.g. the exporter built but a
+// later sync failed) should not roll back the on-disk config.
+func (r *Registry) swapVault(username string, e *userEntry, newPath string) {
+	logger := slog.Default().With("user", username)
+
+	r.mu.Lock()
+	oldCancel := e.vaultCancel
+	e.vaultCancel = nil
+	oldVault := e.vault
+	e.vault = nil
+	r.mu.Unlock()
+
+	if oldCancel != nil {
+		oldCancel()
+		e.vaultWorkers.Wait()
+		logger.Info("vault: workers stopped for reload", "previous_path", safePath(oldVault))
+	}
+
+	if newPath == "" {
+		logger.Info("vault: disabled by reload (vault_path cleared)")
+		return
+	}
+
+	exp, err := vault.New(e.store, newPath)
+	if err != nil {
+		logger.Warn("vault: exporter creation failed on reload", "path", newPath, "err", err)
+		return
+	}
+	r.mu.Lock()
+	e.vault = exp
+	r.mu.Unlock()
+
+	r.startVaultWorkers(username, e)
+	logger.Info("vault: workers restarted with new path", "path", newPath)
+
+	// Kick off an initial sync against the new path so notes appear
+	// without waiting for the 5-minute ticker. Detached from the
+	// caller's request context so the MCP call returns promptly.
+	go func() {
+		if err := exp.Sync(r.baseCtx); err != nil && !errors.Is(err, vault.ErrSyncInFlight) {
+			logger.Warn("vault: post-reload sync failed", "err", err)
+		}
+	}()
+}
+
+func safePath(v *vault.Exporter) string {
+	if v == nil {
+		return ""
+	}
+	return v.Path()
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func linkedInstancesEqual(a, b []store.LinkedInstance) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // Close cancels every worker context and closes every Store. Safe to
 // call once.
 func (r *Registry) Close() {
@@ -392,6 +598,7 @@ func (r *Registry) Close() {
 
 	for _, e := range entries {
 		e.workers.Wait()
+		e.vaultWorkers.Wait()
 		_ = e.store.Close()
 	}
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -5,11 +5,15 @@ package registry
 
 import (
 	"context"
+	"path/filepath"
 	"reflect"
 	"sort"
+	"sync"
 	"testing"
 
 	"github.com/marcelocantos/mnemo/internal/store"
+	"github.com/marcelocantos/mnemo/internal/storetest"
+	"github.com/marcelocantos/mnemo/internal/vault"
 )
 
 // TestReloadReportClassifiesFields validates the diff logic without
@@ -81,5 +85,120 @@ func TestReloadNoOpWhenConfigUnchanged(t *testing.T) {
 	report := r.Reload(cfg)
 	if len(report.Changed) != 0 {
 		t.Errorf("Changed should be empty, got %v", report.Changed)
+	}
+}
+
+// TestSwapVaultEndToEnd builds a Registry around a real Store +
+// Exporter, runs swapVault, and asserts the new exporter is wired and
+// the old workers are gone. Regression for the prior deadlock in
+// startVaultWorkers re-acquiring r.mu while ForUser still owned it,
+// and for the concurrent-swap race that left orphaned workers.
+func TestSwapVaultEndToEnd(t *testing.T) {
+	projectDir := t.TempDir()
+	s := storetest.NewStore(t, projectDir)
+
+	oldDir := filepath.Join(t.TempDir(), "old-vault")
+	newDir := filepath.Join(t.TempDir(), "new-vault")
+	oldExp, err := vault.New(s, oldDir)
+	if err != nil {
+		t.Fatalf("vault.New old: %v", err)
+	}
+
+	r := NewRegistry(context.Background(), store.Config{VaultPath: oldDir}, "")
+	defer r.Close()
+
+	e := &userEntry{store: s, vault: oldExp, homeDir: t.TempDir()}
+
+	// Simulate the ForUser path: caller acquires r.mu, calls
+	// startVaultWorkers under the lock, releases. Pre-fix this
+	// deadlocked because startVaultWorkers re-acquired r.mu.
+	r.mu.Lock()
+	r.startVaultWorkers("u", e)
+	r.mu.Unlock()
+	if e.vaultCancel == nil {
+		t.Fatal("vaultCancel not set after startVaultWorkers")
+	}
+
+	// Swap to the new path. swapVault should: stop old workers,
+	// build a new exporter at newDir, and start fresh workers.
+	r.swapVault("u", e, newDir)
+	r.mu.Lock()
+	gotPath := ""
+	if e.vault != nil {
+		gotPath = e.vault.Path()
+	}
+	hasCancel := e.vaultCancel != nil
+	r.mu.Unlock()
+
+	if gotPath != newDir {
+		t.Errorf("vault path after swap: got %q want %q", gotPath, newDir)
+	}
+	if !hasCancel {
+		t.Errorf("vaultCancel should be set after swap to non-empty path")
+	}
+
+	// Swap to disabled (empty path). Workers should drain and exporter
+	// clear.
+	r.swapVault("u", e, "")
+	r.mu.Lock()
+	if e.vault != nil {
+		t.Errorf("vault should be nil after swap to empty path, got %v", e.vault)
+	}
+	if e.vaultCancel != nil {
+		t.Errorf("vaultCancel should be nil after disable")
+	}
+	r.mu.Unlock()
+}
+
+// TestReloadSerialisesConcurrentSwaps fires multiple Reload calls in
+// parallel and asserts the final state matches the last write under
+// reloadMu. Without reloadMu serialisation, two concurrent swapVault
+// flows could leave the registry with orphaned cancel funcs or
+// duplicate worker sets per user.
+func TestReloadSerialisesConcurrentSwaps(t *testing.T) {
+	projectDir := t.TempDir()
+	s := storetest.NewStore(t, projectDir)
+
+	r := NewRegistry(context.Background(), store.Config{}, "")
+	defer r.Close()
+
+	r.mu.Lock()
+	r.stores["u"] = &userEntry{store: s, homeDir: t.TempDir()}
+	r.mu.Unlock()
+
+	dirs := []string{
+		filepath.Join(t.TempDir(), "a"),
+		filepath.Join(t.TempDir(), "b"),
+		filepath.Join(t.TempDir(), "c"),
+	}
+
+	var wg sync.WaitGroup
+	for _, d := range dirs {
+		wg.Add(1)
+		go func(path string) {
+			defer wg.Done()
+			r.Reload(store.Config{VaultPath: path})
+		}(d)
+	}
+	wg.Wait()
+
+	r.mu.Lock()
+	finalPath := ""
+	if r.stores["u"].vault != nil {
+		finalPath = r.stores["u"].vault.Path()
+	}
+	r.mu.Unlock()
+
+	// Final path must be one of the dirs (whichever Reload won the
+	// reloadMu race last), not a partial/empty state.
+	matched := false
+	for _, d := range dirs {
+		if finalPath == d {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		t.Errorf("final vault path %q must be one of the concurrent reload inputs %v", finalPath, dirs)
 	}
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -5,6 +5,7 @@ package registry
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -85,6 +86,45 @@ func TestReloadNoOpWhenConfigUnchanged(t *testing.T) {
 	report := r.Reload(cfg)
 	if len(report.Changed) != 0 {
 		t.Errorf("Changed should be empty, got %v", report.Changed)
+	}
+}
+
+// TestReloadVaultFailureReportedAsWarning runs Reload with a
+// vault_path that points at a regular file. vault.New's MkdirAll
+// fails, and Reload must NOT classify vault_path as Adopted — instead
+// the failure surfaces in Warnings so the MCP caller sees that
+// although the on-disk config now reflects the new value, no vault is
+// actually active.
+func TestReloadVaultFailureReportedAsWarning(t *testing.T) {
+	projectDir := t.TempDir()
+	s := storetest.NewStore(t, projectDir)
+
+	// Create a regular file at the target path. MkdirAll on an
+	// existing regular-file path fails with ENOTDIR on Unix /
+	// equivalent on Windows.
+	badPath := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(badPath, []byte("blocking"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	r := NewRegistry(context.Background(), store.Config{}, "")
+	defer r.Close()
+	r.mu.Lock()
+	r.stores["u"] = &userEntry{store: s, homeDir: t.TempDir()}
+	r.mu.Unlock()
+
+	report := r.Reload(store.Config{VaultPath: badPath})
+
+	if len(report.Warnings) == 0 {
+		t.Fatalf("expected a warning for failed vault.New, got none. report=%+v", report)
+	}
+	for _, a := range report.Adopted {
+		if a == "vault_path" {
+			t.Errorf("vault_path should NOT be Adopted when swap failed; report=%+v", report)
+		}
+	}
+	if len(report.Changed) == 0 || report.Changed[0] != "vault_path" {
+		t.Errorf("vault_path should still be Changed even on adoption failure; report=%+v", report)
 	}
 }
 

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/marcelocantos/mnemo/internal/store"
 	"github.com/marcelocantos/mnemo/internal/storetest"
@@ -188,6 +189,93 @@ func TestSwapVaultEndToEnd(t *testing.T) {
 		t.Errorf("vaultCancel should be nil after disable")
 	}
 	r.mu.Unlock()
+}
+
+// TestStartVaultWorkersReturnsVctx exercises the contract that
+// startVaultWorkers returns the vault sub-context (so swapVault can
+// pipe its post-reload sync through vctx instead of r.baseCtx).
+// Pre-fix the post-reload sync used r.baseCtx; a cascaded reload
+// (A→B→C) would force C to block on B-sync's natural completion even
+// though B's vault had been decommissioned. Cancelling the returned
+// context here is equivalent to swapVault's next-swap oldCancel(): if
+// the contract holds, Done fires immediately.
+func TestStartVaultWorkersReturnsVctx(t *testing.T) {
+	projectDir := t.TempDir()
+	s := storetest.NewStore(t, projectDir)
+
+	dir := filepath.Join(t.TempDir(), "v")
+	exp, err := vault.New(s, dir)
+	if err != nil {
+		t.Fatalf("vault.New: %v", err)
+	}
+	r := NewRegistry(context.Background(), store.Config{VaultPath: dir}, "")
+	defer r.Close()
+
+	e := &userEntry{store: s, vault: exp, homeDir: t.TempDir()}
+	r.mu.Lock()
+	vctx := r.startVaultWorkers("u", e)
+	r.mu.Unlock()
+	if vctx == nil {
+		t.Fatal("startVaultWorkers must return a non-nil context when vault is set")
+	}
+
+	// Drive vctx through e.vaultCancel: this is the exact path
+	// swapVault uses (oldCancel()), so it proves vctx is the same
+	// context that the next swap will cancel.
+	e.vaultCancel()
+	select {
+	case <-vctx.Done():
+	default:
+		t.Errorf("vctx returned from startVaultWorkers must be cancelled when e.vaultCancel runs")
+	}
+	e.vaultWorkers.Wait()
+
+	// Disabled-vault path: returned context is nil and no workers
+	// run.
+	empty := &userEntry{store: s, homeDir: t.TempDir()}
+	r.mu.Lock()
+	got := r.startVaultWorkers("u2", empty)
+	r.mu.Unlock()
+	if got != nil {
+		t.Errorf("startVaultWorkers should return nil when vault is unset")
+	}
+}
+
+// TestCloseAcquiresReloadMu pins down the Close/Reload ordering: Close
+// must not return while a swapVault is mid-flight, otherwise the
+// re-entry that spawns new vault workers would race against the Store
+// being closed. The deterministic surface: with the guard in place,
+// Close blocks until a hostile no-op Reload that holds reloadMu
+// releases. Without the guard, Close returns instantly.
+func TestCloseAcquiresReloadMu(t *testing.T) {
+	r := NewRegistry(context.Background(), store.Config{}, "")
+
+	// Grab reloadMu manually to simulate an in-flight Reload that
+	// has not yet released it. swapVault's first half holds it via
+	// Reload's defer.
+	r.reloadMu.Lock()
+
+	done := make(chan struct{})
+	go func() {
+		r.Close()
+		close(done)
+	}()
+
+	// If Close ignored reloadMu it would race past us and finish
+	// almost immediately. Give it a generous head start, then assert
+	// it is still blocked.
+	select {
+	case <-done:
+		t.Fatal("Close returned while reloadMu was held — the Close/Reload race guard is missing")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	r.reloadMu.Unlock()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not return after reloadMu released")
+	}
 }
 
 // TestReloadSerialisesConcurrentSwaps fires multiple Reload calls in

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/marcelocantos/mnemo/internal/store"
+)
+
+// TestReloadReportClassifiesFields validates the diff logic without
+// requiring any per-user Store to be initialised. A Registry with no
+// stores still produces a meaningful Changed/Adopted/RequiresRestart
+// report — the live-adoption pass simply has no entries to iterate.
+func TestReloadReportClassifiesFields(t *testing.T) {
+	old := store.Config{
+		WorkspaceRoots:   []string{"/old/ws"},
+		ExtraProjectDirs: []string{"/old/proj"},
+		SynthesisRoots:   []string{"/old/syn"},
+		VaultPath:        "/old/vault",
+	}
+	r := NewRegistry(context.Background(), old, "")
+	defer r.Close()
+
+	newCfg := store.Config{
+		WorkspaceRoots:   []string{"/new/ws"},
+		ExtraProjectDirs: []string{"/old/proj"}, // unchanged
+		SynthesisRoots:   []string{"/new/syn"},
+		VaultPath:        "/new/vault",
+	}
+	report := r.Reload(newCfg)
+
+	sort.Strings(report.Changed)
+	sort.Strings(report.Adopted)
+	wantChanged := []string{"synthesis_roots", "vault_path", "workspace_roots"}
+	if !reflect.DeepEqual(report.Changed, wantChanged) {
+		t.Errorf("Changed: got %v want %v", report.Changed, wantChanged)
+	}
+	wantAdopted := wantChanged // all three classify as live-adoptable
+	if !reflect.DeepEqual(report.Adopted, wantAdopted) {
+		t.Errorf("Adopted: got %v want %v", report.Adopted, wantAdopted)
+	}
+	if len(report.RequiresRestart) != 0 {
+		t.Errorf("RequiresRestart: got %v want []", report.RequiresRestart)
+	}
+	if got := r.CurrentConfig().VaultPath; got != "/new/vault" {
+		t.Errorf("CurrentConfig().VaultPath: got %q want /new/vault", got)
+	}
+}
+
+func TestReloadFlagsLinkedInstancesAsRestart(t *testing.T) {
+	old := store.Config{LinkedInstances: nil}
+	r := NewRegistry(context.Background(), old, "")
+	defer r.Close()
+
+	newCfg := store.Config{
+		LinkedInstances: []store.LinkedInstance{
+			{Name: "alice", URL: "https://x/", PeerCert: "alice"},
+		},
+	}
+	report := r.Reload(newCfg)
+	if len(report.RequiresRestart) != 1 || report.RequiresRestart[0] != "linked_instances" {
+		t.Errorf("RequiresRestart: got %v want [linked_instances]", report.RequiresRestart)
+	}
+	for _, a := range report.Adopted {
+		if a == "linked_instances" {
+			t.Errorf("linked_instances should not be in Adopted: %v", report.Adopted)
+		}
+	}
+}
+
+func TestReloadNoOpWhenConfigUnchanged(t *testing.T) {
+	cfg := store.Config{VaultPath: "/v", WorkspaceRoots: []string{"/w"}}
+	r := NewRegistry(context.Background(), cfg, "")
+	defer r.Close()
+
+	report := r.Reload(cfg)
+	if len(report.Changed) != 0 {
+		t.Errorf("Changed should be empty, got %v", report.Changed)
+	}
+}

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -113,6 +113,77 @@ func loadConfigFrom(path string) (Config, error) {
 	return cfg, nil
 }
 
+// ConfigPath returns the absolute path to ~/.mnemo/config.json for the
+// current process user. Returns an error only when the home directory
+// cannot be resolved.
+func ConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".mnemo", "config.json"), nil
+}
+
+// WriteConfig persists cfg to ~/.mnemo/config.json atomically and after
+// passing the same federation-peer validation that LoadConfig applies on
+// startup. The write is atomic in the rename-into-place sense: a tmp
+// file is written next to the target and renamed once fsync'd, so a
+// crashed writer cannot leave a half-formed config visible to a
+// subsequent LoadConfig call.
+//
+// Used by the mnemo_config MCP tool to apply runtime configuration
+// changes (chiefly vault_path) without requiring a daemon restart.
+func WriteConfig(cfg Config) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	if err := cfg.validateLinkedInstances(filepath.Join(home, ".mnemo", "peers")); err != nil {
+		return err
+	}
+	path := filepath.Join(home, ".mnemo", "config.json")
+	return writeConfigTo(path, cfg)
+}
+
+// writeConfigTo is the testable core of WriteConfig: it writes cfg to
+// path using a sibling tmp file + rename so concurrent readers always
+// observe either the previous or the new file, never a partial write.
+// The parent directory is created if missing (mode 0o755).
+func writeConfigTo(path string, cfg Config) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	data = append(data, '\n')
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".config.json.*")
+	if err != nil {
+		return fmt.Errorf("create tmp: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("sync tmp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("close tmp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
 // validateLinkedInstances enforces the rules documented on
 // LinkedInstance: unique names, https-only URLs, and resolvable
 // peer certificates (either as a name under peersDir or as inline

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -131,6 +131,11 @@ func ConfigPath() (string, error) {
 // crashed writer cannot leave a half-formed config visible to a
 // subsequent LoadConfig call.
 //
+// vault_path is trial-balloon validated (see validateVaultPath) before
+// the rename so the persisted config is always loadable cleanly — a
+// path that vault.New would reject is rejected here too, leaving the
+// previous on-disk config intact.
+//
 // Used by the mnemo_config MCP tool to apply runtime configuration
 // changes (chiefly vault_path) without requiring a daemon restart.
 func WriteConfig(cfg Config) error {
@@ -141,8 +146,40 @@ func WriteConfig(cfg Config) error {
 	if err := cfg.validateLinkedInstances(filepath.Join(home, ".mnemo", "peers")); err != nil {
 		return err
 	}
+	if err := cfg.validateVaultPath(home); err != nil {
+		return err
+	}
 	path := filepath.Join(home, ".mnemo", "config.json")
 	return writeConfigTo(path, cfg)
+}
+
+// validateVaultPath mirrors the only fallible step of vault.New
+// (os.MkdirAll on the resolved root) so a bad vault_path is rejected
+// before WriteConfig commits the new config to disk. Without this
+// check, a write of e.g. {"vault_path": "/dev/null"} succeeds and
+// persists; the subsequent Reload's swapVault fails and surfaces a
+// Warning, but the on-disk config is already wrong and the next
+// daemon start re-hits the failure during initial setup.
+//
+// home is the daemon's home directory — used to ~-expand vault_path.
+// In the common single-user deployment this matches the per-user
+// homeDir that Reload's swapVault uses. On a multi-user Windows
+// Service install where different users may resolve ~ differently,
+// trial-balloon coverage against the daemon home is still enough to
+// catch the typical "garbage path" mistake; user-specific resolution
+// failures continue to surface as Reload Warnings.
+//
+// Empty VaultPath is the documented "vault disabled" state and skips
+// validation.
+func (c Config) validateVaultPath(home string) error {
+	resolved := c.ResolvedVaultPath(home)
+	if resolved == "" {
+		return nil
+	}
+	if err := os.MkdirAll(resolved, 0o755); err != nil {
+		return fmt.Errorf("vault_path %q is not usable: %w", c.VaultPath, err)
+	}
+	return nil
 }
 
 // writeConfigTo is the testable core of WriteConfig: it writes cfg to

--- a/internal/store/config_test.go
+++ b/internal/store/config_test.go
@@ -76,6 +76,51 @@ func TestWriteConfigToAtomicReplace(t *testing.T) {
 	}
 }
 
+// TestValidateVaultPathRejectsRegularFile mirrors the vault.New failure
+// mode that the WriteConfig trial-balloon must catch: a vault_path
+// pointing at an existing regular file makes MkdirAll return ENOTDIR.
+// Without this guard a "mnemo_config op=write" with a bad path would
+// persist, leaving on-disk config that the next daemon start cannot
+// bring up cleanly.
+func TestValidateVaultPathRejectsRegularFile(t *testing.T) {
+	home := t.TempDir()
+	bad := filepath.Join(home, "not-a-dir")
+	if err := os.WriteFile(bad, []byte("blocking"), 0o644); err != nil {
+		t.Fatalf("seed regular file: %v", err)
+	}
+
+	cfg := Config{VaultPath: bad}
+	if err := cfg.validateVaultPath(home); err == nil {
+		t.Fatalf("expected error for vault_path pointing at a regular file, got nil")
+	}
+}
+
+// TestValidateVaultPathEmptyIsAllowed documents the "vault disabled"
+// semantics: an empty VaultPath passes validation without touching the
+// filesystem (so disabling vault via mnemo_config never trips the
+// trial-balloon).
+func TestValidateVaultPathEmptyIsAllowed(t *testing.T) {
+	if err := (Config{}).validateVaultPath(t.TempDir()); err != nil {
+		t.Errorf("empty vault_path should pass validation, got %v", err)
+	}
+}
+
+// TestValidateVaultPathExpandsTilde checks that ~ expansion happens
+// against the supplied home before MkdirAll runs. A literal "~/v" must
+// not be passed to MkdirAll — that would create a directory named "~"
+// in the current working directory.
+func TestValidateVaultPathExpandsTilde(t *testing.T) {
+	home := t.TempDir()
+	cfg := Config{VaultPath: "~/v"}
+	if err := cfg.validateVaultPath(home); err != nil {
+		t.Fatalf("tilde expansion: %v", err)
+	}
+	wantDir := filepath.Join(home, "v")
+	if fi, err := os.Stat(wantDir); err != nil || !fi.IsDir() {
+		t.Errorf("expected MkdirAll on %q, stat err=%v", wantDir, err)
+	}
+}
+
 func TestValidateLinkedInstancesValidPeerByName(t *testing.T) {
 	peersDir := t.TempDir()
 	writePeerCert(t, filepath.Join(peersDir, "alice.pem"))

--- a/internal/store/config_test.go
+++ b/internal/store/config_test.go
@@ -25,6 +25,57 @@ func TestValidateLinkedInstancesEmpty(t *testing.T) {
 	}
 }
 
+func TestWriteConfigToRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	cfg := Config{
+		WorkspaceRoots:   []string{"/tmp/a", "/tmp/b"},
+		ExtraProjectDirs: []string{"/mnt/c"},
+		VaultPath:        "~/Documents/v",
+	}
+	if err := writeConfigTo(path, cfg); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := loadConfigFrom(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.VaultPath != cfg.VaultPath {
+		t.Errorf("vault_path: got %q want %q", got.VaultPath, cfg.VaultPath)
+	}
+	if len(got.WorkspaceRoots) != 2 || got.WorkspaceRoots[0] != "/tmp/a" {
+		t.Errorf("workspace_roots: %v", got.WorkspaceRoots)
+	}
+	if len(got.ExtraProjectDirs) != 1 || got.ExtraProjectDirs[0] != "/mnt/c" {
+		t.Errorf("extra_project_dirs: %v", got.ExtraProjectDirs)
+	}
+}
+
+func TestWriteConfigToAtomicReplace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{"vault_path":"/old"}`), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := writeConfigTo(path, Config{VaultPath: "/new"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(data), `"vault_path": "/new"`) {
+		t.Errorf("expected /new in file, got: %s", data)
+	}
+	// Tmp file must not be left behind.
+	entries, _ := os.ReadDir(dir)
+	for _, ent := range entries {
+		if strings.HasPrefix(ent.Name(), ".config.json.") {
+			t.Errorf("tmp file left behind: %s", ent.Name())
+		}
+	}
+}
+
 func TestValidateLinkedInstancesValidPeerByName(t *testing.T) {
 	peersDir := t.TempDir()
 	writePeerCert(t, filepath.Join(peersDir, "alice.pem"))

--- a/internal/tools/config_tool_test.go
+++ b/internal/tools/config_tool_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/marcelocantos/mnemo/internal/store"
+)
+
+// fakeCtl is a minimal ConfigController for handler-level tests; the
+// real adapter (configController in main.go) talks to a live Registry.
+type fakeCtl struct {
+	cur    store.Config
+	last   store.Config
+	report ConfigReport
+	err    error
+}
+
+func (f *fakeCtl) Get() store.Config { return f.cur }
+func (f *fakeCtl) Put(c store.Config) (ConfigReport, error) {
+	f.last = c
+	if f.err != nil {
+		return ConfigReport{}, f.err
+	}
+	f.cur = c
+	return f.report, nil
+}
+
+func TestMergeConfigPatchOnlyOverlaysProvidedKeys(t *testing.T) {
+	current := store.Config{
+		WorkspaceRoots: []string{"/a"},
+		VaultPath:      "/old",
+	}
+	merged, err := mergeConfigPatch(current, map[string]any{
+		"vault_path": "/new",
+	})
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	if merged.VaultPath != "/new" {
+		t.Errorf("vault_path: got %q want /new", merged.VaultPath)
+	}
+	// Untouched key must survive.
+	if len(merged.WorkspaceRoots) != 1 || merged.WorkspaceRoots[0] != "/a" {
+		t.Errorf("workspace_roots dropped: %v", merged.WorkspaceRoots)
+	}
+}
+
+func TestMergeConfigPatchClearWithEmptyString(t *testing.T) {
+	current := store.Config{VaultPath: "/old"}
+	merged, err := mergeConfigPatch(current, map[string]any{
+		"vault_path": "",
+	})
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	if merged.VaultPath != "" {
+		t.Errorf("vault_path should be cleared, got %q", merged.VaultPath)
+	}
+}
+
+func TestConfigToolReadReturnsJSON(t *testing.T) {
+	ctl := &fakeCtl{cur: store.Config{VaultPath: "/v"}}
+	ch := &callHandler{}
+	out, isErr, err := ch.config(map[string]any{"op": "read"}, ctl)
+	if err != nil || isErr {
+		t.Fatalf("read: isErr=%v err=%v", isErr, err)
+	}
+	if !strings.Contains(out, `"vault_path": "/v"`) {
+		t.Errorf("expected vault_path in output, got: %s", out)
+	}
+}
+
+func TestConfigToolWriteAppliesPatch(t *testing.T) {
+	ctl := &fakeCtl{
+		cur: store.Config{
+			WorkspaceRoots: []string{"/a"},
+			VaultPath:      "/old",
+		},
+		report: ConfigReport{
+			Changed: []string{"vault_path"},
+			Adopted: []string{"vault_path"},
+		},
+	}
+	ch := &callHandler{}
+	out, isErr, err := ch.config(map[string]any{
+		"op":    "write",
+		"patch": map[string]any{"vault_path": "/new"},
+	}, ctl)
+	if err != nil || isErr {
+		t.Fatalf("write: isErr=%v err=%v out=%s", isErr, err, out)
+	}
+	if ctl.last.VaultPath != "/new" {
+		t.Errorf("controller saw vault_path %q want /new", ctl.last.VaultPath)
+	}
+	if len(ctl.last.WorkspaceRoots) != 1 || ctl.last.WorkspaceRoots[0] != "/a" {
+		t.Errorf("workspace_roots clobbered: %v", ctl.last.WorkspaceRoots)
+	}
+	if !strings.Contains(out, "Adopted live:") || !strings.Contains(out, "vault_path") {
+		t.Errorf("missing adopted line: %s", out)
+	}
+}
+
+func TestConfigToolWriteRequiresPatch(t *testing.T) {
+	ctl := &fakeCtl{}
+	ch := &callHandler{}
+	_, isErr, err := ch.config(map[string]any{"op": "write"}, ctl)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !isErr {
+		t.Errorf("expected tool-level error for missing patch")
+	}
+}
+
+func TestConfigToolUnknownOp(t *testing.T) {
+	ctl := &fakeCtl{}
+	ch := &callHandler{}
+	_, isErr, err := ch.config(map[string]any{"op": "drop"}, ctl)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !isErr {
+		t.Errorf("expected error for unknown op")
+	}
+}
+
+func TestConfigToolNoControllerAvailable(t *testing.T) {
+	ch := &callHandler{}
+	_, isErr, err := ch.config(map[string]any{}, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !isErr {
+		t.Errorf("expected error when controller not wired")
+	}
+}

--- a/internal/tools/config_tool_test.go
+++ b/internal/tools/config_tool_test.go
@@ -62,6 +62,20 @@ func TestMergeConfigPatchClearWithEmptyString(t *testing.T) {
 	}
 }
 
+func TestMergeConfigPatchRejectsUnknownKeys(t *testing.T) {
+	_, err := mergeConfigPatch(store.Config{}, map[string]any{
+		"vaultpath":         "/x", // missing underscore
+		"random_other_key":  "y",
+		"workspace_roots":   []any{"/a"}, // valid; should still error overall
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown keys")
+	}
+	if !strings.Contains(err.Error(), "vaultpath") || !strings.Contains(err.Error(), "random_other_key") {
+		t.Errorf("error should mention both typos, got: %v", err)
+	}
+}
+
 func TestConfigToolReadReturnsJSON(t *testing.T) {
 	ctl := &fakeCtl{cur: store.Config{VaultPath: "/v"}}
 	ch := &callHandler{}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -35,13 +35,15 @@ type VaultSyncer interface {
 }
 
 // ConfigReport mirrors registry.ReloadReport without importing the
-// registry package. The mnemo_config write handler returns these three
-// slices verbatim so the caller can see which fields were applied live
-// vs deferred to restart.
+// registry package. The mnemo_config write handler returns these four
+// slices verbatim so the caller can see which fields were applied live,
+// which require a restart, and which adoption attempts failed despite
+// the config write itself succeeding.
 type ConfigReport struct {
 	Changed         []string
 	Adopted         []string
 	RequiresRestart []string
+	Warnings        []string
 }
 
 // ConfigController is the dependency the mnemo_config tool uses to read
@@ -2120,7 +2122,12 @@ func (h *callHandler) reworkHistory(args map[string]any) (string, bool, error) {
 }
 
 // vaultNotConfigured is the standard response when vault_path is absent.
-const vaultNotConfigured = "vault not configured. Set vault_path in ~/.mnemo/config.json to enable.\n\nExample:\n  {\"vault_path\": \"~/.mnemo/vault\"}"
+const vaultNotConfigured = `Vault export is not configured. Mnemo runs fine without it — vault export is an optional Obsidian/Logseq integration that materialises sessions, decisions, memories, plans, and targets as Markdown notes in a directory you choose, and re-ingests human annotations you add below the <!-- mnemo:generated --> fence so they become searchable across all your transcripts.
+
+To enable now without restarting the daemon:
+  mnemo_config(op="write", patch={"vault_path": "~/Documents/mnemo-vault"})
+
+Or edit ~/.mnemo/config.json and restart the daemon.`
 
 func (h *callHandler) vaultSync() (string, bool, error) {
 	if h.vault == nil {
@@ -2314,12 +2321,18 @@ func renderConfigWrite(merged store.Config, report ConfigReport) string {
 	if len(report.Changed) == 0 {
 		b.WriteString("No field values changed (patch matched the existing config).\n")
 	} else {
-		fmt.Fprintf(&b, "Changed fields:        %s\n", strings.Join(report.Changed, ", "))
+		fmt.Fprintf(&b, "Changed fields:          %s\n", strings.Join(report.Changed, ", "))
 		if len(report.Adopted) > 0 {
-			fmt.Fprintf(&b, "Adopted live:          %s\n", strings.Join(report.Adopted, ", "))
+			fmt.Fprintf(&b, "Adopted live:            %s\n", strings.Join(report.Adopted, ", "))
 		}
 		if len(report.RequiresRestart) > 0 {
 			fmt.Fprintf(&b, "Requires daemon restart: %s\n", strings.Join(report.RequiresRestart, ", "))
+		}
+		if len(report.Warnings) > 0 {
+			b.WriteString("\nAdoption warnings (config persisted but live adoption failed):\n")
+			for _, w := range report.Warnings {
+				fmt.Fprintf(&b, "  - %s\n", w)
+			}
 		}
 	}
 	b.WriteString("\nNew config:\n")

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -551,7 +551,7 @@ Modes:
   - op=read (default): return the current effective config as JSON, plus a list of resolved-paths (workspace_roots, vault_path, synthesis_roots) with ~ expanded.
   - op=write: merge "patch" into the current config, validate, persist to disk, and adopt the change in the running daemon.
 
-Patch semantics: patch is a JSON object with the same shape as ~/.mnemo/config.json. Only keys present in the patch are changed; unset keys are left untouched. To clear a field, set it to its zero value (empty string for vault_path, empty array for the slices).
+Patch semantics: patch is a JSON object with the same shape as ~/.mnemo/config.json. Only keys present in the patch are changed; unset keys are left untouched. Array fields are replaced wholesale — to add or remove a single entry, read the current config first and write the full updated array. To clear a field, set it to its zero value (empty string for vault_path, empty array for the slices).
 
 Hot-reload coverage:
   - vault_path: applied live. The existing vault workers stop, a fresh exporter is built at the new path, and an initial sync starts in the background. Set vault_path to "" to disable vault export entirely.
@@ -2257,6 +2257,13 @@ var knownConfigKeys = map[string]struct{}{
 // Config field added later participates automatically as long as it
 // has a json tag, and the resulting Config goes through json.Unmarshal
 // which catches obvious type mismatches early.
+//
+// CONTRACT: every exported Config field must carry a `json:"name"`
+// tag. A field tagged `json:"-"` (runtime-only / derived) is silently
+// zeroed on every patch round-trip, even when the patch does not
+// touch it. If a future Config field needs to survive merges without
+// being patchable, switch this function to reflective field-by-field
+// merge.
 //
 // Patch keys are validated against knownConfigKeys before merging so
 // typos surface as tool errors instead of silent no-ops. Add a new

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -2194,7 +2194,7 @@ func (h *callHandler) config(args map[string]any, ctl ConfigController) (string,
 	}
 	switch op {
 	case "read":
-		return renderConfigRead(ctl.Get()), false, nil
+		return renderConfigRead(ctl.Get(), h.callerHome()), false, nil
 	case "write":
 		patch, _ := args["patch"].(map[string]any)
 		if len(patch) == 0 {
@@ -2215,13 +2215,56 @@ func (h *callHandler) config(args map[string]any, ctl ConfigController) (string,
 	}
 }
 
+// callerHome resolves the home directory for the request's
+// Username, falling back to the daemon's own home if the user is
+// unset or unresolvable. The read path uses this only for ~
+// expansion in the displayed "Resolved paths" block; on Windows
+// Service deployments the daemon runs as LocalSystem, and a per-
+// user mnemo_config call should see vault_path resolved against the
+// caller's home, not the service account's.
+func (h *callHandler) callerHome() string {
+	if h.cc.Username != "" {
+		if home, err := store.ResolveHomeFor(h.cc.Username); err == nil {
+			return home
+		}
+	}
+	home, _ := osUserHome()
+	return home
+}
+
+// knownConfigKeys is the closed set of JSON keys mnemo_config accepts
+// in a patch. Anything else is rejected up-front so a typo like
+// "vaultpath" produces an error rather than being silently dropped by
+// json.Unmarshal's unknown-field handling.
+var knownConfigKeys = map[string]struct{}{
+	"workspace_roots":    {},
+	"extra_project_dirs": {},
+	"synthesis_roots":    {},
+	"vault_path":         {},
+	"linked_instances":   {},
+}
+
 // mergeConfigPatch round-trips current through JSON so the patch's
 // keys overlay only the fields the user actually specified. This is
 // simpler and safer than reflective field-by-field merging: any new
 // Config field added later participates automatically as long as it
 // has a json tag, and the resulting Config goes through json.Unmarshal
 // which catches obvious type mismatches early.
+//
+// Patch keys are validated against knownConfigKeys before merging so
+// typos surface as tool errors instead of silent no-ops. Add a new
+// entry to knownConfigKeys when adding a Config field.
 func mergeConfigPatch(current store.Config, patch map[string]any) (store.Config, error) {
+	var unknown []string
+	for k := range patch {
+		if _, ok := knownConfigKeys[k]; !ok {
+			unknown = append(unknown, k)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return store.Config{}, fmt.Errorf("unknown config keys: %s", strings.Join(unknown, ", "))
+	}
 	curJSON, err := json.Marshal(current)
 	if err != nil {
 		return store.Config{}, fmt.Errorf("marshal current: %w", err)
@@ -2247,7 +2290,7 @@ func mergeConfigPatch(current store.Config, patch map[string]any) (store.Config,
 	return merged, nil
 }
 
-func renderConfigRead(cfg store.Config) string {
+func renderConfigRead(cfg store.Config, home string) string {
 	var b strings.Builder
 	b.WriteString("Current mnemo config (~/.mnemo/config.json):\n\n")
 	data, _ := json.MarshalIndent(cfg, "", "  ")
@@ -2256,7 +2299,6 @@ func renderConfigRead(cfg store.Config) string {
 	b.WriteString("Resolved paths:\n")
 	fmt.Fprintf(&b, "  workspace_roots:    %v\n", cfg.ResolvedWorkspaceRoots())
 	fmt.Fprintf(&b, "  synthesis_roots:    %v\n", cfg.ResolvedSynthesisRoots())
-	home, _ := osUserHome()
 	vp := cfg.ResolvedVaultPath(home)
 	if vp == "" {
 		b.WriteString("  vault_path:         (vault disabled)\n")

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -33,6 +34,27 @@ type VaultSyncer interface {
 	Path() string
 }
 
+// ConfigReport mirrors registry.ReloadReport without importing the
+// registry package. The mnemo_config write handler returns these three
+// slices verbatim so the caller can see which fields were applied live
+// vs deferred to restart.
+type ConfigReport struct {
+	Changed         []string
+	Adopted         []string
+	RequiresRestart []string
+}
+
+// ConfigController is the dependency the mnemo_config tool uses to read
+// and atomically apply config changes. Injected from main so the tools
+// package stays free of any direct dependency on the registry or
+// filesystem layout. Get returns a snapshot of the live Config. Put
+// validates+persists newCfg to disk and applies in-process adoption
+// across every per-user Store.
+type ConfigController interface {
+	Get() store.Config
+	Put(newCfg store.Config) (ConfigReport, error)
+}
+
 // Handler handles tool calls, dispatching each incoming call to the
 // per-user Store resolved from the call's Username. The resolver is
 // injected so the tools package does not need to import the
@@ -42,6 +64,7 @@ type VaultSyncer interface {
 type Handler struct {
 	resolve      func(username string) (store.Backend, error)
 	resolveVault func(username string) VaultSyncer // nil when vault disabled
+	cfgCtl       ConfigController                  // nil when mnemo_config disabled
 	seen         sync.Map
 }
 
@@ -57,6 +80,13 @@ func NewHandler(resolve func(string) (store.Backend, error)) *Handler {
 // the vault tools report "vault not configured".
 func (h *Handler) SetVaultResolver(fn func(string) VaultSyncer) {
 	h.resolveVault = fn
+}
+
+// SetConfigController wires the mnemo_config tool to a live config
+// source. Calling this is optional; when not called, mnemo_config
+// reports that runtime reconfiguration is not available.
+func (h *Handler) SetConfigController(c ConfigController) {
+	h.cfgCtl = c
 }
 
 // callHandler is the per-call delegate that owns the user-resolved
@@ -512,6 +542,24 @@ Vault must be configured via vault_path in ~/.mnemo/config.json.`),
 		mcp.NewTool("mnemo_vault_status",
 			mcp.WithDescription("Report vault configuration: whether vault is enabled, the vault root path, and a count of notes on disk by section."),
 		),
+		mcp.NewTool("mnemo_config",
+			mcp.WithDescription(`Read or update mnemo's runtime configuration (~/.mnemo/config.json).
+
+Modes:
+  - op=read (default): return the current effective config as JSON, plus a list of resolved-paths (workspace_roots, vault_path, synthesis_roots) with ~ expanded.
+  - op=write: merge "patch" into the current config, validate, persist to disk, and adopt the change in the running daemon.
+
+Patch semantics: patch is a JSON object with the same shape as ~/.mnemo/config.json. Only keys present in the patch are changed; unset keys are left untouched. To clear a field, set it to its zero value (empty string for vault_path, empty array for the slices).
+
+Hot-reload coverage:
+  - vault_path: applied live. The existing vault workers stop, a fresh exporter is built at the new path, and an initial sync starts in the background. Set vault_path to "" to disable vault export entirely.
+  - workspace_roots, extra_project_dirs, synthesis_roots: applied live; subsequent ingest passes pick up the new roots.
+  - linked_instances: persisted to disk but requires a daemon restart to take effect (the federation client is built once at startup).
+
+Response includes which fields changed, which were adopted live, and which require a restart.`),
+			mcp.WithString("op", mcp.Description("Operation: \"read\" (default) or \"write\".")),
+			mcp.WithObject("patch", mcp.Description("For op=write: object with the keys to update. Same shape as ~/.mnemo/config.json. Omitted keys are left unchanged.")),
+		),
 	}
 }
 
@@ -619,6 +667,8 @@ func (h *Handler) Call(ctx context.Context, cc CallContext, name string, args ma
 		return ch.vaultSync()
 	case "mnemo_vault_status":
 		return ch.vaultStatus()
+	case "mnemo_config":
+		return ch.config(args, h.cfgCtl)
 	default:
 		return "", false, fmt.Errorf("unknown tool: %s", name)
 	}
@@ -2124,4 +2174,122 @@ func countMDFiles(dir string) int {
 		return nil
 	})
 	return count
+}
+
+// config implements the mnemo_config tool. ctl is nil when main did not
+// wire up the controller; in that case both modes report unavailability
+// rather than crashing.
+//
+// The write path merges patch onto a fresh snapshot of the live config.
+// Only keys present in the patch JSON are applied — unspecified keys
+// preserve their current value. This makes "configure vault_path"
+// safe to call without re-stating workspace_roots/etc.
+func (h *callHandler) config(args map[string]any, ctl ConfigController) (string, bool, error) {
+	if ctl == nil {
+		return "mnemo_config not available (server started without config controller)", true, nil
+	}
+	op, _ := args["op"].(string)
+	if op == "" {
+		op = "read"
+	}
+	switch op {
+	case "read":
+		return renderConfigRead(ctl.Get()), false, nil
+	case "write":
+		patch, _ := args["patch"].(map[string]any)
+		if len(patch) == 0 {
+			return "op=write requires a non-empty \"patch\" object", true, nil
+		}
+		current := ctl.Get()
+		merged, err := mergeConfigPatch(current, patch)
+		if err != nil {
+			return fmt.Sprintf("patch invalid: %v", err), true, nil
+		}
+		report, err := ctl.Put(merged)
+		if err != nil {
+			return fmt.Sprintf("write failed: %v", err), true, nil
+		}
+		return renderConfigWrite(merged, report), false, nil
+	default:
+		return fmt.Sprintf("unknown op %q: expected \"read\" or \"write\"", op), true, nil
+	}
+}
+
+// mergeConfigPatch round-trips current through JSON so the patch's
+// keys overlay only the fields the user actually specified. This is
+// simpler and safer than reflective field-by-field merging: any new
+// Config field added later participates automatically as long as it
+// has a json tag, and the resulting Config goes through json.Unmarshal
+// which catches obvious type mismatches early.
+func mergeConfigPatch(current store.Config, patch map[string]any) (store.Config, error) {
+	curJSON, err := json.Marshal(current)
+	if err != nil {
+		return store.Config{}, fmt.Errorf("marshal current: %w", err)
+	}
+	var asMap map[string]any
+	if err := json.Unmarshal(curJSON, &asMap); err != nil {
+		return store.Config{}, fmt.Errorf("unmarshal current: %w", err)
+	}
+	if asMap == nil {
+		asMap = map[string]any{}
+	}
+	for k, v := range patch {
+		asMap[k] = v
+	}
+	mergedJSON, err := json.Marshal(asMap)
+	if err != nil {
+		return store.Config{}, fmt.Errorf("marshal merged: %w", err)
+	}
+	var merged store.Config
+	if err := json.Unmarshal(mergedJSON, &merged); err != nil {
+		return store.Config{}, fmt.Errorf("decode merged: %w", err)
+	}
+	return merged, nil
+}
+
+func renderConfigRead(cfg store.Config) string {
+	var b strings.Builder
+	b.WriteString("Current mnemo config (~/.mnemo/config.json):\n\n")
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	b.Write(data)
+	b.WriteString("\n\n")
+	b.WriteString("Resolved paths:\n")
+	fmt.Fprintf(&b, "  workspace_roots:    %v\n", cfg.ResolvedWorkspaceRoots())
+	fmt.Fprintf(&b, "  synthesis_roots:    %v\n", cfg.ResolvedSynthesisRoots())
+	home, _ := osUserHome()
+	vp := cfg.ResolvedVaultPath(home)
+	if vp == "" {
+		b.WriteString("  vault_path:         (vault disabled)\n")
+	} else {
+		fmt.Fprintf(&b, "  vault_path:         %s\n", vp)
+	}
+	return b.String()
+}
+
+func renderConfigWrite(merged store.Config, report ConfigReport) string {
+	var b strings.Builder
+	b.WriteString("mnemo config updated and persisted to ~/.mnemo/config.json.\n\n")
+	if len(report.Changed) == 0 {
+		b.WriteString("No field values changed (patch matched the existing config).\n")
+	} else {
+		fmt.Fprintf(&b, "Changed fields:        %s\n", strings.Join(report.Changed, ", "))
+		if len(report.Adopted) > 0 {
+			fmt.Fprintf(&b, "Adopted live:          %s\n", strings.Join(report.Adopted, ", "))
+		}
+		if len(report.RequiresRestart) > 0 {
+			fmt.Fprintf(&b, "Requires daemon restart: %s\n", strings.Join(report.RequiresRestart, ", "))
+		}
+	}
+	b.WriteString("\nNew config:\n")
+	data, _ := json.MarshalIndent(merged, "", "  ")
+	b.Write(data)
+	b.WriteString("\n")
+	return b.String()
+}
+
+// osUserHome is split into a tiny helper so tests can stub home
+// resolution if needed; the current callers only need a best-effort
+// path for read-side rendering.
+func osUserHome() (string, error) {
+	return os.UserHomeDir()
 }

--- a/internal/vault/README.md
+++ b/internal/vault/README.md
@@ -50,7 +50,22 @@ touched**.
 
 ## How to enable
 
-Add `vault_path` to `~/.mnemo/config.json`:
+Two paths, both equivalent. Pick whichever is more convenient.
+
+**Live (no restart)** — ask Claude (or any MCP client) to call
+`mnemo_config`:
+
+```
+mnemo_config(op="write", patch={"vault_path": "~/Documents/mnemo-vault"})
+```
+
+The daemon validates, persists to `~/.mnemo/config.json`, stops the
+old vault workers (if any), and starts new ones against the new path.
+An initial sync kicks off in the background. Setting `vault_path` back
+to `""` disables vault export the same way.
+
+**Edit-and-restart** — add `vault_path` to `~/.mnemo/config.json`
+directly:
 
 ```json
 {
@@ -58,14 +73,14 @@ Add `vault_path` to `~/.mnemo/config.json`:
 }
 ```
 
-`~` expands to your home directory. The directory is created on first
-startup — you don't need to create it manually.
-
-Restart the daemon after changing config:
+Then restart:
 
 ```bash
 brew services restart mnemo
 ```
+
+`~` expands to your home directory. The directory is created on first
+startup — you don't need to create it manually.
 
 **Verify it's working** — in any Claude Code session, ask Claude to
 call `mnemo_vault_status`. It will report the vault path and the number

--- a/main.go
+++ b/main.go
@@ -558,6 +558,13 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 		return v
 	})
 
+	// Wire the mnemo_config tool to the live Registry. Get returns a
+	// snapshot of the current Config; Put persists the new config to
+	// disk via store.WriteConfig (which re-runs the same validation as
+	// LoadConfig) and asks the Registry to adopt it across every
+	// already-initialised per-user Store.
+	handler.SetConfigController(configController{reg: reg})
+
 	// Build a federation client if linked_instances are configured —
 	// this owns one persistent http.Client per peer and is shared
 	// across every fan-out tool registration. Failure to construct
@@ -670,4 +677,28 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 		}
 		return nil
 	}
+}
+
+// configController adapts a *registry.Registry to tools.ConfigController.
+// Defined in main rather than in registry to keep registry from
+// importing the tools package (a cycle we already avoid for
+// dependency hygiene).
+type configController struct {
+	reg *registry.Registry
+}
+
+func (c configController) Get() store.Config {
+	return c.reg.CurrentConfig()
+}
+
+func (c configController) Put(newCfg store.Config) (tools.ConfigReport, error) {
+	if err := store.WriteConfig(newCfg); err != nil {
+		return tools.ConfigReport{}, err
+	}
+	rep := c.reg.Reload(newCfg)
+	return tools.ConfigReport{
+		Changed:         rep.Changed,
+		Adopted:         rep.Adopted,
+		RequiresRestart: rep.RequiresRestart,
+	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -700,5 +700,6 @@ func (c configController) Put(newCfg store.Config) (tools.ConfigReport, error) {
 		Changed:         rep.Changed,
 		Adopted:         rep.Adopted,
 		RequiresRestart: rep.RequiresRestart,
+		Warnings:        rep.Warnings,
 	}, nil
 }


### PR DESCRIPTION
## Summary

- Adds `mnemo_config` MCP tool — read (`op=read`) or update (`op=write` with a JSON `patch`) `~/.mnemo/config.json` without restarting the daemon.
- Hot-reload covers `vault_path`, `workspace_roots`, `extra_project_dirs`, `synthesis_roots`. `linked_instances` is persisted to disk but flagged `requires_restart` (the federation client is wired once at startup).
- `Registry` refactored so vault workers run under a separate sub-context: vault hot-swap stops just the vault goroutines, builds a fresh `Exporter` at the new path, and kicks off an initial sync — transcript ingest, compactor, CI poller, and the cost reconciler continue uninterrupted.

## Motivation

Follow-up to the vault export merge (#74). After that landed, switching `vault_path` still required `brew services restart mnemo`. The ask was for the daemon to reconfigure itself on the fly when asked via an MCP tool, so an agent (or any MCP client) can set `vault_path` end-to-end during a normal conversation.

## Notes

- `op=write` validates with the same linked-instances rules as `LoadConfig` and writes atomically (tmp file + rename).
- Patch semantics: only keys present in the patch JSON are changed; unset keys keep their existing value. Clear a field with its zero value.
- `tools.Handler` gets a new `ConfigController` slot alongside the existing `VaultResolver`. `main.go` adapts `*registry.Registry` to satisfy it. Tools package stays free of any direct import on registry.
- The initial vault-sync goroutine inside the main ingest worker now captures the vault pointer locally so a concurrent reload can't make it write to the new exporter while the old one still has notes to materialise.

## Test plan

- [x] `go build -tags sqlite_fts5 ./...` clean
- [x] `go vet -tags sqlite_fts5 ./...` clean
- [x] `go test -tags sqlite_fts5 ./...` green across api, compact, endpoint, federation, mcpconfig, registry, reviewer, store, targets, tools, vault
- [x] `internal/store/config_test.go` — `writeConfigTo` roundtrip + atomic replace (no tmp leftovers)
- [x] `internal/tools/config_tool_test.go` — `mergeConfigPatch` overlay (unspecified keys untouched, empty string clears), tool handler read/write/error paths, missing-controller path
- [x] `internal/registry/registry_test.go` — `Reload` classifies changed fields, flags `linked_instances` as restart-required, no-ops when unchanged
- [ ] Manual smoke (local daemon): call `mnemo_config` `op=read` → JSON returned; `op=write` with `{"vault_path": "~/tmp/v"}` → file updated, vault workers restarted, initial sync runs against new path
- [ ] Manual smoke: setting `vault_path: ""` disables vault; `mnemo_vault_status` reports "not configured"

🤖 Generated with [Claude Code](https://claude.com/claude-code)