### PR TITLE
🎯T56: drop sqldeep dispatch in Store.Query

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1504,7 +1504,7 @@ targets:
     achieved: 2026-05-12
   T56:
     name: Store.Query unconditionally transpiles via sqldeep instead of dispatching on syntax
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -1542,6 +1542,7 @@ targets:
       Cleanup-shaped. Independent of T49/T50/T51 — can ship anytime. If sqldeep round-tripping reveals a real issue with a specific SQL construct, file an upstream sqldeep target rather than adding a special case back to mnemo.
     origin: manual
     discovered: 2026-05-11
+    achieved: 2026-05-20
   T57:
     name: internal/store TestUsage* tests pass on master
     status: achieved
@@ -1556,7 +1557,7 @@ targets:
     achieved: 2026-05-12
   T58:
     name: CI is enforced as a required status check on master
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -1568,6 +1569,7 @@ targets:
     - T57
     origin: manual
     discovered: 2026-05-11
+    achieved: 2026-05-20
   T59:
     name: Compaction is triggered by session-activity heuristics, not by MCP connection bindings
     status: identified

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -8,6 +8,7 @@ package store
 
 import (
 	"bufio"
+	"context"
 	"database/sql"
 	_ "embed"
 	"encoding/json"
@@ -5155,34 +5156,39 @@ func parseLsofOutput(data []byte) map[string]int {
 	return result
 }
 
-// isSqldeep returns true if the query uses sqldeep nested syntax.
-func isSqldeep(upper string) bool {
-	return strings.HasPrefix(upper, "FROM") || strings.Contains(upper, "SELECT {")
-}
-
-// Query runs a read-only SQL query and returns rows as maps.
-// Accepts both plain SQL (SELECT/WITH) and sqldeep nested syntax
-// (FROM ... SELECT { ... }). sqldeep queries are transparently
-// transpiled to SQL before execution.
+// Query runs a read-only SQL query and returns rows as maps. Input is
+// unconditionally passed through sqldeep.Transpile — sqldeep is a strict
+// superset of SQL, so plain SELECT/WITH round-trips unchanged. Read-only
+// enforcement is delegated to SQLite via PRAGMA query_only on the
+// dedicated connection used for the query; write statements are rejected
+// by SQLite itself, not by a string-prefix sniff in Go.
 func (s *Store) Query(query string, args ...any) ([]map[string]any, error) {
-	q := strings.TrimSpace(query)
-	upper := strings.ToUpper(q)
-
-	execSQL := query
-	if isSqldeep(upper) {
-		sql, err := sqldeep.Transpile(q)
-		if err != nil {
-			return nil, fmt.Errorf("sqldeep transpile: %w", err)
-		}
-		execSQL = sql
-	} else if !strings.HasPrefix(upper, "SELECT") && !strings.HasPrefix(upper, "WITH") {
-		return nil, fmt.Errorf("only SELECT, WITH, and sqldeep (FROM ... SELECT { }) queries are allowed")
+	execSQL, err := sqldeep.Transpile(strings.TrimSpace(query))
+	if err != nil {
+		return nil, fmt.Errorf("sqldeep transpile: %w", err)
 	}
 
 	s.rwmu.RLock()
 	defer s.rwmu.RUnlock()
 
-	rows, err := s.db.Query(execSQL, args...)
+	ctx := context.Background()
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		// Reset before releasing so the next user of the (single-pool)
+		// connection isn't accidentally read-only. Use a background
+		// context so cancellation of the caller's query doesn't also
+		// cancel the reset.
+		_, _ = conn.ExecContext(context.Background(), "PRAGMA query_only = 0")
+		conn.Close()
+	}()
+	if _, err := conn.ExecContext(ctx, "PRAGMA query_only = 1"); err != nil {
+		return nil, fmt.Errorf("set query_only: %w", err)
+	}
+
+	rows, err := conn.QueryContext(ctx, execSQL, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -5207,6 +5213,13 @@ func (s *Store) Query(query string, args ...any) ([]map[string]any, error) {
 		if len(results) >= 100 {
 			break
 		}
+	}
+	// SQLITE_READONLY from PRAGMA query_only fires at sqlite3_step time,
+	// which surfaces as rows.Err() rather than the QueryContext result —
+	// so write statements (DELETE/DROP/INSERT/UPDATE) reach this check
+	// without an earlier prepare-time error.
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return results, nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -418,14 +418,26 @@ func TestQuery(t *testing.T) {
 		t.Errorf("expected count=2, got %v", rows[0]["cnt"])
 	}
 
-	// Write queries must be rejected.
-	_, err = s.Query("DELETE FROM messages")
-	if err == nil {
-		t.Error("expected error for DELETE query")
+	// Write queries must be rejected by the SQLite query_only layer,
+	// not by Go-side string-prefix sniffing.
+	for _, q := range []string{
+		"DELETE FROM messages",
+		"DROP TABLE messages",
+		"INSERT INTO messages (session_id, project, role, text) VALUES ('x','y','user','z')",
+		"UPDATE messages SET text = 'x'",
+	} {
+		if _, err := s.Query(q); err == nil {
+			t.Errorf("expected error for write query %q", q)
+		}
 	}
-	_, err = s.Query("DROP TABLE messages")
-	if err == nil {
-		t.Error("expected error for DROP query")
+
+	// Writes through Query must not have actually mutated state.
+	rows, err = s.Query("SELECT COUNT(*) AS cnt FROM messages WHERE session_id = 'sess-query'")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cnt, _ := rows[0]["cnt"].(int64); cnt != 2 {
+		t.Errorf("expected count still 2 after blocked writes, got %v", rows[0]["cnt"])
 	}
 
 	// WITH (CTE) queries should work.
@@ -435,6 +447,12 @@ func TestQuery(t *testing.T) {
 	}
 	if len(rows) != 1 {
 		t.Fatalf("expected 1 row from CTE, got %d", len(rows))
+	}
+
+	// After a Query, subsequent writes via the normal store path
+	// must still work — query_only must not leak into the shared pool.
+	if _, err := s.db.Exec("CREATE TEMP TABLE _t (x INT)"); err != nil {
+		t.Errorf("query_only leaked into shared connection: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Remove the `isSqldeep` syntax-dispatch helper; `Store.Query` now unconditionally pipes input through `sqldeep.Transpile`. sqldeep is a strict SQL superset, so plain `SELECT`/`WITH` round-trips unchanged.
- Move read-only enforcement off the Go-side string-prefix check and onto SQLite. Each `Query` grabs a dedicated `sql.Conn`, sets `PRAGMA query_only = 1`, runs the query, and resets the pragma before returning the connection to the pool. Errors from `sqlite3_step` propagate via `rows.Err()`.
- `TestQuery` now covers DELETE/DROP/INSERT/UPDATE rejection and verifies the pragma does not leak across the single-pool shared connection.

Bundled in the same PR: retirement of 🎯T58 (master ruleset 16212844 was updated out-of-band to require both `test` jobs as status checks, with the existing repo-admin bypass actor preserved).

## Test plan
- [x] `go test -tags "sqlite_fts5" ./...` — full suite green
- [x] `TestQuery` rejects DELETE / DROP / INSERT / UPDATE through `Store.Query`
- [x] `TestQuery` verifies row count is unchanged after blocked writes
- [x] `TestQuery` verifies a subsequent `s.db.Exec("CREATE TEMP TABLE ...")` still works (no query_only leak)
- [ ] CI green on ubuntu + windows runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)