### PR TITLE
Release v0.37.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,19 @@ jobs:
           repository: marcelocantos/sqldeep
           path: sqldeep
 
+      - name: Install sqlite3 headers (Windows)
+        # sqlift's bundled sqlift.cpp does #include <sqlite3.h>; MinGW
+        # on the Windows runner has no sqlite3 dev package preinstalled,
+        # so cgo's C++ pass can't resolve the header. Install via the
+        # pre-shipped MSYS2 pacman and expose the include path through
+        # CGO_CPPFLAGS (applies to both C and C++ preprocessor passes).
+        # The header is architecture-independent, so the same install
+        # covers both amd64 and arm64 cross-compile legs.
+        if: matrix.goos == 'windows'
+        run: |
+          /c/msys64/usr/bin/pacman -S --needed --noconfirm mingw-w64-x86_64-sqlite3
+          echo "CGO_CPPFLAGS=-IC:/msys64/mingw64/include" >> "$GITHUB_ENV"
+
       - name: Install llvm-mingw (windows/arm64 cross)
         # windows-latest has x86_64 MinGW GCC preinstalled but no
         # arm64 target. Install llvm-mingw — a Windows-hosted,

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.36.0"
+	version              = "0.37.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
Release prep for v0.37.0.

## Summary

- Bumps `version` in `main.go` to `0.37.0`
- Fixes `release.yml` to install MinGW sqlite3 headers on Windows runners (was missing from v0.36.0's release CI; same fix landed in `ci.yml` via #82)

## Why this isn't v0.36.1

v0.36.0 shipped without Windows binaries due to the release.yml gap. Per project policy (always-minor), the workflow fix ships as v0.37.0 rather than a patch. v0.36.0 stays in the release list as honest history.

## Changes since v0.36.0

- **Fixed**: release.yml installs MinGW sqlite3 headers and exposes `CGO_CPPFLAGS=-IC:/msys64/mingw64/include` so sqlift's bundled cpp compiles on both Windows matrix legs (amd64 + arm64 cross).

## Test plan

- [x] Workflow fix verified by the equivalent change in ci.yml (PR #82's Windows CI passed)
- [ ] Release CI green on v0.37.0 tag
