### PR TITLE
Release v0.40.0

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1677,7 +1677,7 @@ targets:
     achieved: 2026-05-18
   T62:
     name: Daemon eager-starts default user's workers at boot
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -1696,6 +1696,7 @@ targets:
       Per-MCP-client lazy initialization is a separate concern that doesn't apply here — `ForUser` is keyed by OS user, not by connection.
     origin: manual
     discovered: 2026-05-19
+    achieved: 2026-05-19
   T7:
     name: Agent-defined query templates
     status: achieved

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.39.0"
+	version              = "0.40.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
Release prep for v0.40.0.

## Summary

- Bumps `version` in `main.go` to `0.40.0`

## Changes since v0.39.0

- **🎯T62: eager-start default user's workers at daemon boot** (#89) — fixes the bug discovered in v0.39.0 where the backup worker (and every other per-user worker) only started on the first MCP tool call. For a brew-services daemon with no active Claude session, the daily backup never fired.

## Test plan

- [x] `go test -tags sqlite_fts5 -count=1 ./...` passes (12 packages)
- [x] PR #89 CI green on both ubuntu + windows
- [ ] CI green on this branch
- [ ] After brew upgrade + restart, daemon log shows backup worker startup without MCP traffic
