### PR TITLE
🎯T61 Phase 1: backup primitive + pre-migration snapshot

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1638,6 +1638,42 @@ targets:
       This target is small and independent — does not depend on T49/T59. Discovered 2026-05-14 while investigating the compactor wiring gap.
     origin: manual
     discovered: 2026-05-14
+  T61:
+    name: Automated periodic backups of mnemo.db
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - Daemon goroutine snapshots ~/.mnemo/mnemo.db daily during a 03:00–04:00 local window using VACUUM INTO + gzip, written to ~/.mnemo/backups/mnemo-YYYYMMDDTHHMMSSZ.db.gz
+    - Backup only fires after observing ≥15 min of write quiescence within the 03–04 window; if no quiescence by end-of-window+1h, the day is skipped and logged
+    - Pre-migration backup fires synchronously from applySchema when sqlift.Diff is non-empty, tagged in the same daily pool (shared retention)
+    - Retention keeps last N (default 7) backups; older snapshots GC'd after each successful backup
+    - 'BackupConfig is part of Config and hot-reloadable via mnemo_config: Enabled bool (default true), Dir string (default ~/.mnemo/backups), KeepDailies int (default 7), WindowStart/WindowEnd time-of-day strings, QuiescenceMin duration'
+    - 'Activity tracking: Store exposes LastWriteAt() updated by ingest + backfill + vault + similar write paths'
+    - MCP tool mnemo_backup_status lists existing backups with size, age, and source (daily / pre-migration)
+    - 'MCP tool mnemo_backup_now triggers an immediate backup (manual override) with idempotency: skips if a backup ran within the last hour unless force=true'
+    - 'Backup output is a valid SQLite DB: open it, count rows in entries, verify against live DB''s count (within tolerance for any concurrent ingest)'
+    - On-disk layout designed so future optimization (zstd-dict, chunked dedup) can replace gzip without breaking the file-naming/scanning logic
+    - 'Tests cover: Backup() produces openable SQLite, retention GC keeps only last N, quiescence check skips when activity recent, pre-migration tag survives daily GC for at least one cycle'
+    context: |-
+      Independent of migration safety, mnemo should periodically snapshot its DB so users have a recovery path against any failure mode — bad migration, corruption, accidental rm, ransomware, disk fault. Live DBs are now multi-GB; replaying from JSONL is impossible because Claude Code rotates transcripts. Backups become the only path to recovery.
+
+      Empirical measurements on a 7.1 GB live DB:
+      - VACUUM INTO is ~35s, deterministic (consecutive runs produce byte-identical output), works against a running daemon (mode=ro client takes a shared lock)
+      - gzip -1 produces 1.9 GB in ~40s; gzip -6 trims another 200 MB for an extra 50s. -1 is the right tradeoff at 3am.
+      - Disk math: 1.7 GB × 7 dailies ≈ 12 GB at this scale; ~1.5 GB for a 500 MB DB user.
+
+      Decided design (per user 2026-05-18):
+      - Start with gzip full snapshots (MVP); layout designed so future zstd-dict or chunked dedup can drop in
+      - On by default with retention=7
+      - Pre-migration backups share the daily pool (cheaper on disk; trade-off accepted)
+      - 03:00–04:00 local random scheduling within the window
+      - ≥15 min quiescence required to actually fire
+      - Manual override via mnemo_backup_now
+
+      Future optimization opportunity: consecutive snapshots are byte-identical when no logical changes occurred. zstd-with-baseline-dict could drop power-user storage from 12 GB to ~5-6 GB at ~300 LOC; chunked dedup gets to ~2-3 GB at ~1000 LOC. Track as a follow-up target if disk pressure surfaces.
+    origin: manual
+    discovered: 2026-05-18
   T7:
     name: Agent-defined query templates
     status: achieved

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -1,0 +1,238 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+// Package backup produces compressed, atomic snapshots of mnemo's SQLite
+// database via SQLite's `VACUUM INTO`. Snapshots are safe against a
+// concurrent daemon (the source is opened read-only; SQLite serializes
+// the snapshot via a shared lock) and the output is a fully-consistent
+// standalone DB file — no WAL replay needed to restore.
+//
+// On-disk layout under the backup directory:
+//
+//	mnemo-{tag}-YYYYMMDDTHHMMSSZ.db.gz
+//
+// where {tag} is "daily" for the periodic snapshot or "pre-migration"
+// for the one taken before sqlift.Apply. Filenames are sortable by
+// recency (lexicographic == chronological).
+//
+// The package deliberately does not own the schedule, retention policy,
+// or storage backend — those live in internal/registry as a worker
+// goroutine. This package is the I/O primitive only.
+package backup
+
+import (
+	"compress/gzip"
+	"database/sql"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Tag classifies a backup by what triggered it.
+type Tag string
+
+const (
+	TagDaily        Tag = "daily"
+	TagPreMigration Tag = "pre-migration"
+	TagManual       Tag = "manual"
+)
+
+// Result reports timing and sizes from a Backup call.
+type Result struct {
+	Path        string        // final on-disk path of the compressed backup
+	RawSize     int64         // size of the VACUUM INTO output before compression
+	GzippedSize int64         // size of the on-disk .gz file
+	Elapsed     time.Duration // total wall-clock for VACUUM + integrity + gzip
+}
+
+// Filename returns the canonical backup filename for the given tag and
+// timestamp. The format is sortable lexicographically by chronological
+// order, so worker rotation logic can just sort by name.
+func Filename(tag Tag, t time.Time) string {
+	return fmt.Sprintf("mnemo-%s-%s.db.gz", tag, t.UTC().Format("20060102T150405Z"))
+}
+
+// Backup snapshots the SQLite database at srcPath into destPath. destPath
+// must end in .db.gz (caller's responsibility — typically constructed via
+// filepath.Join(dir, Filename(tag, time.Now()))). destPath's parent
+// directory must exist and be writable.
+//
+// Mechanism:
+//  1. VACUUM INTO produces a fully-consistent standalone DB at a sibling
+//     temp file (same filesystem, so the later rename is atomic).
+//  2. PRAGMA integrity_check on the snapshot — bail if corrupted.
+//  3. Gzip-compress (level 1 — favours speed over size; the consecutive-
+//     snapshot redundancy gzip can't catch is left for a future zstd-dict
+//     or chunked-dedup pass) to destPath.tmp.
+//  4. fsync + atomic rename to destPath.
+//
+// On any failure the function leaves no partial output (temp files are
+// cleaned up). The compressed backup at destPath either exists fully or
+// does not exist at all.
+func Backup(srcPath, destPath string) (Result, error) {
+	start := time.Now()
+	if filepath.Ext(destPath) != ".gz" {
+		return Result{}, fmt.Errorf("destPath must end in .gz: %s", destPath)
+	}
+	destDir := filepath.Dir(destPath)
+
+	// VACUUM INTO target. Same directory as destPath so the eventual gzip
+	// rename is on the same filesystem.
+	tmpDBFile, err := os.CreateTemp(destDir, ".backup-*.db")
+	if err != nil {
+		return Result{}, fmt.Errorf("alloc tmpdb: %w", err)
+	}
+	tmpDBPath := tmpDBFile.Name()
+	tmpDBFile.Close()
+	// VACUUM INTO refuses to write to an existing file. Remove the placeholder
+	// CreateTemp left behind, then ensure cleanup on any exit.
+	if err := os.Remove(tmpDBPath); err != nil {
+		return Result{}, fmt.Errorf("remove tmpdb placeholder: %w", err)
+	}
+	defer os.Remove(tmpDBPath)
+
+	if err := vacuumInto(srcPath, tmpDBPath); err != nil {
+		return Result{}, err
+	}
+
+	rawInfo, err := os.Stat(tmpDBPath)
+	if err != nil {
+		return Result{}, fmt.Errorf("stat tmpdb: %w", err)
+	}
+
+	if err := integrityCheck(tmpDBPath); err != nil {
+		return Result{}, err
+	}
+
+	gzSize, err := gzipFile(tmpDBPath, destPath)
+	if err != nil {
+		return Result{}, err
+	}
+
+	return Result{
+		Path:        destPath,
+		RawSize:     rawInfo.Size(),
+		GzippedSize: gzSize,
+		Elapsed:     time.Since(start),
+	}, nil
+}
+
+// vacuumInto runs `VACUUM INTO destPath` against a read-only handle of
+// srcPath. The destination must not exist; SQLite refuses to overwrite.
+func vacuumInto(srcPath, destPath string) error {
+	// mode=ro takes a shared lock; safe alongside a concurrent writer.
+	// _txlock=deferred avoids holding an exclusive lock unnecessarily.
+	dsn := fmt.Sprintf("file:%s?mode=ro&_txlock=deferred", srcPath)
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return fmt.Errorf("open src: %w", err)
+	}
+	defer db.Close()
+
+	// SQLite quotes the path in single-quotes; escape any embedded single
+	// quote by doubling. Path is caller-controlled so this is defensive
+	// rather than necessary in practice, but cheap.
+	quoted := "'" + replaceAll(destPath, "'", "''") + "'"
+	if _, err := db.Exec("VACUUM INTO " + quoted); err != nil {
+		return fmt.Errorf("vacuum into: %w", err)
+	}
+	return nil
+}
+
+// integrityCheck opens dbPath read-only and runs PRAGMA integrity_check.
+// Returns nil only when SQLite reports "ok" — any other result is a
+// corruption signal and we bail out of the backup rather than ship a
+// broken snapshot.
+func integrityCheck(dbPath string) error {
+	dsn := fmt.Sprintf("file:%s?mode=ro", dbPath)
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return fmt.Errorf("reopen for integrity_check: %w", err)
+	}
+	defer db.Close()
+	var result string
+	if err := db.QueryRow("PRAGMA integrity_check").Scan(&result); err != nil {
+		return fmt.Errorf("integrity_check exec: %w", err)
+	}
+	if result != "ok" {
+		return fmt.Errorf("integrity_check reported corruption: %s", result)
+	}
+	return nil
+}
+
+// gzipFile compresses srcPath into destPath (atomic rename via .tmp). Uses
+// gzip BestSpeed; the consecutive-snapshot redundancy that gzip can't catch
+// is left for a future dedup pass.
+func gzipFile(srcPath, destPath string) (int64, error) {
+	tmpPath := destPath + ".tmp"
+	out, err := os.Create(tmpPath)
+	if err != nil {
+		return 0, fmt.Errorf("create gz tmp: %w", err)
+	}
+	cleanup := func() { out.Close(); os.Remove(tmpPath) }
+
+	gw, err := gzip.NewWriterLevel(out, gzip.BestSpeed)
+	if err != nil {
+		cleanup()
+		return 0, fmt.Errorf("gzip writer: %w", err)
+	}
+
+	in, err := os.Open(srcPath)
+	if err != nil {
+		gw.Close()
+		cleanup()
+		return 0, fmt.Errorf("open src for gzip: %w", err)
+	}
+	if _, err := io.Copy(gw, in); err != nil {
+		in.Close()
+		gw.Close()
+		cleanup()
+		return 0, fmt.Errorf("gzip copy: %w", err)
+	}
+	in.Close()
+	if err := gw.Close(); err != nil {
+		cleanup()
+		return 0, fmt.Errorf("gzip close: %w", err)
+	}
+	if err := out.Sync(); err != nil {
+		cleanup()
+		return 0, fmt.Errorf("fsync gz: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		os.Remove(tmpPath)
+		return 0, fmt.Errorf("close gz: %w", err)
+	}
+	fi, err := os.Stat(tmpPath)
+	if err != nil {
+		os.Remove(tmpPath)
+		return 0, fmt.Errorf("stat gz: %w", err)
+	}
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		os.Remove(tmpPath)
+		return 0, fmt.Errorf("rename gz: %w", err)
+	}
+	return fi.Size(), nil
+}
+
+// replaceAll is a stdlib-equivalent helper kept local so backup.go has no
+// strings import (the rest of the package doesn't need it either).
+func replaceAll(s, old, new string) string {
+	if old == "" || old == new {
+		return s
+	}
+	var b []byte
+	for i := 0; i < len(s); {
+		if i+len(old) <= len(s) && s[i:i+len(old)] == old {
+			b = append(b, new...)
+			i += len(old)
+			continue
+		}
+		b = append(b, s[i])
+		i++
+	}
+	return string(b)
+}

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package backup
+
+import (
+	"compress/gzip"
+	"database/sql"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// seedDB creates a small SQLite DB with N rows. Returns its path.
+func seedDB(t *testing.T, n int) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "src.db")
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`
+		CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT);
+		CREATE INDEX idx_t_val ON t(val);
+	`); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		if _, err := db.Exec("INSERT INTO t(val) VALUES(?)", "row-"+strings.Repeat("x", i%20)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return path
+}
+
+// countRows opens a possibly-gzipped backup and returns the row count of
+// table t. For .gz it ungzips into a temp file first.
+func countRows(t *testing.T, path string) int {
+	t.Helper()
+	dbPath := path
+	if strings.HasSuffix(path, ".gz") {
+		f, err := os.Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		gz, err := gzip.NewReader(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer gz.Close()
+		out, err := os.CreateTemp("", "verify-*.db")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(out.Name())
+		if _, err := io.Copy(out, gz); err != nil {
+			t.Fatal(err)
+		}
+		out.Close()
+		dbPath = out.Name()
+	}
+	db, err := sql.Open("sqlite3", "file:"+dbPath+"?mode=ro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var n int
+	if err := db.QueryRow("SELECT count(*) FROM t").Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+func TestBackupRoundTrip(t *testing.T) {
+	const rows = 250
+	src := seedDB(t, rows)
+	dir := t.TempDir()
+	dest := filepath.Join(dir, Filename(TagDaily, time.Now()))
+
+	res, err := Backup(src, dest)
+	if err != nil {
+		t.Fatalf("Backup: %v", err)
+	}
+	if res.Path != dest {
+		t.Errorf("Result.Path = %q, want %q", res.Path, dest)
+	}
+	if res.RawSize == 0 || res.GzippedSize == 0 {
+		t.Errorf("Result.RawSize=%d Result.GzippedSize=%d, both should be >0", res.RawSize, res.GzippedSize)
+	}
+	if res.Elapsed <= 0 {
+		t.Errorf("Result.Elapsed = %v, want >0", res.Elapsed)
+	}
+
+	if got := countRows(t, dest); got != rows {
+		t.Errorf("restored row count = %d, want %d", got, rows)
+	}
+}
+
+func TestBackupRejectsNonGzDestination(t *testing.T) {
+	src := seedDB(t, 1)
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "snapshot.db") // missing .gz
+
+	_, err := Backup(src, dest)
+	if err == nil {
+		t.Fatal("expected error for non-.gz destination, got nil")
+	}
+	if !strings.Contains(err.Error(), ".gz") {
+		t.Errorf("error doesn't mention .gz: %v", err)
+	}
+}
+
+func TestBackupCleansUpTempOnFailure(t *testing.T) {
+	src := seedDB(t, 1)
+	dir := t.TempDir()
+	// Destination directory must exist; we point at a path inside a
+	// non-existent subdir to force gzipFile to fail when creating the
+	// .tmp file.
+	dest := filepath.Join(dir, "nope", Filename(TagDaily, time.Now()))
+
+	_, err := Backup(src, dest)
+	if err == nil {
+		t.Fatal("expected error when destination dir doesn't exist")
+	}
+
+	// dir should be exactly as we left it (no .backup-*.db, no .tmp files
+	// leaking up to the parent).
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".backup-") || strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("leftover temp file: %s", e.Name())
+		}
+	}
+}
+
+func TestBackupSurvivesPathWithQuote(t *testing.T) {
+	src := seedDB(t, 5)
+	// Path with a single quote in the directory name. SQLite's VACUUM
+	// INTO uses single-quoted paths; backup.go escapes embedded quotes.
+	dir := filepath.Join(t.TempDir(), "with'quote")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(dir, Filename(TagDaily, time.Now()))
+
+	if _, err := Backup(src, dest); err != nil {
+		t.Fatalf("Backup with quoted path: %v", err)
+	}
+	if got := countRows(t, dest); got != 5 {
+		t.Errorf("row count = %d, want 5", got)
+	}
+}
+
+func TestFilenameTagAndTimeFormat(t *testing.T) {
+	ts := time.Date(2026, 5, 18, 3, 17, 42, 0, time.UTC)
+	got := Filename(TagPreMigration, ts)
+	want := "mnemo-pre-migration-20260518T031742Z.db.gz"
+	if got != want {
+		t.Errorf("Filename = %q, want %q", got, want)
+	}
+}
+
+func TestFilenameSortableChronologically(t *testing.T) {
+	older := Filename(TagDaily, time.Date(2026, 5, 18, 3, 0, 0, 0, time.UTC))
+	newer := Filename(TagDaily, time.Date(2026, 5, 18, 4, 0, 0, 0, time.UTC))
+	if older >= newer {
+		t.Errorf("filenames don't sort chronologically: %s !< %s", older, newer)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -22,9 +22,11 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/marcelocantos/mnemo/internal/backup"
 	"github.com/marcelocantos/sqldeep/go/sqldeep"
 	"github.com/marcelocantos/sqlift/go/sqlift"
 	_ "github.com/mattn/go-sqlite3"
@@ -39,6 +41,7 @@ const NoncePrefix = "mnemo:self:"
 // Store is a searchable index of Claude Code transcripts.
 type Store struct {
 	db         *sql.DB
+	dbPath     string
 	projectDir string
 
 	mu      sync.Mutex
@@ -82,6 +85,40 @@ type Store struct {
 	// without bound on every Sync cycle. Populated via
 	// RegisterExcludedPath, queried via IsExcluded.
 	exclusions *exclusionRegistry
+
+	// lastWriteAt is the unix-nano timestamp of the most recent ingest
+	// or backfill that committed rows. Updated by NoteActivity; read
+	// by the backup worker via LastWriteAt() to detect a quiescent
+	// window before taking a snapshot. Tracked in-memory only — a
+	// daemon restart resets it to startup time, which is conservative
+	// (worker will wait the full quiescence period before its first
+	// backup attempt). Atomic so reads and writes don't need rwmu.
+	lastWriteAt atomic.Int64
+}
+
+// NoteActivity records that a write happened just now. The backup worker
+// reads this via LastWriteAt to detect a quiescent window before snapshotting.
+// Call from any ingest / backfill path that commits rows. Cheap (atomic
+// store of an int64).
+func (s *Store) NoteActivity() {
+	s.lastWriteAt.Store(time.Now().UnixNano())
+}
+
+// LastWriteAt returns the wall-clock time of the most recent NoteActivity
+// call, or the zero Time if nothing has been recorded since startup.
+func (s *Store) LastWriteAt() time.Time {
+	ns := s.lastWriteAt.Load()
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns)
+}
+
+// DBPath returns the filesystem path of the underlying SQLite database.
+// Used by the backup worker to point sqlift / VACUUM INTO at the right
+// file without re-deriving the path.
+func (s *Store) DBPath() string {
+	return s.dbPath
 }
 
 // SetWorkspaceRoots configures the filesystem roots under which repo-
@@ -465,6 +502,46 @@ func applySchema(dbPath string) error {
 	if err != nil {
 		return fmt.Errorf("sqlift diff: %w", err)
 	}
+	if plan.Empty() {
+		// No diff — nothing to back up before, nothing to apply.
+		return nil
+	}
+
+	// Pre-migration backup. Cheap insurance even though AllowNone gates
+	// reject everything destructive: if a future sqlift bug or an
+	// unexpected interaction at apply time corrupts the live DB, this
+	// snapshot is the rollback point. Tagged pre-migration so the daily
+	// worker's retention GC can identify it; sharing the daily pool per
+	// 🎯T61 design.
+	backupDir := filepath.Join(filepath.Dir(dbPath), "backups")
+	if err := os.MkdirAll(backupDir, 0o755); err != nil {
+		slog.Warn("backup dir create failed; proceeding without pre-migration backup",
+			"dir", backupDir, "err", err)
+	} else {
+		destPath := filepath.Join(backupDir,
+			backup.Filename(backup.TagPreMigration, time.Now()))
+		// sqlift's connection holds a write lock; release it briefly so
+		// Backup can take a fresh shared lock via its own read-only handle.
+		sdb.Close()
+		res, berr := backup.Backup(dbPath, destPath)
+		if berr != nil {
+			slog.Warn("pre-migration backup failed; proceeding with migration anyway",
+				"err", berr)
+		} else {
+			slog.Info("pre-migration backup written",
+				"path", res.Path,
+				"raw_mb", res.RawSize/(1<<20),
+				"gz_mb", res.GzippedSize/(1<<20),
+				"elapsed", res.Elapsed.Round(time.Second))
+		}
+		// Re-open sqlift handle for Apply.
+		sdb, err = sqlift.Open(dbPath)
+		if err != nil {
+			return fmt.Errorf("sqlift reopen after backup: %w", err)
+		}
+		defer sdb.Close()
+	}
+
 	return sqlift.Apply(sdb, plan, sqlift.ApplyOptions{Allow: sqlift.AllowNone})
 }
 
@@ -498,6 +575,7 @@ func New(dbPath, projectDir string) (*Store, error) {
 	}
 	s := &Store{
 		db:         db,
+		dbPath:     dbPath,
 		projectDir: projectDir,
 		offsets:    make(map[string]int64),
 		imageSem:   make(chan struct{}, n),
@@ -5620,6 +5698,7 @@ func (s *Store) ingestFile(path string) error {
 
 	if count > 0 {
 		slog.Debug("ingested", "file", filepath.Base(path), "messages", count)
+		s.NoteActivity()
 	}
 
 	// Detect decision pairs (proposal + confirmation) in this session.


### PR DESCRIPTION
🎯T61 Phase 1. Foundation for the automated backup scheme — primitive + pre-migration hook. Phase 2 (periodic worker + config + MCP tools) is a separate PR.

## What lands

1. **`internal/backup` package.** `Backup(src, dest)` primitive: `VACUUM INTO` → `PRAGMA integrity_check` → gzip BestSpeed → atomic rename. Safe against a running daemon (shared lock via `mode=ro`). 6 unit tests + verified end-to-end against the 7.1 GB live mnemo.db (80s wall, 1.96 GB output).

2. **Pre-migration backup hook.** `applySchema` snapshots the live DB before invoking `sqlift.Apply` whenever the diff is non-empty. Even with AllowNone gates rejecting all destructive ops, this is cheap insurance: if a future sqlift bug or unexpected apply-time interaction corrupts the DB, the snapshot is the rollback point. Tagged `pre-migration` so future retention can identify it.

3. **Activity tracking foundation.** `Store.NoteActivity()` / `Store.LastWriteAt()` for the Phase 2 worker to detect a quiescent window. Wired into `ingestFile`'s post-commit path. `Store.DBPath()` exposes the SQLite path to the worker.

## Why the split

The pre-migration hook is the most-load-bearing piece (catches the immediate migration-safety concern). The periodic worker is the larger surface and benefits from focused review on its own. Phase 1 stands on its own — it's already a complete improvement.

## Empirical findings (recorded in 🎯T61 context)

- `VACUUM INTO` is **deterministic**: consecutive runs against unchanged data produce byte-identical output. Daily backups against quiet days are identical files. Future optimization path: zstd-with-baseline-dict (~5-6 GB total at power-user scale) or chunked dedup (~2-3 GB).
- `VACUUM INTO` doesn't shrink FTS5-heavy DBs. 7.1 GB → 7.1 GB intermediate → 1.96 GB after gzip BestSpeed.
- macOS/Linux runners have system sqlite3; Windows path is covered by the existing pacman install from #82.

## Deferred to Phase 2

- `BackupConfig` (Enabled, Dir, KeepDailies, WindowStart, WindowEnd, QuiescenceMin) — hot-reloadable via `mnemo_config`
- Registry worker goroutine: 03:00–04:00 local random scheduling, ≥15 min quiescence, run backup, GC old, repeat
- `mnemo_backup_status` + `mnemo_backup_now` MCP tools
- Wire `NoteActivity` into remaining write paths (vault, github backfill, memories, skills, etc.)

## Test plan

- [x] `go test -tags sqlite_fts5 -count=1 ./internal/backup/... ./internal/store/...` passes (6 backup tests + all existing store tests)
- [x] End-to-end backup of the live 7.1 GB DB (1m40s, 1.96 GB output, daemon stays running)
- [ ] CI green on this branch
