### PR TITLE
Release v0.38.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,11 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           /c/msys64/usr/bin/pacman -S --needed --noconfirm mingw-w64-x86_64-sqlite3
-          # CGO_CPPFLAGS applies to both C and C++ preprocessor passes,
-          # so sqlift's bundled sqlift.cpp (compiled via cgo's C++ path)
-          # finds sqlite3.h through it. CGO_CFLAGS alone covers only C.
+          # sqlift's bundled sqlift.cpp does #include <sqlite3.h>;
+          # CGO_CPPFLAGS applies to both C and C++ preprocessor passes so
+          # cgo's C++ compile finds the header. sqlite3 *symbols* come
+          # from mattn/go-sqlite3's bundled copy, so no -L/-l needed.
           echo "CGO_CPPFLAGS=-IC:/msys64/mingw64/include" >> "$GITHUB_ENV"
-          echo "CGO_LDFLAGS=-LC:/msys64/mingw64/lib" >> "$GITHUB_ENV"
 
       - name: Build sqldeep
         working-directory: sqldeep

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 
 require gopkg.in/yaml.v3 v3.0.1
 
-require github.com/marcelocantos/sqlift/go/sqlift v0.16.0 // indirect
+require github.com/marcelocantos/sqlift/go/sqlift v0.17.0 // indirect
 
 require (
 	github.com/google/jsonschema-go v0.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/marcelocantos/sqldeep/go/sqldeep v0.19.0 h1:1npO3O71dlB1UKK82tHfR4YnR
 github.com/marcelocantos/sqldeep/go/sqldeep v0.19.0/go.mod h1:XdlOCW70ivrXHNED2yVSNGABWPFwoo7c9ldxdQwM1ec=
 github.com/marcelocantos/sqlift/go/sqlift v0.16.0 h1:Ns3RrnhwmW1lzsOgmfxo7+4lIm4aay4b1Bkg5m4L+do=
 github.com/marcelocantos/sqlift/go/sqlift v0.16.0/go.mod h1:9/YUWcuHsBjM0OySf6nQ3TtRjGkU1gGP0vJiMDwY3QY=
+github.com/marcelocantos/sqlift/go/sqlift v0.17.0 h1:loDWD8WkZHC91lsJEBcCp++Gcq42to4roRsZ4kzyqWk=
+github.com/marcelocantos/sqlift/go/sqlift v0.17.0/go.mod h1:9/YUWcuHsBjM0OySf6nQ3TtRjGkU1gGP0vJiMDwY3QY=
 github.com/mark3labs/mcp-go v0.47.0 h1:h44yeM3DduDyQgzImYWu4pt6VRkqP/0p/95AGhWngnA=
 github.com/mark3labs/mcp-go v0.47.0/go.mod h1:JKTC7R2LLVagkEWK7Kwu7DbmA6iIvnNAod6yrHiQMag=
 github.com/mattn/go-sqlite3 v1.14.41 h1:8p7Pwz5NHkEbWSqc/ygU4CBGubhFFkpgP9KwcdkAHNA=

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.37.0"
+	version              = "0.38.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
Release prep for v0.38.0.

## Summary

- Bumps `version` in `main.go` to `0.38.0`
- Bumps `github.com/marcelocantos/sqlift/go/sqlift` to v0.17.0 (drops unconditional `-lsqlite3` from sqlift cgo)
- Drops `CGO_LDFLAGS=-LC:/msys64/mingw64/lib` from ci.yml — no longer needed once sqlift stops demanding `-lsqlite3`; mattn/go-sqlite3's bundled sqlite3 provides the symbols statically

## Why

v0.36.0 and v0.37.0 release CIs failed on Windows arm64 because sqlift's cgo added `-lsqlite3` which the cross-linker couldn't satisfy. sqlift v0.17.0 (marcelocantos/sqlift#16) drops the flag; mattn provides sqlite3 symbols statically across all platforms including arm64 cross-compile.

## Changes since v0.37.0

- Adopt sqlift v0.17.0
- ci.yml cleanup

## Test plan

- [x] `go test -tags sqlite_fts5 -count=1 ./...` passes locally
- [x] Verified mnemo builds against local sqlift v0.17 without auto-link issues
- [ ] CI green on this branch
- [ ] Release CI: all 5 builds + homebrew job succeed (was failing on Windows arm64 in v0.37.0)
