### PR TITLE
Release v0.35.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.34.0"
+	version              = "0.35.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
Release prep for v0.35.0.

## Summary

- Bumps `version` in `main.go` to `0.35.0`

## Changes since v0.34.0

- **Added**: `mnemo_config` MCP tool with hot-reload of `vault_path`, `workspace_roots`, `extra_project_dirs`, `synthesis_roots` (#77 — @nnavnita)

## Test plan

- [x] `go test -tags "sqlite_fts5" ./...` passes locally
- [x] `mnemo --version` reports `0.35.0`
- [ ] CI green on this branch
