### PR TITLE
🎯T60: sweep stale daemon_connections rows

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1617,7 +1617,7 @@ targets:
     achieved: 2026-04-07
   T60:
     name: Stale daemon_connections rows are reliably marked closed
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -1642,6 +1642,7 @@ targets:
       This target is small and independent — does not depend on T49/T59. Discovered 2026-05-14 while investigating the compactor wiring gap.
     origin: manual
     discovered: 2026-05-14
+    achieved: 2026-05-20
   T61:
     name: Automated periodic backups of mnemo.db
     status: achieved

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -319,6 +319,57 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 	// Periodic backup worker (🎯T61). Opted in by default; opt out via
 	// {"backup": {"disabled": true}} in config.json.
 	r.startBackupWorker(username, e, logger)
+
+	// Daemon connection sweeper (🎯T60). Marks daemon_connections rows
+	// closed once last_seen_at falls outside the idle threshold. The
+	// HTTP MCP transport has no reliable disconnect signal, so this
+	// sweep is the authoritative reaper. Opted in by default; opt out
+	// via {"connection_sweep": {"disabled": true}}.
+	r.startConnectionSweeper(e, logger)
+}
+
+// startConnectionSweeper spawns the per-user daemon_connections
+// sweeper goroutine. On each tick it calls
+// Store.MarkStaleConnectionsClosed; rows whose last_seen_at fell
+// outside the idle threshold are marked closed. No-ops when the
+// sweeper is disabled in config.
+func (r *Registry) startConnectionSweeper(e *userEntry, logger *slog.Logger) {
+	cfg := r.cfg.ConnectionSweep
+	if !cfg.IsEnabled() {
+		logger.Info("connection sweeper: disabled by config")
+		return
+	}
+	interval, err := cfg.EffectiveInterval()
+	if err != nil {
+		logger.Warn("connection sweeper: bad interval, falling back to 1m", "err", err)
+		interval = time.Minute
+	}
+	stale, err := cfg.EffectiveStaleAfter()
+	if err != nil {
+		logger.Warn("connection sweeper: bad stale_after, falling back to 10m", "err", err)
+		stale = 10 * time.Minute
+	}
+
+	e.workers.Add(1)
+	go func() {
+		defer e.workers.Done()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			n, err := e.store.MarkStaleConnectionsClosed(stale, time.Now())
+			if err != nil {
+				logger.Warn("connection sweeper: failed", "err", err)
+			} else if n > 0 {
+				logger.Info("connection sweeper: closed stale rows",
+					"count", n, "stale_after", stale)
+			}
+			select {
+			case <-r.baseCtx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
 }
 
 // startReconcilerWorker spawns (or no-ops) the per-user Anthropic

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -74,6 +74,69 @@ type Config struct {
 	// from transcript tokens) is always on and requires zero external
 	// calls.
 	CostReconciliation CostReconciliationConfig `json:"cost_reconciliation,omitempty"`
+
+	// ConnectionSweep controls the daemon_connections sweeper
+	// (🎯T60). Absent in config.json → defaults apply, sweeper
+	// enabled. Set {"connection_sweep": {"disabled": true}} to opt
+	// out (the open-row count will then grow unbounded as it did
+	// before — accepted only if some external mechanism reaps).
+	ConnectionSweep ConnectionSweepConfig `json:"connection_sweep,omitempty"`
+}
+
+// ConnectionSweepConfig controls how often the daemon checks for
+// stale daemon_connections rows and how long a row must be idle
+// before being marked closed. A zero-value ConnectionSweepConfig
+// (i.e. the section absent from config.json) means enabled, sweep
+// every minute, idle threshold 10 minutes.
+type ConnectionSweepConfig struct {
+	// Disabled opts out of the sweeper. Negated form so the zero
+	// value (absent section) means enabled.
+	Disabled bool `json:"disabled,omitempty"`
+
+	// Interval between sweep ticks. Format: a Go time.ParseDuration
+	// string. Empty → "1m".
+	Interval string `json:"interval,omitempty"`
+
+	// StaleAfter is the duration since last_seen_at after which a
+	// connection is considered stale and marked closed. Format: a
+	// Go time.ParseDuration string. Empty → "10m".
+	StaleAfter string `json:"stale_after,omitempty"`
+}
+
+// IsEnabled reports whether the sweeper should run. Defaults to true;
+// only an explicit `"disabled": true` opts out.
+func (c ConnectionSweepConfig) IsEnabled() bool { return !c.Disabled }
+
+// EffectiveInterval returns the parsed sweep interval, or 1 minute
+// when unset.
+func (c ConnectionSweepConfig) EffectiveInterval() (time.Duration, error) {
+	if c.Interval == "" {
+		return time.Minute, nil
+	}
+	d, err := time.ParseDuration(c.Interval)
+	if err != nil {
+		return 0, fmt.Errorf("interval: %w", err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("interval must be positive, got %v", d)
+	}
+	return d, nil
+}
+
+// EffectiveStaleAfter returns the parsed idle threshold, or 10 minutes
+// when unset.
+func (c ConnectionSweepConfig) EffectiveStaleAfter() (time.Duration, error) {
+	if c.StaleAfter == "" {
+		return 10 * time.Minute, nil
+	}
+	d, err := time.ParseDuration(c.StaleAfter)
+	if err != nil {
+		return 0, fmt.Errorf("stale_after: %w", err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("stale_after must be positive, got %v", d)
+	}
+	return d, nil
 }
 
 // CostReconciliationConfig gates the Anthropic Admin API reconciler.

--- a/internal/store/connections.go
+++ b/internal/store/connections.go
@@ -39,9 +39,9 @@ func (s *Store) RecordConnectionOpen(connectionID string, pid int, acceptedAt ti
 }
 
 // RecordConnectionClose marks a connection as closed. The HTTP MCP
-// transport does not expose a reliable disconnect signal, so this is
-// currently only called when the daemon shuts down or when a future
-// idle-timeout sweeper is added. Existing callers (tests) still work.
+// transport does not expose a reliable disconnect signal, so direct
+// callers are limited to daemon shutdown paths. The authoritative
+// reaper is the periodic sweeper in MarkStaleConnectionsClosed.
 func (s *Store) RecordConnectionClose(connectionID string, closedAt time.Time) {
 	s.rwmu.Lock()
 	defer s.rwmu.Unlock()
@@ -53,6 +53,31 @@ func (s *Store) RecordConnectionClose(connectionID string, closedAt time.Time) {
 	`, ts, ts, connectionID); err != nil {
 		slog.Warn("connection close update failed", "conn", connectionID, "err", err)
 	}
+}
+
+// MarkStaleConnectionsClosed marks open daemon_connections rows whose
+// last_seen_at falls outside threshold of now as closed. Returns the
+// number of rows updated. Idempotent: rows already closed, or with
+// last_seen_at still within threshold, are not touched. The
+// authoritative reaper for 🎯T60 — the HTTP MCP transport gives no
+// reliable disconnect signal, so a periodic sweep is the only way to
+// bound the open-connection count against crashes, kill -9, and
+// network drops.
+func (s *Store) MarkStaleConnectionsClosed(threshold time.Duration, now time.Time) (int, error) {
+	s.rwmu.Lock()
+	defer s.rwmu.Unlock()
+	cutoff := now.UTC().Add(-threshold).Format(time.RFC3339Nano)
+	nowTS := now.UTC().Format(time.RFC3339Nano)
+	res, err := s.db.Exec(`
+		UPDATE daemon_connections
+		SET closed_at = ?
+		WHERE closed_at IS NULL AND last_seen_at < ?
+	`, nowTS, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
 }
 
 // RecordConnectionSession upserts the (connection_id, session_id)

--- a/internal/store/connections_test.go
+++ b/internal/store/connections_test.go
@@ -56,6 +56,61 @@ func TestConnectionLifecycle(t *testing.T) {
 	}
 }
 
+// TestMarkStaleConnectionsClosed verifies the sweeper closes only
+// rows whose last_seen_at falls outside the threshold, leaves fresh
+// and already-closed rows alone, and is idempotent on a second pass.
+func TestMarkStaleConnectionsClosed(t *testing.T) {
+	s := newTestStore(t, t.TempDir())
+
+	t0 := time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC)
+	// Three open rows with varied last_seen_at, one already-closed row.
+	s.RecordConnectionOpen("stale", 1001, t0)                      // last_seen = t0
+	s.RecordConnectionOpen("fresh", 1002, t0.Add(20*time.Minute))  // last_seen = t0+20m
+	s.RecordConnectionOpen("border", 1003, t0.Add(15*time.Minute)) // last_seen = t0+15m (exactly threshold)
+	s.RecordConnectionOpen("closed", 1004, t0)                     // pre-closed below
+	s.RecordConnectionClose("closed", t0.Add(time.Minute))
+
+	now := t0.Add(25 * time.Minute) // threshold 10m → cutoff t0+15m
+	n, err := s.MarkStaleConnectionsClosed(10*time.Minute, now)
+	if err != nil {
+		t.Fatalf("MarkStaleConnectionsClosed: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 stale row closed, got %d", n)
+	}
+
+	open, err := s.OpenConnections()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(open) != 2 {
+		t.Fatalf("expected 2 open rows after sweep, got %d: %+v", len(open), open)
+	}
+	for _, c := range open {
+		if c.ConnectionID == "stale" {
+			t.Errorf("stale row should have been closed: %+v", c)
+		}
+	}
+
+	// Second pass: nothing should change.
+	n2, err := s.MarkStaleConnectionsClosed(10*time.Minute, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n2 != 0 {
+		t.Errorf("expected idempotent second pass, got %d rows updated", n2)
+	}
+
+	// Border row crosses the threshold once `now` advances enough.
+	n3, err := s.MarkStaleConnectionsClosed(10*time.Minute, t0.Add(26*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n3 != 1 {
+		t.Errorf("expected border row to close after now advances, got %d", n3)
+	}
+}
+
 // TestConnectionSessionBinding verifies the upsert semantics of
 // RecordConnectionSession: first-seen is preserved, last-seen is
 // bumped on repeat observations, and SessionsForConnection /


### PR DESCRIPTION
## Summary
- `Store.MarkStaleConnectionsClosed(threshold, now)` marks open `daemon_connections` rows whose `last_seen_at` falls outside the threshold as closed. Idempotent; rows already closed or within threshold are untouched.
- `ConnectionSweepConfig` (defaults: enabled, 1m interval, 10m idle threshold) wires the sweep into per-user worker bring-up in `internal/registry/registry.go`, alongside the existing CI poller, reconciler, and backup worker. Opt-out via `{"connection_sweep": {"disabled": true}}`.
- Replaces a no-op `RecordConnectionClose` that has zero non-test call sites — the HTTP MCP transport gives no reliable disconnect signal, so the periodic sweep is the authoritative reaper. This bounds the open-row count against daemon crashes, `kill -9`, and network drops.

The optional acceptance criterion — also hooking the HTTP-MCP server's connection-close lifecycle for faster reaping — is deferred. The sweeper alone satisfies the primary acceptance.

## Test plan
- [x] `go test -tags "sqlite_fts5" ./...` — full suite green
- [x] `TestMarkStaleConnectionsClosed` — stale row closed, fresh + border rows left open, already-closed row not re-touched, second pass idempotent, border row closes once `now` advances
- [ ] CI green on ubuntu + windows runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)