### PR TITLE
🎯T63: cost reconciliation is opt-in via explicit config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,43 @@ means data removal is decoupled from schema change.
    user-triggered or scheduled, customisable in scope, and
    idempotent. The columns themselves are still not dropped.
 
+## External API egress
+
+mnemo is conservative about outbound calls to hosted APIs. The
+ingest path is fully local (filesystem only); only a few features
+talk to external services, and each is gated independently.
+
+**Anthropic Admin API (cost reconciliation, 🎯T63).** Disabled by
+default. The reconciler — which fetches authoritative daily costs
+from the Admin API to populate `reconciled_costs` — only starts when
+**both** of these hold:
+
+1. `cost_reconciliation.enabled: true` is set in `~/.mnemo/config.json`.
+2. `ANTHROPIC_ADMIN_API_KEY` is present in the daemon's environment.
+
+The key alone is not sufficient. A user who keeps the key around for
+other tooling will **not** trigger any mnemo Admin API call until
+they explicitly opt in via config. The estimated-cost path (derived
+from transcript tokens by the ingest layer) is always on and
+requires zero external calls — the default `mnemo_usage` view runs
+purely off local data.
+
+This default exists for users operating in environments where
+unsolicited outbound calls to hosted APIs require security-team
+review. Opt-in must be deliberate; defaults are silent.
+
+**GitHub API.** Used by the PR/issue/CI backfill workers per repo
+that already appears in session history. No org-scope fan-out; no
+secret material required (relies on the local `gh` auth).
+
+**Federation (🎯T15 / linked instances).** Outbound calls to peer
+mnemo daemons are gated on `linked_instances` being non-empty in
+config. Absent → zero federation calls.
+
+The append-only schema policy and the opt-in egress posture compose:
+restoring an older backup never silently triggers a backfill of
+data from external APIs that the user did not authorise.
+
 ## Delivery
 
 Merged to master via squash PR.

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1699,6 +1699,28 @@ targets:
     origin: manual
     discovered: 2026-05-19
     achieved: 2026-05-19
+  T63:
+    name: Cost reconciliation is gated by explicit opt-in config, not by ambient ANTHROPIC_ADMIN_API_KEY presence
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - A new config key (e.g. cost_reconciliation_enabled bool, default false) lives in ~/.mnemo/config.json and is consulted by StartReconciler in internal/store/reconciler.go before any Admin API call.
+    - With the config flag off (the default), the reconciler exits early on startup with an informational log line and makes ZERO outbound Admin API calls, regardless of whether ANTHROPIC_ADMIN_API_KEY is set in the environment.
+    - With the config flag on AND the key present, the reconciler runs as today.
+    - With the config flag on AND the key missing, the reconciler logs the existing key-missing warning and exits.
+    - Documentation (CLAUDE.md or a README section) describes reconciliation as opt-in and explains the rationale (security-reviewed environments where unsolicited Admin API egress is undesirable).
+    - An mnemo_config write that flips the flag is hot-reloaded into a running daemon (start/stop the reconciler goroutine without a restart), consistent with the existing hot-reload coverage.
+    context: |-
+      User feedback 2026-05-21: \"Cost reconciliation will need to be an opt-in feature. I often operate in environments where those APIs are not available, and I don't want to have security teams ask questions about why I'm trying to call these APIs.\"
+
+      Today's behaviour (internal/store/reconciler.go:57-83): StartReconciler reads ANTHROPIC_ADMIN_API_KEY from the environment and, if present, immediately polls the Anthropic Admin API once and then every reconcilerInterval (1 minute) for the lifetime of the daemon. There is no config-level gate. If the user has the key set for any other tool, mnemo silently starts hitting the Admin API.
+
+      This is the wrong default for environments with security review on outbound egress. The fix is to add an explicit boolean (e.g. `cost_reconciliation_enabled`) in ~/.mnemo/config.json, default false, that StartReconciler must check first. Key presence is necessary but not sufficient.
+
+      Distinct from 🎯T46: T46 is about *delivering* the reconciled-mode value (verification, key wiring, production rollout). This target is about *gating* the feature so its existence doesn't impose a security-review burden by default. Both can ship independently — this one is small (one config field, one early-return branch, doc update, hot-reload hook) and should ship first so that T46's eventual resumption doesn't widen the surface.
+    origin: manual
+    discovered: 2026-05-20
   T7:
     name: Agent-defined query templates
     status: achieved

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1701,7 +1701,7 @@ targets:
     achieved: 2026-05-19
   T63:
     name: Cost reconciliation is gated by explicit opt-in config, not by ambient ANTHROPIC_ADMIN_API_KEY presence
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -1721,6 +1721,7 @@ targets:
       Distinct from 🎯T46: T46 is about *delivering* the reconciled-mode value (verification, key wiring, production rollout). This target is about *gating* the feature so its existence doesn't impose a security-review burden by default. Both can ship independently — this one is small (one config field, one early-return branch, doc update, hot-reload hook) and should ship first so that T46's eventual resumption doesn't widen the surface.
     origin: manual
     discovered: 2026-05-20
+    achieved: 2026-05-20
   T7:
     name: Agent-defined query templates
     status: achieved

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -90,12 +90,14 @@ type Registry struct {
 // poller, reconciler) all continue uninterrupted, since the Store and
 // transcript ingest pipeline are unaffected by a vault path change.
 type userEntry struct {
-	store        *store.Store
-	vault        *vault.Exporter // nil when vault_path is not configured
-	workers      sync.WaitGroup
-	vaultCancel  context.CancelFunc // cancels the vault sub-context; nil when vault disabled
-	vaultWorkers sync.WaitGroup     // tracks only vault goroutines, so reload can wait for them
-	homeDir      string             // remembered for Reload's ~/ expansion
+	store             *store.Store
+	vault             *vault.Exporter // nil when vault_path is not configured
+	workers           sync.WaitGroup
+	vaultCancel       context.CancelFunc // cancels the vault sub-context; nil when vault disabled
+	vaultWorkers      sync.WaitGroup     // tracks only vault goroutines, so reload can wait for them
+	reconcilerCancel  context.CancelFunc // cancels the reconciler sub-context; nil when disabled
+	reconcilerWorkers sync.WaitGroup     // tracks reconciler goroutine for hot-reload
+	homeDir           string             // remembered for Reload's ~/ expansion
 }
 
 // NewRegistry builds an empty Registry. The baseCtx is cancelled on
@@ -307,17 +309,62 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 		}
 	}()
 
-	// Anthropic Admin API cost reconciler (🎯T45).
-	// StartReconciler is a no-op when ANTHROPIC_ADMIN_API_KEY is absent.
-	e.workers.Add(1)
-	go func() {
-		defer e.workers.Done()
-		e.store.StartReconciler(r.baseCtx)
-	}()
+	// Anthropic Admin API cost reconciler (🎯T45, 🎯T63). Opt-in via
+	// config.cost_reconciliation.enabled — disabled by default so that
+	// no outbound Admin API call is made unless the operator
+	// explicitly says so. Tracked per-userEntry so Reload can start
+	// and stop the goroutine when the flag flips.
+	r.startReconcilerWorker(e)
 
 	// Periodic backup worker (🎯T61). Opted in by default; opt out via
 	// {"backup": {"disabled": true}} in config.json.
 	r.startBackupWorker(username, e, logger)
+}
+
+// startReconcilerWorker spawns (or no-ops) the per-user Anthropic
+// Admin API reconciler goroutine. Reads the latest cfg.CostReconciliation
+// flag and tracks the cancel func + waitgroup on e so a subsequent
+// Reload can stop the goroutine cleanly when the flag flips off.
+//
+// Caller must hold no locks; this method serialises against r.mu only
+// when writing the cancel func into e. Safe to call from both
+// startWorkers (initial bring-up) and Reload (config flip).
+func (r *Registry) startReconcilerWorker(e *userEntry) {
+	enabled := r.cfg.CostReconciliation.IsEnabled()
+	if !enabled {
+		// Run the gated entry-point once anyway to surface the
+		// "disabled" log line at the same level/cadence as before.
+		// StartReconciler is a synchronous no-op in this branch.
+		e.store.StartReconciler(r.baseCtx, false)
+		return
+	}
+	ctx, cancel := context.WithCancel(r.baseCtx)
+	r.mu.Lock()
+	e.reconcilerCancel = cancel
+	r.mu.Unlock()
+	e.reconcilerWorkers.Add(1)
+	go func() {
+		defer e.reconcilerWorkers.Done()
+		e.store.StartReconciler(ctx, true)
+		// StartReconciler spawns its own inner goroutine and returns;
+		// keep this outer goroutine alive until ctx is cancelled so
+		// reconcilerWorkers.Wait() in Reload covers both layers.
+		<-ctx.Done()
+	}()
+}
+
+// stopReconcilerWorker cancels the per-user reconciler goroutine (if
+// any) and waits for it to drain. Idempotent — safe to call when the
+// reconciler is already stopped.
+func (r *Registry) stopReconcilerWorker(e *userEntry) {
+	r.mu.Lock()
+	cancel := e.reconcilerCancel
+	e.reconcilerCancel = nil
+	r.mu.Unlock()
+	if cancel != nil {
+		cancel()
+		e.reconcilerWorkers.Wait()
+	}
 }
 
 // startBackupWorker resolves the backup config and launches the daily
@@ -609,6 +656,18 @@ func (r *Registry) Reload(newCfg store.Config) ReloadReport {
 	if !linkedInstancesEqual(old.LinkedInstances, newCfg.LinkedInstances) {
 		report.Changed = append(report.Changed, "linked_instances")
 		report.RequiresRestart = append(report.RequiresRestart, "linked_instances")
+	}
+	if old.CostReconciliation.IsEnabled() != newCfg.CostReconciliation.IsEnabled() {
+		report.Changed = append(report.Changed, "cost_reconciliation.enabled")
+		for _, e := range entries {
+			// Tear down the existing goroutine (no-op when previously
+			// disabled) then start a fresh one if the new state opts
+			// in. startReconcilerWorker reads r.cfg, which was already
+			// swapped above under r.mu.
+			r.stopReconcilerWorker(e)
+			r.startReconcilerWorker(e)
+		}
+		report.Adopted = append(report.Adopted, "cost_reconciliation.enabled")
 	}
 	return report
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -58,6 +58,45 @@ func TestReloadReportClassifiesFields(t *testing.T) {
 	}
 }
 
+// TestReloadFlipsCostReconciliation verifies that toggling the
+// cost_reconciliation.enabled flag through Reload appears in the
+// Changed and Adopted fields. The flag is recognised as a live-
+// adoptable config change (🎯T63), distinct from linked_instances
+// which requires a restart.
+func TestReloadFlipsCostReconciliation(t *testing.T) {
+	old := store.Config{
+		CostReconciliation: store.CostReconciliationConfig{Enabled: false},
+	}
+	r := NewRegistry(context.Background(), old, "")
+	defer r.Close()
+
+	on := store.Config{
+		CostReconciliation: store.CostReconciliationConfig{Enabled: true},
+	}
+	report := r.Reload(on)
+	if !contains(report.Changed, "cost_reconciliation.enabled") {
+		t.Errorf("Changed: got %v want cost_reconciliation.enabled", report.Changed)
+	}
+	if !contains(report.Adopted, "cost_reconciliation.enabled") {
+		t.Errorf("Adopted: got %v want cost_reconciliation.enabled", report.Adopted)
+	}
+
+	// Flip off again — should re-appear as a change.
+	report = r.Reload(old)
+	if !contains(report.Changed, "cost_reconciliation.enabled") {
+		t.Errorf("Reload back to off, Changed: got %v want cost_reconciliation.enabled", report.Changed)
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestReloadFlagsLinkedInstancesAsRestart(t *testing.T) {
 	old := store.Config{LinkedInstances: nil}
 	r := NewRegistry(context.Background(), old, "")

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -64,7 +64,34 @@ type Config struct {
 	// Backup controls the daemon's periodic backup worker (🎯T61).
 	// Absent in config.json → all defaults apply, backup enabled.
 	Backup BackupConfig `json:"backup,omitempty"`
+
+	// CostReconciliation controls the Anthropic Admin API reconciler
+	// (🎯T63). Disabled by default: even with ANTHROPIC_ADMIN_API_KEY
+	// set in the environment, no outbound Admin API call is made until
+	// the user explicitly opts in via this config block. This protects
+	// users in security-reviewed environments where unsolicited egress
+	// to hosted APIs is undesirable. The estimated-cost path (derived
+	// from transcript tokens) is always on and requires zero external
+	// calls.
+	CostReconciliation CostReconciliationConfig `json:"cost_reconciliation,omitempty"`
 }
+
+// CostReconciliationConfig gates the Anthropic Admin API reconciler.
+// A zero-value CostReconciliationConfig (i.e. the section omitted from
+// config.json) means disabled — opposite of BackupConfig's safety
+// default, because the safe default for unsolicited outbound API calls
+// is "do not call".
+type CostReconciliationConfig struct {
+	// Enabled opts in to the reconciler. When false (the zero value
+	// and documented default), StartReconciler exits immediately and
+	// makes zero Admin API calls regardless of whether
+	// ANTHROPIC_ADMIN_API_KEY is set in the daemon's environment.
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+// IsEnabled reports whether the reconciler should run. False by
+// default (zero-value config = no Admin API calls).
+func (c CostReconciliationConfig) IsEnabled() bool { return c.Enabled }
 
 // BackupConfig controls the periodic backup worker. Field defaults are
 // resolved via the Effective* methods so a zero-value BackupConfig (the

--- a/internal/store/reconciler.go
+++ b/internal/store/reconciler.go
@@ -52,13 +52,26 @@ type costReportEntry struct {
 // Admin API for authoritative daily costs and stores them via
 // UpsertReconciledCost. It stops when ctx is cancelled.
 //
-// If ANTHROPIC_ADMIN_API_KEY is not set, a one-time warning is logged and
-// the reconciler exits immediately without affecting normal operation.
-func (s *Store) StartReconciler(ctx context.Context) {
+// Gating (🎯T63):
+//   - enabled=false (the default, per CostReconciliationConfig): log an
+//     informational line and return; no Admin API call is ever made,
+//     regardless of whether ANTHROPIC_ADMIN_API_KEY is set.
+//   - enabled=true but ANTHROPIC_ADMIN_API_KEY missing: log a warning
+//     and return; the user opted in but the key is unreachable.
+//   - enabled=true with the key present: poll once immediately, then
+//     every reconcilerInterval.
+func (s *Store) StartReconciler(ctx context.Context, enabled bool) {
+	if !enabled {
+		slog.Info("cost reconciliation disabled: opt-in via " +
+			"config.cost_reconciliation.enabled = true; " +
+			"usage rows will report source=estimated")
+		return
+	}
 	apiKey := os.Getenv(anthropicAdminAPIKeyEnv)
 	if apiKey == "" {
-		slog.Warn("cost reconciliation disabled: ANTHROPIC_ADMIN_API_KEY not set; " +
-			"usage rows will report source=estimated")
+		slog.Warn("cost reconciliation enabled in config but " +
+			"ANTHROPIC_ADMIN_API_KEY not set; usage rows will " +
+			"report source=estimated")
 		return
 	}
 

--- a/internal/store/reconciler_test.go
+++ b/internal/store/reconciler_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestStartReconcilerOptInGate verifies the 🎯T63 contract:
+// StartReconciler with enabled=false must return immediately without
+// spawning a goroutine, regardless of whether ANTHROPIC_ADMIN_API_KEY
+// is set in the environment. The intent is that an operator with the
+// key in their shell for unrelated tooling does NOT accidentally
+// activate the Admin API reconciler.
+//
+// We use a synthetic "would-have-fired" detector: with enabled=false,
+// StartReconciler returns synchronously; with enabled=true and no key,
+// it likewise returns synchronously (key-missing branch); only with
+// enabled=true and a key would it spawn a goroutine. The test asserts
+// the synchronous return semantics directly.
+func TestStartReconcilerOptInGate(t *testing.T) {
+	s := newTestStore(t, t.TempDir())
+
+	// Inject a fake key so the only thing preventing API calls is the
+	// opt-in flag itself.
+	t.Setenv(anthropicAdminAPIKeyEnv, "sk-ant-admin-fake")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// enabled=false must return immediately and never invoke the
+	// network. We bound the call with a generous-but-finite timeout —
+	// if StartReconciler were to spawn a goroutine and block here,
+	// the test would deadlock; the timeout converts that into a
+	// visible failure rather than a hang.
+	done := make(chan struct{})
+	go func() {
+		s.StartReconciler(ctx, false)
+		close(done)
+	}()
+	select {
+	case <-done:
+		// success — StartReconciler returned synchronously
+	case <-time.After(2 * time.Second):
+		t.Fatal("StartReconciler(ctx, false) did not return; opt-in gate is leaky")
+	}
+}
+
+// TestStartReconcilerEnabledWithoutKey verifies the second guard:
+// when the operator opts in via config but the environment is missing
+// the key, StartReconciler still returns without spawning a worker.
+// This is the existing key-missing branch, kept for completeness.
+func TestStartReconcilerEnabledWithoutKey(t *testing.T) {
+	s := newTestStore(t, t.TempDir())
+
+	// Explicitly clear the env so the key-missing branch fires even
+	// on a host that happens to have it set.
+	t.Setenv(anthropicAdminAPIKeyEnv, "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		s.StartReconciler(ctx, true)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StartReconciler(ctx, true) without key did not return")
+	}
+}


### PR DESCRIPTION
## Summary

- New `cost_reconciliation.enabled` field in `~/.mnemo/config.json` (default `false`). The Anthropic Admin API reconciler no longer starts on ambient key presence — opt-in is now deliberate.
- `StartReconciler` takes an `enabled bool` and short-circuits with an info log when false. With the flag on but `ANTHROPIC_ADMIN_API_KEY` missing, the existing key-missing warning still fires.
- Hot-reload wired: per-userEntry `reconcilerCancel`/`reconcilerWorkers`, with Reload starting/stopping the goroutine when the flag flips. Consistent with `vault_path` coverage.
- CLAUDE.md gains an "External API egress" section documenting the opt-in posture for Admin API, GitHub backfill, and federation.

## Why

User feedback: \"Cost reconciliation will need to be an opt-in feature. I often operate in environments where those APIs are not available, and I don't want to have security teams ask questions about why I'm trying to call these APIs.\"

The previous shape (key-only gate) silently turned the reconciler on whenever the key happened to be in the daemon's environment for any reason. That's the wrong default for security-reviewed environments and for users who keep the key around for other tooling.

## Acceptance for 🎯T63

- [x] New config flag, default false, consulted by `StartReconciler`.
- [x] Flag off → zero Admin API calls regardless of key.
- [x] Flag on + key → runs as today.
- [x] Flag on + no key → existing warning, no calls.
- [x] Documentation describes opt-in rationale.
- [x] `mnemo_config` write hot-reloads (start/stop goroutine without restart).

## Test plan

- [x] `go test -tags sqlite_fts5 ./...` — full suite green
- [x] `make bullseye` — invariants green
- [x] New tests: `TestStartReconcilerOptInGate`, `TestStartReconcilerEnabledWithoutKey`, `TestReloadFlipsCostReconciliation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)