### PR TITLE
Release v0.36.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.35.0"
+	version              = "0.36.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
Release prep for v0.36.0.

## Summary

- Bumps `version` in `main.go` to `0.36.0`

## Changes since v0.35.0

- **🎯T49**: sqlift-mediated schema with strict additive-only policy (#82) — replaces wipe-and-reingest with non-destructive schema migration

## Test plan

- [x] `go test -tags sqlite_fts5 -count=1 ./...` passes (all 11 packages)
- [x] `make bullseye` invariants clean
- [ ] CI green on this branch
