### PR TITLE
RFC: vault library wing redesign (v2 vault_path)

### DIFF
--- a/docs/design/vault-clustering.md
+++ b/docs/design/vault-clustering.md
@@ -1,6 +1,6 @@
 # Vault Clustering Engine
 
-*Status: design draft — 2026-05-20.*
+*Status: design draft — 2026-05-20 (rev 2026-05-22, review pass 1).*
 *Subordinate to `docs/design/vault-library-wing.md` (Slice 8).*
 *Prerequisite: Slice 7 (patterns persisted) must land first.*
 
@@ -11,11 +11,24 @@
 The library wing's most valuable abstractions — themes, cross-repo
 similarities, lessons — all rely on grouping content by topical
 similarity. This document specifies how that grouping is computed,
-stored, kept fresh, and rendered. Two engines are specified: a
-heuristic default that runs entirely locally, and an opt-in
-embeddings engine that calls a hosted provider. Per T63's egress
-posture (PR #92), the embeddings engine is **off by default** —
-users opt in explicitly, API key presence alone is not enough.
+stored, kept fresh, and rendered.
+
+**Two engines are specified.** Engine B (heuristic, TF-IDF +
+single-link agglomerative, fully local) is the **realistic default**
+that ships first and is on by default. Engine A (hosted-provider
+embeddings + single-link agglomerative) is **opt-in** per T63 egress
+posture; it swaps the TF-IDF vectorisation step for hosted-provider
+embeddings but reuses the rest of Engine B's pipeline. HDBSCAN is
+the algorithmically right choice for Engine A's downstream clustering
+but is **deferred**: no pure-Go HDBSCAN library currently meets the
+correctness bar, and porting one is non-trivial. Configuration keys
+for the HDBSCAN path are reserved (`vault_clustering.hdbscan.*`)
+and the swap can happen in a follow-up slice without breaking
+config. This keeps Slice 8 a *shippable* slice.
+
+Per T63's egress posture (PR #92), the embeddings engine is **off by
+default** — users opt in explicitly, API key presence alone is not
+enough.
 
 The engine treats four input sources as equal first-class signal:
 decision summaries, compaction span summaries, persisted patterns
@@ -41,8 +54,11 @@ text changed.
 2. **Default works fully offline.** The heuristic engine is the
    default and ships first. It produces serviceable themes for every
    user without any opt-in or external dependency. The embeddings
-   engine improves on it for users who opt in; the heuristic engine
-   is not a toy.
+   engine improves on it specifically by coalescing synonyms and
+   handling vocabulary drift better; downstream of vectorisation
+   both engines run the same single-link agglomerative clustering,
+   so the embeddings engine is *not* a wholesale algorithmic
+   upgrade. The heuristic engine is not a toy.
 3. **Bounded cost.** Single-digit cents per re-cluster for a
    median user. Order-of-magnitude predictable for any user.
 4. **User content as ground truth.** When `vault_indexing_scope`
@@ -124,6 +140,14 @@ as standalone documents.
 Weight: 1.5. User-authored content is the strongest available signal
 of human-meaningful structure and serves as anchor labels.
 
+**Two thresholds, on purpose.** Corpus admission for `vault_user`
+documents is `≥ 100` tokens (this filter). Label-anchor eligibility
+is `≥ 200` tokens (`vault_clustering.label.user_min_tokens`; see
+"Cluster labelling"). The two are deliberately different: a
+shorter note carries enough signal to *belong* to a cluster but
+not enough to *name* it. Both thresholds are configurable; they
+should be moved together if changed.
+
 ### Stream merge
 
 All four streams are merged into a `corpus` view at clustering time:
@@ -140,54 +164,179 @@ short-project-name form already used in v1.
 
 ## Outbound API posture
 
-The embeddings engine makes outbound HTTP calls to a hosted embedding
-provider (Voyage AI, OpenAI, etc.). Per the precedent set by **T63
-(PR #92, cost reconciliation opt-in)**, every mnemo feature that
-performs unsolicited outbound traffic to hosted APIs defaults **off**
-and requires explicit opt-in via config — even when the relevant API
-key is present in the environment for other reasons.
+The clustering pipeline has **two independent egress surfaces** to a
+hosted API, each governed by its own opt-in per T63 (PR #92, cost
+reconciliation precedent):
 
-This rule applies to the embeddings engine. Specifically:
+1. **Embeddings.** Compute float vectors via a hosted embedding
+   provider (Voyage AI, etc.). Required for Engine A; not used by
+   Engine B.
+2. **LLM labelling.** Generate human-readable cluster labels via
+   Claude Haiku 4.5. Optional in both engines; falls back to the
+   bigram heuristic when off.
 
-- `vault_clustering.engine` defaults to `"heuristic"`. The heuristic
-  engine has no network dependencies.
-- A user opts into the embeddings engine by writing
-  `vault_clustering.engine: "embeddings"` (live via `mnemo_config`
-  or by editing `~/.mnemo/config.json`). Mere presence of a Voyage
-  API key in the environment is not enough.
-- If the user sets `engine: "embeddings"` but no provider key is
-  configured, the daemon logs a warning, falls back to the heuristic
-  engine for that pass, and reports the degraded state via
-  `mnemo_vault_status`.
-- The opt-in posture is documented in CLAUDE.md alongside the
-  other egress features (GitHub backfill, federation, cost
-  reconciliation) when this slice ships.
+A user can opt into either, both, or neither. The matrix:
 
-This deliberately gives a worse default to new users than the
-embeddings engine would. Justification: the heuristic engine is
-explicitly designed to be non-toy (see Engine B below); the user can
-opt in to better quality with a one-line config change; respecting
-egress posture matters more than maximising default theme quality.
+| Embeddings | Labelling | Behaviour                                          |
+|------------|-----------|----------------------------------------------------|
+| off        | off       | Engine B end-to-end, bigram labels. No external calls. |
+| off        | on        | Engine B clustering, LLM labelling for cluster names. One outbound surface. |
+| on         | off       | Engine A clustering with Voyage embeddings, bigram labels. One outbound surface. |
+| on         | on        | Engine A + LLM labels. Two outbound surfaces.       |
+
+Each surface defaults off and requires its own explicit
+configuration:
+
+- **Embeddings opt-in.** `vault_clustering.engine: "embeddings"`
+  (default `"heuristic"`). Mere presence of a Voyage API key in
+  the environment is not enough.
+- **Labelling opt-in.** `vault_clustering.label.engine: "llm"`
+  (default `"bigram"`). Mere presence of an Anthropic API key is
+  not enough.
+
+If a user sets either to on but the corresponding API key is
+absent, the daemon logs a warning, falls back to the off behaviour
+for that pass, and reports the degraded state in
+`mnemo_vault_status.warnings[]`. The pass does not block.
+
+The CLAUDE.md egress section lists both surfaces alongside GitHub
+backfill, federation, and cost reconciliation when this slice
+ships.
+
+The defaults are deliberately worse than what hosted APIs could
+offer. Justification: the heuristic engine + bigram labelling is
+explicitly designed to be non-toy (see Engine B); a one-line
+config change is the user's deliberate ask; respecting egress
+posture matters more than maximising default theme quality.
 
 ## Engine A — embeddings (opt-in)
+
+### Status
+
+Engine A is **opt-in** (per T63 egress posture) and **partially
+aspirational**. The provider interface, embedding cache, model-version
+pinning, and labelling pipeline are committed. The HDBSCAN
+sub-component is not — see "Cluster algorithm" below for the
+shipped-as-of-Slice-8 behaviour and the deferred HDBSCAN follow-up.
 
 ### Vectorisation
 
 For each `corpus` row, compute a 1024-dimensional embedding via the
-configured provider. Default provider: Voyage AI `voyage-3-lite`
-(cheap, multilingual, 1024d output). Alternative: OpenAI
-`text-embedding-3-small` (1536d, truncated to 1024 via PCA). Provider
-chosen by `vault_clustering.embedding_provider`; falls back to
-heuristic engine if no key is set.
+configured provider.
+
+The provider interface is **provider-agnostic from day one**, even
+though Voyage AI is the only concrete provider that ships with Slice
+8. The interface lives in `internal/cluster/embedding_provider.go`:
+
+```go
+type EmbeddingProvider interface {
+    // Name returned in cluster_embeddings.provider.
+    Name() string
+    // Model returned in cluster_embeddings.model.
+    Model() string
+    // ModelVersion returned in cluster_embeddings.model_version.
+    // Empty string if the provider does not version models
+    // (callers should treat the empty value as a stable tag).
+    ModelVersion() string
+    // Dimensions returned in cluster_embeddings.dimensions.
+    Dimensions() int
+    // Embed produces dense float32 vectors for each input string.
+    Embed(ctx context.Context, texts []string) ([][]float32, error)
+}
+```
+
+Concrete provider for Slice 8: `internal/cluster/voyage.go`
+implementing `EmbeddingProvider` against Voyage AI's
+`voyage-3-lite`. The provider is selected by
+`vault_clustering.embedding_provider` (default `"voyage"`). OpenAI,
+Cohere, local embedding servers, etc. are out of scope for Slice 8
+but cost nothing to support later because the interface already
+admits them.
+
+Per the egress posture, the embeddings engine falls back to the
+heuristic engine when:
+- `vault_clustering.engine` is not `"embeddings"`, or
+- `vault_clustering.engine` is `"embeddings"` but the configured
+  provider returns an auth error / has no API key.
 
 Embeddings cached in a new `cluster_embeddings` table keyed by
-`(kind, entity_id, content_hash)`. Recompute only when the
-`content_hash` changes. Median user has on the order of 10³ docs;
-re-embedding cost is single-digit cents at provider rates.
+`(doc_kind, entity_id, content_hash, provider, model, model_version)`.
+Recompute only when any of those change. Median user has on the
+order of 10³ docs; re-embedding cost is single-digit cents at
+provider rates.
+
+#### Model-version pinning and drift
+
+A user who switches from `voyage-3-lite` to `voyage-3`, or whose
+provider versions a model in place, must not silently corrupt the
+existing cluster set. The cache key includes `provider`, `model`,
+and `model_version` precisely so:
+
+- Switching models leaves the old embeddings in the cache,
+  available if the user reverts.
+- The next clustering pass after a switch fully re-embeds the
+  corpus under the new (provider, model, model_version) — these
+  rows are absent from the cache, so the pipeline regenerates them.
+- Cluster IDs are derived from `sha1(sorted member set)`; the
+  member-set is determined by the embeddings the active model
+  produces. A model swap that re-segments the corpus produces new
+  cluster IDs, and `_mnemo/themes/<slug>.md` paths churn
+  accordingly. This is the **right** behaviour: a different
+  embedding space is a different clustering, and pretending
+  otherwise would silently corrupt cluster identity. The user is
+  warned via `mnemo_vault_status` immediately after the swap and
+  before the next pass runs.
+- `mnemo_vault_themes_inspect` surfaces the model fingerprint the
+  current theme was clustered under, so a user can distinguish
+  "this theme is from before the model swap" from "this theme is
+  from after."
+- A `mnemo_vault_recluster(force_reembed: true)` parameter lets a
+  user force a clean re-embed even when content has not changed —
+  useful when the provider has silently revised a model under the
+  same version string.
 
 ### Cluster algorithm
 
-HDBSCAN over the embedding matrix. Parameters:
+#### Shipped behaviour (Slice 8 MVP)
+
+Embeddings (replace TF-IDF vectorisation) → cosine similarity →
+single-link agglomerative clustering. The label-quality gates and
+ID-derivation rules below all apply. This delivers ~80% of
+embeddings' value (synonym coalescing, broader topical association)
+without requiring an HDBSCAN library.
+
+**Threshold tuning per engine.** The single-link threshold is the
+same shape (`similarity ≥ X`) for both engines, but the *value*
+behaves differently because the underlying vector spaces differ:
+TF-IDF cosines vs. dense-embedding cosines have different
+distributions. Engine A reads its threshold from
+`vault_clustering.embedding_threshold` (default `0.55`, looser than
+Engine B's `0.35` because embeddings produce higher pairwise
+cosines on related text). Engine B continues to use
+`vault_clustering.heuristic_threshold`. The two are independent
+config keys — tuning one does not affect the other — and both are
+listed in the config keys table.
+
+#### Deferred — HDBSCAN follow-up
+
+HDBSCAN is the algorithmically right choice for unknown-cluster-
+count, noise-tolerant clustering and was the original Engine A
+spec. Reality check:
+
+- No pure-Go HDBSCAN library currently meets the schema/test bar
+  (idiomatic Go, stable API, MIT/BSD/Apache, actively maintained,
+  matches the reference scikit-learn behaviour on golden corpora).
+- Porting one from scratch is non-trivial correctness risk; agent
+  assistance helps with mechanical translation but does not
+  eliminate the correctness risk of reimplementing density-based
+  clustering.
+- The slice ships shippably with single-link, not with an
+  in-development HDBSCAN port.
+
+When a HDBSCAN binding becomes available (or the port is
+green-lit as its own slice), Engine A swaps `agglomerative` for
+`hdbscan` behind the same interface. Configuration shape ready
+for that day:
 
 | Parameter              | Default | Rationale                                    |
 |------------------------|---------|----------------------------------------------|
@@ -196,7 +345,12 @@ HDBSCAN over the embedding matrix. Parameters:
 | `cluster_selection_epsilon` | 0.0 | strict — prefer many small clusters over megaclusters |
 | `metric`               | cosine  | standard for text embeddings                 |
 
-HDBSCAN chosen over k-means because:
+These are documented under `vault_clustering.hdbscan.*` and ignored
+by the running daemon until the HDBSCAN path is wired up. The keys
+are reserved so users can write them today without warnings.
+
+HDBSCAN's properties when it lands:
+
 - No fixed cluster count assumption (the corpus has unknown topic
   count).
 - Tolerates noise points (decisions/spans that don't belong in any
@@ -209,23 +363,73 @@ HDBSCAN chosen over k-means because:
 Within each cluster, identify representative documents by inverse
 distance to cluster centroid. Take the top-5.
 
-Then:
+Then, in priority order:
 
-1. **If the cluster contains at least one `vault_user` document**
-   (scope `"full"` or `"includes"` enabled, user wrote a thematic
-   note that landed in this cluster), use the user document's title
-   as the cluster label. This is the ground-truth path: the user
-   wrote "Auth middleware redesign" once and now owns that label.
+1. **User-anchored label, if a qualifying `vault_user` document is
+   present** (scope `"full"` or `"includes"` enabled, user wrote a
+   note that landed in this cluster). Naively picking any
+   `vault_user` member produces broken labels — a journal entry
+   titled `2026-05-12` or a stub note titled `Inbox` can outweigh
+   the rest of the cluster's content. To prevent that, the
+   user-anchor path applies **all** of these quality gates before
+   accepting the title:
 
-2. **Otherwise**, generate a label via Claude Haiku 4.5 with the
-   prompt: "These are excerpts grouped by topical similarity. Label
-   the topic in ≤6 words, all lowercase, no punctuation:" followed
-   by the top-5 representative excerpts. Cap at 6 words, lowercase,
-   kebab-case for slug derivation.
+   - **Centroid-closeness.** The candidate must be the
+     centroid-closest `vault_user` member of the cluster (smallest
+     embedding distance / largest TF-IDF similarity, depending on
+     engine). Any `vault_user` is not enough — only the one closest
+     to the cluster's centre.
+   - **Minimum body content.** The note must have **≥ 200 tokens** of
+     body content excluding frontmatter, code fences, and the title
+     line. Stub notes and dailies routinely have one-line bodies; this
+     filters them out. Threshold configurable via
+     `vault_clustering.label.user_min_tokens`.
+   - **Filename pattern exclusion.** Daily-note filenames are
+     excluded regardless of content length. The default exclusion
+     regex set (`vault_clustering.label.user_filename_exclude`) is:
+     ```
+     ^\d{4}-\d{2}-\d{2}(\.md)?$        # YYYY-MM-DD
+     ^\d{4}_\d{2}_\d{2}(\.md)?$        # YYYY_MM_DD
+     ^\d{4}\.\d{2}\.\d{2}(\.md)?$      # YYYY.MM.DD
+     ^(daily|journal|journals|inbox|scratch|todo|untitled)(\.md)?$
+     ```
+     Plus any path under `daily/`, `journals/`, `inbox/`, `scratch/`.
+     User overrideable.
+   - **Title-content coherence.** The candidate's title must share
+     at least one non-stopword token with the cluster centroid text
+     (after stemming). A note titled "Random thoughts" whose body
+     happens to mention auth middleware tangentially is not an
+     anchor for the auth-middleware cluster.
 
-3. **If LLM labelling fails** (no API key, rate limit, etc.), fall
-   back to the most-frequent non-stopword bigram across the cluster's
-   top-5 excerpts. Crude but deterministic.
+   If no `vault_user` member passes all four gates, the user-anchor
+   path is skipped and labelling falls through to step 2. The cluster
+   members that *failed* the gates remain in the cluster — they
+   just do not contribute the label.
+
+2. **LLM-generated label.** Generate a label via Claude Haiku 4.5
+   with the prompt: "These are excerpts grouped by topical
+   similarity. Label the topic in ≤6 words, all lowercase, no
+   punctuation:" followed by the top-5 representative excerpts. Cap
+   at 6 words, lowercase, kebab-case for slug derivation. **Opt-in
+   per T63 egress posture** — gated on
+   `vault_clustering.label.engine: "llm"` (default `"bigram"`).
+   Mere presence of an Anthropic API key is not enough; a user who
+   has not opted in stays on the bigram path even with a key
+   available. Disabled-but-asked-for (no key, rate-limited,
+   provider error) falls through to step 3 and reports the
+   degraded state via `mnemo_vault_status.warnings[]`.
+
+3. **Bigram fallback.** Most-frequent non-stopword bigram across the
+   cluster's top-5 excerpts. Crude but deterministic. Used when LLM
+   labelling is disabled or fails.
+
+The `mnemo_vault_themes_inspect` tool reports which of the three
+paths produced the label, including the gate that fired when an
+expected user-anchor was rejected. A user who sees a cluster
+labelled "various topics" instead of their note title can immediately
+see why ("daily-note pattern matched", "below 200-token minimum",
+"title shared no tokens with centroid") and respond — either by
+renaming the note, beefing it up, or relaxing a gate via config.
 
 ### Stability
 
@@ -237,11 +441,26 @@ which is the right semantic (a different set is a different theme).
 Renamed themes (same membership, new label) retain the same ID, so
 `_mnemo/themes/<slug>.md` paths churn only when membership churns.
 
+**Stability is scoped to an embedding fingerprint, not absolute.**
+The ID derivation is stable across runs *within* a fixed
+(provider, model, model_version) fingerprint. A model swap (or a
+provider-side silent revision; see Mode 7) re-segments the corpus
+and produces a fresh set of cluster IDs. This is intentional — a
+different embedding space defines different clusters — and the
+churn is warned about via `mnemo_vault_status` before the next
+pass commits. The heuristic engine's stability is absolute (no
+external fingerprint), modulo IDF recomputation, which is
+deterministic for a given corpus.
+
 ---
 
 ## Engine B — heuristic (default)
 
-Same input streams. No embeddings. No LLM labelling.
+Same input streams. No embeddings required. Labelling chain (Engine
+B uses the same chain as Engine A — see "Cluster labelling" above):
+user-anchored → optional LLM → bigram. LLM labelling is
+independently opt-in via `vault_clustering.label.engine`; when off,
+Engine B runs fully offline.
 
 ### Document representation
 
@@ -263,10 +482,18 @@ Single-link agglomerative clustering with threshold `similarity ≥ 0.35`
 (tuneable via `vault_clustering.heuristic_threshold`). Stop when no
 pair exceeds the threshold.
 
-This produces fewer, broader clusters than HDBSCAN — acceptable for
-the fallback. Documented limitation.
+This produces fewer, broader clusters than HDBSCAN would. Acceptable
+for the **default** engine — most users land here and the broader
+clusters are easier to scan in the wing than dense fine-grained
+ones. The post-pass `merge_threshold` second pass (Mode 1
+mitigation) keeps near-duplicates from sprawling.
 
 ### Labelling
+
+The unified labelling chain (see "Engine A → Cluster labelling")
+applies to both engines: user-anchored → optional LLM → bigram. The
+bigram path used by Engine B by default (since LLM labelling
+defaults off) is:
 
 Most-frequent non-stopword bigram across the cluster's documents,
 weighted by document weight. Capitalise as title case for the page
@@ -288,6 +515,28 @@ token.
 - Domain drift. A repo with heavy jargon dominates corpus IDF and
   warps clusters. Embeddings are more robust.
 - Label quality. Bigrams are choppier than LLM labels.
+
+#### Mitigation for domain drift
+
+The heuristic engine applies two corrections before the
+single-link pass to limit one-repo IDF dominance:
+
+1. **Per-repo IDF cap.** IDF for a token is computed corpus-wide
+   but clamped to `max(idf(token), p95(idf))` so a single repo's
+   esoteric vocabulary cannot push tokens to the extremes of the
+   IDF distribution. The clamp value is recomputed each pass.
+2. **Per-repo document quota.** When the corpus is heavily
+   imbalanced (one repo contributes >50% of documents), down-sample
+   the dominant repo to 2× the second-largest repo's contribution
+   before TF-IDF vectorisation. Down-sampling is stratified by
+   doc_kind (decision/compaction/pattern) so each stream survives
+   proportionally. Down-sample is configurable via
+   `vault_clustering.heuristic.balance_factor` (default 2.0;
+   `0` disables).
+
+Both corrections are run only by the heuristic engine. The
+embeddings engine is robust to vocabulary imbalance by
+construction and does not need them.
 
 ---
 
@@ -330,28 +579,86 @@ CREATE TABLE cluster_embeddings (
   doc_kind        TEXT NOT NULL,
   entity_id       TEXT NOT NULL,
   content_hash    TEXT NOT NULL,
-  provider        TEXT NOT NULL,
-  vector          BLOB NOT NULL,               -- float32 packed
+  provider        TEXT NOT NULL,                 -- e.g. "voyage"
+  model           TEXT NOT NULL,                 -- e.g. "voyage-3-lite"
+  model_version   TEXT NOT NULL DEFAULT '',      -- provider-reported version tag; '' if unversioned
+  dimensions      INTEGER NOT NULL,              -- vector length, sanity-check on read
+  vector          BLOB NOT NULL,                 -- float32 packed
   computed_at     TEXT NOT NULL,
-  PRIMARY KEY (doc_kind, entity_id, content_hash)
+  PRIMARY KEY (doc_kind, entity_id, content_hash, provider, model, model_version)
 );
+
+CREATE INDEX cluster_embeddings_by_fingerprint
+  ON cluster_embeddings (provider, model, model_version);
 
 CREATE VIRTUAL TABLE themes_fts USING fts5(
   label, slug, centroid_text,
   content='themes', content_rowid='rowid'
 );
+
+CREATE TABLE cluster_runs (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  started_at      TEXT NOT NULL,
+  ended_at        TEXT,                          -- NULL while running
+  engine          TEXT NOT NULL,                 -- "embeddings" | "heuristic"
+  provider        TEXT NOT NULL DEFAULT '',      -- empty for heuristic
+  model           TEXT NOT NULL DEFAULT '',
+  model_version   TEXT NOT NULL DEFAULT '',
+  input_docs      INTEGER NOT NULL DEFAULT 0,
+  output_themes   INTEGER NOT NULL DEFAULT 0,
+  embedding_calls INTEGER NOT NULL DEFAULT 0,
+  estimated_cost  REAL NOT NULL DEFAULT 0,       -- USD; NULL-ish 0 for heuristic
+  failure_mode    TEXT NOT NULL DEFAULT '',      -- empty on success
+  trigger         TEXT NOT NULL,                 -- "interval" | "manual" | "opportunistic"
+  embeddings_bytes INTEGER NOT NULL DEFAULT 0,   -- cumulative size of cluster_embeddings.vector at pass end
+  embeddings_rows  INTEGER NOT NULL DEFAULT 0    -- cumulative row count of cluster_embeddings at pass end
+);
+
+CREATE INDEX cluster_runs_by_started ON cluster_runs (started_at DESC);
+
+CREATE TABLE theme_overrides (
+  theme_id        TEXT PRIMARY KEY,              -- target theme
+  directive       TEXT NOT NULL,                 -- "split" | "merge" | "relabel"
+  payload         TEXT NOT NULL,                 -- JSON; shape depends on directive
+  created_at      TEXT NOT NULL,
+  applied_at      TEXT                           -- NULL until next pass consumes
+);
+
+CREATE TABLE theme_pins (
+  theme_id        TEXT PRIMARY KEY,              -- never auto-retired while pinned
+  pinned_at       TEXT NOT NULL,
+  reason          TEXT NOT NULL DEFAULT ''
+);
 ```
 
-All four are append-only (no destructive drops, no constraint
+All seven are append-only (no destructive drops, no constraint
 tightening). `themes` and `theme_members` are rewritten in full each
 clustering pass; `cluster_embeddings` accumulates and is GC'd by a
-separate pass when the underlying entity disappears.
+separate pass when the underlying entity disappears. `cluster_runs`
+grows unbounded by design (telemetry log) and is trimmed by a
+background sweep when its row count exceeds `max_run_history`
+(default 1000). `theme_overrides` rows are marked `applied_at` rather
+than deleted, so the directive history survives. `theme_pins` rows
+live until the user removes them.
+
+**Vector encoding.** `cluster_embeddings.vector` is the float32
+sequence in **little-endian IEEE 754**, contiguous, length =
+`dimensions × 4` bytes. The encoding is fixed regardless of host
+architecture so a daemon migrated between archs (or a backup
+restored on a different arch) reads vectors correctly. Sanity check
+on read: reject any row whose `length(vector) != dimensions * 4`.
 
 ### Renderer
 
 `internal/vault/themes.go` (new) emits one Markdown file per row in
-`themes` where `weight ≥ vault_clustering.min_cluster_weight`. Page
-shape per the parent design:
+`themes` where `weight ≥ vault_clustering.min_cluster_weight`. The
+renderer hooks into the existing periodic vault sync loop
+(`Exporter.Sync` in v1, retained under `vault_layout="v2"` with
+session/CI/PR writers removed per Slice 4). Page shape per the
+parent design — note the embedded template depends on a small set
+of template helpers registered by the renderer (`date`, `toJSON`,
+`now`); they are documented in `internal/vault/README.md` next to
+the probe-entity contract:
 
 ```markdown
 ---
@@ -362,6 +669,8 @@ weight: {{ .Weight }}
 first-seen: {{ .FirstSeen | date "2006-01-02" }}
 last-touched: {{ .LastTouched | date "2006-01-02" }}
 repos: {{ .Repos | toJSON }}
+label-source: {{ .LabelSource }}             {{/* "vault_user" | "llm" | "bigram" */}}
+embedding_fingerprint: {{ .EmbeddingFingerprint | toJSON }}  {{/* null on heuristic */}}
 ---
 
 # {{ .Label }}
@@ -379,8 +688,12 @@ repos: {{ .Repos | toJSON }}
 ## Related
 {{ range .RelatedThemes }}- [[_mnemo/themes/{{ .Slug }}|{{ .Label }}]]
 {{ end }}
+{{/* Per Q3: pattern members are also surfaced as Related links to their
+     standalone pages, not just as members. They appear in both places. */}}
+{{ range .RelatedPatterns }}- [[_mnemo/patterns/{{ .Slug }}|{{ .Label }}]]
+{{ end }}
 
-## Underlying entities
+## {{ .ProvenanceHeading }}  {{/* "Underlying decisions" | "Underlying entities" — see parent design's per-entity heading table */}}
 {{ range .Members }}- {{ .Kind }} · {{ .Repo }} · {{ .EntityID }}
 {{ end }}
 
@@ -388,6 +701,12 @@ repos: {{ .Repos | toJSON }}
 
 <!-- Your notes below this line — preserved across syncs. -->
 ```
+
+The `ProvenanceHeading` field is computed by the renderer per the
+parent design's per-entity heading table — for a theme whose
+members are exclusively decisions/compactions it is "Underlying
+decisions"; for a mixed-kind theme it is "Underlying entities".
+Custom templates can override.
 
 ### Cross-repo derivation
 
@@ -397,6 +716,32 @@ addition to the theme page. The cross-repo page renders the same
 theme through a different lens: groups evidence by repo, surfaces
 which-repos-first metadata, and is the page bridged into multi-repo
 MOCs.
+
+#### Threshold worked examples
+
+Stream weights (from the Inputs section): decisions 1.0,
+compactions 0.8, patterns 1.2, vault_user 1.5. Per-doc cap is 2.0
+(see Mode 5). Threshold check: theme `weight ≥ 4.0` AND `len(repos)
+≥ 2`.
+
+| Cluster shape (member kinds × repos)                         | Sum of weights | Cross-repo page? |
+|---------------------------------------------------------------|----------------|-------------------|
+| 2 decisions in 1 repo + 1 decision in another                | 3.0            | no (below 4.0)    |
+| 3 decisions × 2 repos + 1 pattern                            | 4.2            | yes               |
+| 1 decision + 2 compactions × 2 repos                         | 2.6            | no                |
+| 4 decisions × 3 repos                                         | 4.0            | yes (boundary)    |
+| 1 user note + 2 decisions × 2 repos                          | 3.5            | no                |
+| 1 user note + 3 decisions × 2 repos                          | 4.5            | yes               |
+
+Reading: low-member clusters spanning only 2 repos do not become
+cross-repo views even if they are technically multi-repo —
+intentional, to avoid every casual mention becoming a page. A
+single user-authored note (weight 1.5) gives a meaningful boost
+toward the threshold; one note plus ~2.5 of other signal crosses
+it. The threshold is tunable via `vault_clustering.min_cluster_weight`
+and a future
+`vault_clustering.cross_repo_weight_threshold` (not in Slice 8;
+listed here for the reviewer's mental model).
 
 No separate `cross_repos` table — cross-repo pages are a derived
 view over `themes`.
@@ -412,8 +757,23 @@ design).
 
 Background goroutine inside `vault.Exporter` (or a sibling
 `vault.Clusterer`) ticks at the interval and runs a full clustering
-pass. Pass duration for a median user is on the order of seconds; for
-heavy users it should remain under one minute.
+pass. Pass duration for a median user:
+
+- **Heuristic engine.** Sub-second for 10³ documents; the
+  bottleneck is TF-IDF recomputation, not clustering itself. For
+  heavy users (10⁴+ documents) the pass remains under ~10 seconds.
+- **Embeddings engine, warm cache.** Sub-second — cache hit on
+  every document; the network round-trip is skipped entirely.
+- **Embeddings engine, cold cache (full re-embed).** Bounded by
+  provider RTT × batch count. With Voyage AI's batch endpoint
+  (128 docs per request), a 10³-doc corpus is one batch round-trip
+  — typically under 10 seconds end-to-end. A 10⁴ corpus is on the
+  order of one minute.
+
+Heavy users with a full re-embed running over the interval is the
+worst case (network-bound, not compute-bound); the
+`opportunistic_threshold` trigger plus the `force_reembed` MCP
+parameter let the user shape this trade-off explicitly.
 
 ### Worker lifecycle
 
@@ -427,16 +787,39 @@ The clustering worker follows the **T61 backup worker pattern**
   daemon boot for the default user, not lazily on first MCP call.
   A passive daemon with no Claude session attached still re-clusters
   on schedule.
-- Hot-reload via `mnemo_config`: changes to `vault_clustering.engine`,
-  `recompute_interval`, or `min_cluster_weight` stop the existing
-  goroutine and restart with the new settings. Per-user `clusterCancel`
-  tracked on the `userEntry` struct alongside `vaultCancel` and
-  `reconcilerCancel`.
+- Hot-reload via `mnemo_config`: **any** change to a
+  `vault_clustering.*` key stops the existing goroutine and
+  restarts with the new settings. The restart is cheap (no
+  re-embedding unless `embedding_provider` / `embedding_model` /
+  `embedding_model_version` changed, in which case Mode 7's
+  warn-then-regenerate flow kicks in on the next pass). Per-user
+  `clusterCancel` tracked on the `userEntry` struct alongside
+  `vaultCancel` and `reconcilerCancel`. Generalising over
+  "any `vault_clustering.*`" — rather than enumerating keys —
+  means new keys added in follow-up slices inherit hot-reload
+  automatically without touching the worker.
 - Quiescence not required (clustering reads only, does not write to
   contended tables in the hot ingest path). Unlike the backup worker
   it can run at any time.
-- Misconfiguration (bad interval, unknown engine) logs a warn and
-  skips the worker. Daemon never blocks on cluster setup failures.
+- Misconfiguration logs a warn and skips the worker (daemon never
+  blocks on cluster setup failures). Specifically:
+  - `recompute_interval`: must parse via Go's `time.ParseDuration`
+    AND be ≥ `"60s"`. Smaller values are clamped up to `"60s"`
+    with a warning; unparseable values fall back to the default
+    `"24h"` with a warning.
+  - `engine`: must be one of `"heuristic"`, `"embeddings"`.
+    Anything else falls back to `"heuristic"` with a warning.
+  - `embedding_provider`: must be a registered provider name.
+    Unknown providers fall back to disabling the embeddings engine
+    (heuristic runs) with a warning.
+  - Numeric thresholds (`min_cluster_weight`, `heuristic_threshold`,
+    `embedding_threshold`, `merge_threshold`, `per_doc_weight_cap`):
+    must be in their plausible ranges (positive; thresholds in
+    `[0, 1]`). Out-of-range values fall back to defaults with a
+    warning.
+  Every misconfiguration warning is also surfaced in
+  `mnemo_vault_status.warnings[]` so the user can see why their
+  configured value did not take effect.
 
 ### Triggered by
 
@@ -447,24 +830,47 @@ The clustering worker follows the **T61 backup worker pattern**
 
 ### Concurrency
 
-Clustering and vault sync share the existing `syncMu` discipline from
-v1: a cluster pass takes a separate `clusterMu`, periodic syncs run
-during/around it without conflict. The renderer reads cluster output
-via a snapshot taken under `clusterMu`, so a sync writing themes
-sees a consistent view.
+Two layers of discipline, working together:
+
+- **In-database snapshot.** Clustering and vault sync share the
+  existing `syncMu` discipline from v1: a cluster pass takes a
+  separate `clusterMu`, periodic syncs run during/around it
+  without conflict. The renderer reads cluster output via a
+  snapshot taken under `clusterMu`, so a sync writing themes sees
+  a consistent view.
+- **On-disk atomicity.** The theme / cross-repo renderer writes
+  every output file using the parent design's atomic-write protocol
+  (`.<name>.mnemo.tmp` sibling + `fsync` + `rename`; see
+  "Operational invariants → Sync atomicity" in
+  `docs/design/vault-library-wing.md`). A clustering pass that
+  produces N theme pages results in N atomic renames; if the
+  daemon crashes mid-pass, the user sees a mix of (old, new) full
+  files but never a torn file. The `_archive/` move for retirements
+  is the same `rename(2)` discipline (also atomic on the same
+  filesystem) — partial retirement is impossible from a crash mid-
+  pass.
 
 ### Cost telemetry
 
-Each pass records to a new `cluster_runs` table:
-- start/end timestamps
-- engine used
-- input doc count
-- output theme count
-- embedding API calls and approximate cost
-- failure mode if any
+Each pass records to the `cluster_runs` table (full DDL in the
+"Output → Tables" section above). Captured fields:
 
-Surfaced via `mnemo_vault_status` and queryable directly. Lets a
-user spot cost outliers without enabling DEBUG logging.
+- `started_at` / `ended_at`
+- `engine` (`"embeddings"` or `"heuristic"`)
+- `provider`, `model`, `model_version` (embeddings runs; empty for heuristic)
+- `input_docs` — corpus size at pass start
+- `output_themes` — emitted themes (capped by `max_themes` if applicable)
+- `embedding_calls`, `estimated_cost` (USD; zero for heuristic)
+- `failure_mode` — empty on success; specific codes on
+  graceful-degrade paths (`embedding_provider_outage_fell_back_to_heuristic`,
+  `embedding_provider_outage_no_fallback`, etc.)
+- `trigger` (`"interval"` / `"manual"` / `"opportunistic"`)
+- `embeddings_bytes`, `embeddings_rows` — `cluster_embeddings`
+  table footprint at pass end, for backup-size monitoring
+
+Surfaced via `mnemo_vault_status.last_cluster_run` and queryable
+directly. Lets a user spot cost outliers and snapshot-size growth
+without enabling DEBUG logging.
 
 ---
 
@@ -477,11 +883,28 @@ user spot cost outliers without enabling DEBUG logging.
   "vault_clustering": {
     "engine": "heuristic",
     "embedding_provider": "voyage",
+    "embedding_model": "voyage-3-lite",
+    "embedding_model_version": "",
     "min_cluster_weight": 3,
     "recompute_interval": "24h",
     "heuristic_threshold": 0.35,
+    "embedding_threshold": 0.55,
     "max_themes": 200,
-    "max_cross_repo": 50
+    "max_cross_repo": 50,
+    "retire_after": "4320h",
+    "max_run_history": 1000,
+    "label": {
+      "engine": "bigram",
+      "user_min_tokens": 200,
+      "user_filename_exclude": []
+    },
+    "hdbscan": {
+      "enabled": false,
+      "min_cluster_size": 3,
+      "min_samples": 2,
+      "cluster_selection_epsilon": 0.0,
+      "metric": "cosine"
+    }
   }
 }
 ```
@@ -490,11 +913,26 @@ user spot cost outliers without enabling DEBUG logging.
 |------------------------------------|--------------|-------------|
 | `vault_clustering.engine`          | `"heuristic"` (explicit opt-in to `"embeddings"`) | yes |
 | `vault_clustering.embedding_provider` | `"voyage"` | yes         |
+| `vault_clustering.embedding_model` | `"voyage-3-lite"` | yes      |
+| `vault_clustering.embedding_model_version` | `""` (provider-reported; user override forces a specific version for reproducibility) | yes |
 | `vault_clustering.min_cluster_weight` | `3`       | yes         |
 | `vault_clustering.recompute_interval` | `"24h"`   | yes         |
-| `vault_clustering.heuristic_threshold` | `0.35`   | yes         |
+| `vault_clustering.heuristic_threshold` | `0.35` (TF-IDF cosine) | yes |
+| `vault_clustering.embedding_threshold` | `0.55` (embeddings cosine) | yes |
 | `vault_clustering.max_themes`      | `200`        | yes         |
 | `vault_clustering.max_cross_repo`  | `50`         | yes         |
+| `vault_clustering.retire_after`    | `"4320h"` (180 days) | yes  |
+| `vault_clustering.max_run_history` | `1000`       | yes         |
+| `vault_clustering.label.engine`    | `"bigram"` (explicit opt-in to `"llm"`, per T63 egress posture) | yes |
+| `vault_clustering.label.user_min_tokens` | `200`  | yes         |
+| `vault_clustering.label.user_filename_exclude` | `[]` (extends defaults) | yes |
+| `vault_clustering.hdbscan.enabled` | `false` (reserved; ignored until HDBSCAN ships) | yes |
+| `vault_clustering.per_doc_weight_cap` | `2.0`     | yes         |
+| `vault_clustering.merge_threshold` | `0.9` (post-pass theme-similarity merge; set to `1.0` to disable) | yes |
+| `vault_clustering.opportunistic_threshold` | `50` (re-cluster outside timer once N new high-signal entities accumulate) | yes |
+| `vault_clustering.embedding_retry_max` | `3`      | yes         |
+| `vault_clustering.fallback_to_heuristic_on_outage` | `true` | yes |
+| `vault_clustering.heuristic.balance_factor` | `2.0` (per-repo document quota; `0` disables) | yes |
 
 `max_themes` caps page emission to prevent a vault explosion when
 clustering accidentally produces 5000 micro-clusters. Themes ranked
@@ -503,20 +941,38 @@ by weight; excess kept in the table but not rendered.
 ### MCP tools
 
 - **`mnemo_vault_recluster`** — trigger an immediate clustering pass.
-  Returns the run report from `cluster_runs`. Parameters: `engine`
-  optional override.
+  Returns the new `cluster_runs` row. Parameters:
+  - `engine`: optional override (`"heuristic"` or `"embeddings"`).
+    Honours the egress posture: an `"embeddings"` override without
+    `vault_clustering.engine: "embeddings"` configured is rejected
+    with an error, not silently approved.
+  - `force_reembed`: bool, default `false`. When `true`, invalidates
+    the cache rows matching the active
+    (provider, model, model_version) fingerprint and re-embeds the
+    full corpus. Useful when a provider has silently revised a model
+    under the same version string. Has no effect when the active
+    engine is `"heuristic"`.
 - **`mnemo_vault_themes_inspect`** — given a theme slug or ID,
   return the full member list with distances, the centroid text,
-  the labelling source (user-anchored vs LLM vs bigram), and the
-  related-theme links. Lets a user understand why a cluster looks
-  the way it does.
+  the labelling source (user-anchored vs LLM vs bigram, including
+  the gate that fired when an expected user-anchor was rejected),
+  the related-theme links, and the embedding fingerprint the
+  cluster was computed under. Lets a user understand why a cluster
+  looks the way it does.
+- **`mnemo_vault_themes_pin`** — pin / unpin a theme so it is
+  exempt from `vault_clustering.retire_after` auto-archival.
+  Parameters: `theme_id`, `unpin` (bool, default `false`),
+  `reason` (string, optional). Persists to the `theme_pins` table.
 - **`mnemo_vault_themes_split`** — manual override: mark a theme
   ID for splitting on the next pass. Persisted in a
   `theme_overrides` table. Next clustering pass applies the
-  split-hint and reports outcomes. Inverse: `mnemo_vault_themes_merge`.
+  split-hint and reports outcomes. Inverse:
+  **`mnemo_vault_themes_merge`**.
 
-The split/merge MCP tools are not in Slice 8's MVP — they are a
+The split/merge tools are not in Slice 8's MVP — they are a
 follow-up after real-world cluster quality data is in hand.
+`themes_inspect`, `recluster` (with `force_reembed`), and
+`themes_pin` ship with Slice 8.
 
 ### Read paths
 
@@ -537,10 +993,21 @@ Same topic appears as multiple themes ("schema migration", "DB
 migration", "database migration"). Symptom: `_mnemo/themes/_index.md`
 has near-duplicate entries.
 
-**Mitigation:** raise `min_cluster_size` from 3 to 5 in HDBSCAN. Or
-post-process: pairwise theme similarity (cosine over centroids); merge
-any pair with similarity > 0.9 in a deterministic second pass.
-Documented as a tunable.
+**Mitigation (for the single-link engine that actually ships):**
+
+- Raise `vault_clustering.min_cluster_weight` (default 3) to require
+  stronger evidence before a cluster is emitted as a theme.
+- Lower `vault_clustering.heuristic_threshold` (default 0.35) so the
+  agglomerative merge admits looser pairs.
+- Run a deterministic second pass: pairwise theme similarity
+  (cosine over centroids); merge any pair with similarity > 0.9. The
+  second-pass merge is on by default in the heuristic engine and
+  configurable via `vault_clustering.merge_threshold` (default 0.9;
+  set to `1.0` to disable).
+- HDBSCAN-specific tunables (`min_cluster_size`,
+  `cluster_selection_epsilon`) are reserved under
+  `vault_clustering.hdbscan.*` for the deferred follow-up and
+  ignored in Slice 8.
 
 ### Mode 2 — megacluster absorption
 
@@ -548,10 +1015,21 @@ One huge cluster covers most of the corpus ("everything about Go"),
 the rest are tiny. Symptom: weight distribution is bimodal with one
 dominant cluster.
 
-**Mitigation:** strict `cluster_selection_epsilon` (already 0.0).
-Stopword list extended with overused project tokens. If still
-occurring, partition the corpus by repo before clustering and merge
-themes post-hoc.
+**Mitigation (single-link engine):**
+
+- Raise `vault_clustering.heuristic_threshold` (default 0.35) — a
+  stricter merge threshold prevents loose chains from absorbing
+  weakly-related documents.
+- Extend the stopword list with overused project-specific tokens.
+- The domain-drift corrections (per-repo IDF cap + per-repo
+  document quota) documented under "Engine B → Mitigation for
+  domain drift" already work against megaclusters that arise from
+  one-repo vocabulary dominance.
+- If still occurring, partition the corpus by repo before
+  clustering and merge themes post-hoc via the second-pass merge
+  documented in Mode 1.
+- HDBSCAN's `cluster_selection_epsilon` is reserved for the
+  deferred follow-up; it is not a Slice 8 lever.
 
 ### Mode 3 — drift in labels
 
@@ -565,12 +1043,38 @@ sticky regardless of pass.
 
 ### Mode 4 — embedding provider outage
 
-Embedding API down for hours. Symptom: clustering pass fails or
-stalls.
+Embedding API down for hours. Symptom: clustering pass cannot
+fetch fresh vectors for any new / content-changed documents.
 
-**Mitigation:** pass fails gracefully, logs error, leaves prior
-`themes` snapshot in place. User sees a "last computed N hours ago"
-banner in `_mnemo/themes/_index.md`. Next successful pass updates.
+**Mitigation (graduated, in order of severity):**
+
+1. **Stale-vector reuse.** If the cache holds vectors at the
+   active (provider, model, model_version) fingerprint for every
+   active corpus document — i.e. nothing changed since last pass —
+   the pass runs entirely from cache. Provider outage is invisible.
+2. **Partial cache miss.** If some documents need fresh vectors,
+   the pass attempts the provider call once. On 5xx / timeout /
+   rate-limit, it retries with exponential backoff up to
+   `vault_clustering.embedding_retry_max` (default 3). If all
+   retries fail and the user has opted into the embeddings engine
+   on this pass, the pass **falls back to the heuristic engine
+   for this run only** (matching the vectorisation-section
+   fallback rule). The next scheduled pass tries the embeddings
+   provider again. The fall-back is logged and surfaced in
+   `mnemo_vault_status.warnings[]` and the `cluster_runs.failure_mode`
+   column for that row (`"embedding_provider_outage_fell_back_to_heuristic"`).
+3. **Configured to refuse fallback.** A user who prefers to skip
+   the pass rather than mix engine outputs can set
+   `vault_clustering.fallback_to_heuristic_on_outage: false`
+   (default `true`). In that case the pass aborts without
+   touching the existing `themes` snapshot; the
+   `_mnemo/themes/_index.md` shows a "last computed N hours ago"
+   banner; `cluster_runs.failure_mode =
+   "embedding_provider_outage_no_fallback"`.
+
+Either path preserves user data — the prior themes snapshot is
+never partially overwritten. The two paths differ only in whether
+a single pass produces output or skips.
 
 ### Mode 5 — vault content dominates spurious clusters
 
@@ -578,9 +1082,25 @@ User has a sprawling vault with one large note tangentially mentioning
 many topics. That note ends up in every cluster as a representative,
 making themes look incoherent.
 
-**Mitigation:** per-document weight cap. A single document contributes
-at most weight 2.0 to any cluster regardless of configured stream
-weight. A user note in three clusters thus splits its influence.
+**Mitigation:** per-document weight cap, applied to the *total* weight
+a single document contributes *across all clusters it lands in*, not
+to its per-cluster contribution. A document is capped at total
+weight `min(stream_weight, 2.0)` — but if it lands in N clusters,
+its per-cluster contribution is `min(stream_weight, 2.0) / N`. So a
+vault note (stream weight 1.5, cap 1.5) appearing in 3 clusters
+contributes 0.5 to each. A pattern row (stream weight 1.2) appearing
+in 2 clusters contributes 0.6 to each. The cap exists to disarm
+single-document mega-influence in pathological splay cases; the
+per-cluster *attenuation* is what actually fixes the failure mode.
+
+The cap of 2.0 is deliberately set just above the highest stream
+weight (1.5 for vault_user) so that in the common case (a document
+lands in exactly one cluster) the cap does not bind. It binds only
+when a document splays into N ≥ 2 clusters, attenuating per-cluster
+contribution to 1/N of its full weight.
+
+Configurable via `vault_clustering.per_doc_weight_cap` (default
+`2.0`), reserved for future tuning.
 
 ### Mode 6 — cluster IDs churn from minor edits
 
@@ -592,6 +1112,28 @@ set; the cluster ID changes; the theme page moves.
 embeddings themselves. A minor text edit doesn't change membership;
 only addition/removal does. Edits to non-member documents don't
 affect ID.
+
+### Mode 7 — embedding model swap silently churns clusters
+
+A user changes `vault_clustering.embedding_model` from
+`voyage-3-lite` to `voyage-3` (or the provider versions the model
+in-place). The new embedding space segments the corpus
+differently. Cluster memberships shift, IDs regenerate, and every
+`_mnemo/themes/<slug>.md` path churns at once.
+
+**Mitigation:** the cache key includes
+`(provider, model, model_version)`, so the swap is observable in
+the cache. The next clustering pass detects that the active
+(provider, model, model_version) has no cached rows for any
+corpus document and **warns** before regenerating: `embedding model
+changed from <old> to <new> — clusters will be regenerated and
+slug paths may change`. Warning surfaces in `mnemo_vault_status`,
+the daemon log, and the pass's `cluster_runs` row. The user can
+abort by reverting the config; the prior themes table is left
+unchanged in that case (a clustering pass runs end-to-end or not
+at all). A `force_reembed: true` flag on `mnemo_vault_recluster`
+lets a user deliberately request a clean re-embed when they
+suspect a silent provider-side model revision.
 
 ---
 
@@ -619,16 +1161,27 @@ Today a theme either exists (membership ≥ threshold) or doesn't.
 But topics fade — a theme that was active six months ago may now be
 historical context, not current work.
 
-Options:
-- **Implicit retirement**: if no member has `ts` newer than 90 days,
-  theme moves to `_mnemo/themes/_archive/` automatically. Listed in
-  `_index.md` under "Past themes".
-- **Persistent indefinitely**: themes live forever; the user prunes
-  via tooling.
+**Answer (implemented).** Implicit retirement at 180 days,
+configurable via `vault_clustering.retire_after`. Mechanics:
 
-**Working answer:** implicit retirement at 180 days; configurable
-via `vault_clustering.retire_after`. The user can pin themes via
-`mnemo_vault_themes_pin` to override.
+- On every clustering pass, compute `most_recent_member_ts` for
+  each theme. If `now − most_recent_member_ts >
+  vault_clustering.retire_after` and the theme is not present in
+  `theme_pins`, move its page from `_mnemo/themes/<slug>.md` to
+  `_mnemo/themes/_archive/<slug>.md`. The move is the same atomic
+  protocol used elsewhere; the file is not regenerated until the
+  cluster reactivates.
+- `_index.md` lists active themes; an archive section at the bottom
+  links to retired ones with their last-seen dates.
+- A retired theme that receives new members on a later pass is
+  promoted back to the live directory automatically. Cluster ID
+  survives the round-trip because membership-set identity is
+  preserved.
+- Pinning: `mnemo_vault_themes_pin(theme_id)` writes to
+  `theme_pins`. Pinned themes never auto-retire. Unpin via the same
+  tool with `unpin: true`.
+- Status: `mnemo_vault_status.abstractions.themes` reports both
+  `rendered` and `archived` counts.
 
 ### Q3: Patterns-only clusters versus theme membership for patterns
 
@@ -643,13 +1196,20 @@ independently rendered. The theme containing it cites it under
 ### Q4: Translation / multilingual corpus
 
 A non-English user (or a polyglot one) generates content in multiple
-languages. Voyage AI's `voyage-3-lite` is multilingual; HDBSCAN over
-cosine distance is language-agnostic; LLM labelling via Haiku is
-multilingual. Heuristic engine's Porter stemmer is English-only.
+languages. Voyage AI's `voyage-3-lite` is multilingual; single-link
+agglomerative over cosine distance is language-agnostic; LLM
+labelling via Haiku is multilingual. Heuristic engine's Porter
+stemmer is English-only.
 
-**Working answer:** embeddings engine handles multilingual natively.
-Heuristic engine is English-best-effort; document the limitation.
-Multilingual heuristic stemming is a follow-up.
+**Working answer:** embeddings engine handles multilingual natively
+(via the multilingual provider model + language-agnostic
+clustering). Heuristic engine is English-best-effort with one
+partial mitigation that ships in Slice 8: tokens are lowercased
+via `unicode.ToLower` (not just ASCII `strings.ToLower`), so
+Latin-script multilingual content tokenises sensibly even though
+the Porter stemmer only stems English. Cross-language synonym
+coalescing (e.g. "auth" / "authentification") still requires the
+embeddings engine. Per-language stemmer plug-ins are a follow-up.
 
 ---
 
@@ -663,23 +1223,70 @@ The clustering engine is considered shipped when:
    The embeddings engine activates only on explicit
    `vault_clustering.engine: "embeddings"` config (per T63 egress
    posture).
-3. Themes are rendered as `_mnemo/themes/<slug>.md` pages with the
+3. The embeddings engine ships with **single-link agglomerative**
+   clustering reusing Engine B's pipeline downstream of
+   vectorisation. HDBSCAN is **not** a Slice 8 commitment.
+4. Themes are rendered as `_mnemo/themes/<slug>.md` pages with the
    parent design's frontmatter and fence contract.
-4. Cross-repo derivation emits `_mnemo/cross-repo/<slug>.md` for
+5. Cross-repo derivation emits `_mnemo/cross-repo/<slug>.md` for
    themes with `len(repos) ≥ 2` and `weight ≥ 4.0`.
-5. Cluster IDs are stable across runs given stable membership.
-6. `cluster_embeddings` cache prevents re-embedding unchanged
-   content.
-7. `cluster_runs` telemetry is queryable.
-8. `mnemo_vault_recluster` and `mnemo_vault_themes_inspect` MCP
-   tools work end-to-end.
-9. User-anchored labels (vault_user documents) win over LLM
-   labels when present.
-10. Embedding provider outage degrades gracefully — last snapshot
-    preserved.
+6. Cluster IDs are stable across runs given stable membership.
+7. `cluster_embeddings` cache is keyed by
+   `(doc_kind, entity_id, content_hash, provider, model, model_version)`
+   and prevents re-embedding unchanged content for the active
+   (provider, model, model_version).
+8. Switching `vault_clustering.embedding_model` triggers a clean
+   re-embed on the next pass; old rows are retained in the cache;
+   `mnemo_vault_status` warns about the model change.
+9. The embedding provider interface (`EmbeddingProvider`) is
+   implemented by at least one concrete provider (Voyage AI) and
+   wired so that a second provider could be added without changing
+   the rest of the pipeline.
+10. `cluster_runs` telemetry is queryable.
+11. `mnemo_vault_recluster` (including `force_reembed: true` and
+    `engine` override), `mnemo_vault_themes_inspect`, and
+    `mnemo_vault_themes_pin` (with `unpin`) MCP tools work
+    end-to-end. `themes_split` / `themes_merge` stubs land
+    (config-rejecting placeholders, ship in follow-up).
+12. User-anchored labels (vault_user documents) win over LLM
+    labels **only** when all four label-quality gates pass
+    (centroid-closest, ≥ 200-token body, filename-pattern
+    exclusion, title-content token overlap). `themes_inspect`
+    reports the labelling path used and the gate that fired when
+    an anchor was rejected.
+13. Embedding provider outage degrades gracefully per Mode 4's
+    graduated mitigation: stale-vector reuse, then bounded retries,
+    then heuristic fallback (or skip-pass if
+    `fallback_to_heuristic_on_outage: false`). Last `themes`
+    snapshot is preserved in every case.
+14. Two-key egress test passes: with both API keys present in the
+    environment but neither `vault_clustering.engine: "embeddings"`
+    nor `vault_clustering.label.engine: "llm"` set, a clustering
+    pass produces zero outbound HTTP requests. Each opt-in is
+    independently testable.
+15. Theme retirement test passes: a theme with no member newer than
+    `vault_clustering.retire_after` moves to
+    `_mnemo/themes/_archive/` on the next pass; pinning the theme
+    (`mnemo_vault_themes_pin`) prevents the move; new members on a
+    later pass promote it back without churning the cluster ID.
+16. `cluster_runs` rows beyond `max_run_history` are trimmed by a
+    background sweep; the most recent rows are preserved.
+17. `vault_clustering.embedding_model_version` override pins the
+    cache key; rows for other versions in the cache are ignored by
+    the active pass but retained for revert.
+18. Per-engine thresholds applied correctly:
+    `heuristic_threshold` tunes Engine B,
+    `embedding_threshold` tunes Engine A,
+    and changing one does not affect the other.
+19. Misconfiguration recovery: unparseable `recompute_interval`,
+    unknown `engine`, unknown `embedding_provider`, and
+    out-of-range numeric thresholds all fall back to documented
+    defaults with a warning surfaced in
+    `mnemo_vault_status.warnings[]`.
 
-Split/merge tools (Q1) and lifecycle states (Q2) ship in a
-follow-up slice.
+Split/merge tools (Q1) ship in a follow-up slice. HDBSCAN
+clustering (deferred Engine A path) ships in a separate follow-up
+slice if/when a pure-Go HDBSCAN binding meets the quality bar.
 
 ---
 
@@ -688,9 +1295,11 @@ follow-up slice.
 Roughly in this order. Each is reviewable independently.
 
 1. **Schema** — add `themes`, `theme_members`, `cluster_embeddings`,
-   `themes_fts`, `cluster_runs` to `internal/store/schema.sql` (single
-   source of truth per T49, PR #82). sqlift `AllowNone` gate admits
-   the pure additions on next daemon start. Pre-migration backup
+   `themes_fts`, `cluster_runs`, `theme_overrides`, `theme_pins` (plus
+   the `cluster_embeddings_by_fingerprint` index and the
+   `cluster_runs_by_started` index) to `internal/store/schema.sql`
+   (single source of truth per T49, PR #82). sqlift `AllowNone` gate
+   admits the pure additions on next daemon start. Pre-migration backup
    (T61 Phase 1) snapshots the prior state.
 2. **Corpus assembly** — `internal/store/cluster_corpus.go` produces
    the `corpus` view from decisions/compactions/patterns/vault_user.
@@ -705,29 +1314,59 @@ Roughly in this order. Each is reviewable independently.
    Wired through `Registry.ForUser` so it benefits from T62's
    eager-start (PR #89). `clusterCancel` tracked per-user for
    hot-reload via `mnemo_config`.
-5. **Embeddings engine (opt-in)** — `internal/cluster/embeddings.go`.
-   Voyage client, HDBSCAN binding (port from `gonum`-compatible
-   implementation), embedding cache. Documented in CLAUDE.md
-   alongside other egress features per T63's posture (PR #92).
+5. **Embeddings engine (opt-in)** — `internal/cluster/embeddings.go`
+   + `internal/cluster/embedding_provider.go` (interface) +
+   `internal/cluster/voyage.go` (first concrete provider). The
+   embedding output feeds into the same single-link agglomerative
+   clustering used by Engine B — no HDBSCAN port in Slice 8.
+   `cluster_embeddings` cache keyed by
+   `(doc_kind, entity_id, content_hash, provider, model, model_version)`.
+   Documented in CLAUDE.md alongside other egress features per
+   T63's posture (PR #92).
 6. **Labelling** — `internal/cluster/label.go`. User-anchor → LLM →
-   bigram fallback chain.
+   bigram fallback chain. The LLM step has its own opt-in gate
+   (`vault_clustering.label.engine: "llm"`, default `"bigram"`) —
+   independent of the embeddings-engine opt-in, per the two-key
+   egress matrix. The user-anchor quality gates (centroid-closest,
+   token minimum, filename exclusion, title-content coherence) land
+   here.
 7. **Renderer** — `internal/vault/themes.go`,
    `internal/vault/cross_repo.go`. Hooks into existing `Exporter.Sync`
    loop.
-8. **MCP tools** — `mnemo_vault_recluster`, `mnemo_vault_themes_inspect`.
-   Wired in `internal/tools/tools.go`.
+8. **MCP tools** — `mnemo_vault_recluster` (with `engine` + `force_reembed`),
+   `mnemo_vault_themes_inspect`, `mnemo_vault_themes_pin` (with
+   `unpin`). Wired in `internal/tools/tools.go`. `mnemo_vault_themes_split`
+   / `themes_merge` land as config-rejecting placeholder stubs;
+   live implementations ship in the follow-up slice.
 9. **Telemetry** — `cluster_runs` writes from both engines; reporting in
    `mnemo_vault_status`.
 10. **Tests** — golden corpus + expected clusters for both engines;
-    stability test (same input → same IDs); embedding cache hit/miss
-    tests; user-anchor labelling tests; opt-in posture test
-    (embeddings stays off without explicit config).
+    stability test (same input → same IDs within an embedding
+    fingerprint); embedding cache hit/miss tests; user-anchor
+    labelling tests for each of the four quality gates;
+    **two-key egress test** (neither opt-in → zero outbound HTTP);
+    Mode 4 graduated outage tests (stale-vector reuse, retry +
+    fallback, refuse-fallback config); Mode 7 model-swap warning
+    test; theme retirement test (retire after threshold, pin
+    prevents, new members promote back, ID stable); `cluster_runs`
+    trim test (`max_run_history` enforced); `embedding_model_version`
+    pin test; atomic-write resilience test (kill mid-pass, verify
+    no torn files and at most one `.tmp` left behind); per-engine
+    threshold test (different defaults applied to the right engine);
+    domain-drift mitigation test (per-repo IDF cap + balance_factor);
+    misconfiguration recovery test (unparseable interval / unknown
+    engine falls back with status warning).
 
-Estimated effort: 2–3 weeks of focused work. The HDBSCAN port is the
-single largest sub-task; if a pure-Go HDBSCAN library that meets the
-schema/test bar is not available, fall back to a hierarchical
-clustering alternative (slightly worse quality, simpler to implement
-from scratch).
+Estimated effort (agent-assisted, sustained engagement): the
+mechanical pieces — schema DDL, renderer, MCP tool wiring, worker
+registration, golden-corpus tests — are hours of work each. Engine B
+and the embeddings engine on top of single-link clustering are days
+of generation + review/iteration. **HDBSCAN is explicitly out of
+scope** for this slice; it is reserved for a follow-up if and when a
+pure-Go HDBSCAN binding becomes available. The label-quality gates,
+model-version pinning, and provider-agnostic interface are
+single-day additions each, sequenced after the Engine B baseline
+lands.
 
 ---
 

--- a/docs/design/vault-clustering.md
+++ b/docs/design/vault-clustering.md
@@ -1,0 +1,788 @@
+# Vault Clustering Engine
+
+*Status: design draft — 2026-05-20.*
+*Subordinate to `docs/design/vault-library-wing.md` (Slice 8).*
+*Prerequisite: Slice 7 (patterns persisted) must land first.*
+
+---
+
+## TL;DR
+
+The library wing's most valuable abstractions — themes, cross-repo
+similarities, lessons — all rely on grouping content by topical
+similarity. This document specifies how that grouping is computed,
+stored, kept fresh, and rendered. Two engines are specified: a
+heuristic default that runs entirely locally, and an opt-in
+embeddings engine that calls a hosted provider. Per T63's egress
+posture (PR #92), the embeddings engine is **off by default** —
+users opt in explicitly, API key presence alone is not enough.
+
+The engine treats four input sources as equal first-class signal:
+decision summaries, compaction span summaries, persisted patterns
+(Slice 7), and — under permitted indexing scopes — user-authored
+vault content. Output is a `themes` table of cluster rows plus a
+`theme_members` table joining clusters to source entities. Themes
+above a configurable weight threshold are materialised as
+`_mnemo/themes/<slug>.md` pages; themes spanning ≥ 2 repos are
+additionally surfaced as `_mnemo/cross-repo/<slug>.md` views.
+
+Clustering runs on a long cadence (default 24h) because the
+output is noisy on short windows and the cost is non-trivial. A
+content-hash cache means recomputation only touches entities whose
+text changed.
+
+---
+
+## Goals
+
+1. **Stable, human-legible clusters.** Cluster labels do not drift
+   on every pass. A theme that was meaningful yesterday is still
+   recognisable today.
+2. **Default works fully offline.** The heuristic engine is the
+   default and ships first. It produces serviceable themes for every
+   user without any opt-in or external dependency. The embeddings
+   engine improves on it for users who opt in; the heuristic engine
+   is not a toy.
+3. **Bounded cost.** Single-digit cents per re-cluster for a
+   median user. Order-of-magnitude predictable for any user.
+4. **User content as ground truth.** When `vault_indexing_scope`
+   is `"full"` or `"includes"`, user-authored notes anchor and
+   label clusters rather than competing with auto-extracted text.
+5. **Transparent.** A user can inspect cluster membership, see why
+   a session was grouped a particular way, and flag misclassifications.
+
+---
+
+## Non-goals
+
+- **Real-time clustering.** Themes update on a long cadence.
+  Sub-minute freshness is out of scope.
+- **Cross-user clustering.** Each daemon clusters its own user's
+  corpus. Team-mnemo (T36) governs any multi-user case.
+- **Topic modelling as a service.** Mnemo does not expose a generic
+  clustering API. The engine serves the vault renderer; it is not
+  a standalone tool surface.
+- **Hierarchical themes.** Themes are flat. A future iteration may
+  add parent/child relationships if cluster labels prove they
+  warrant the structure.
+- **Replacing existing search.** FTS5 over message bodies remains
+  the search backbone. Clustering produces grouping, not retrieval.
+
+---
+
+## Inputs
+
+The engine consumes four signal types. Each contributes "documents"
+to a unified corpus from which clusters are derived.
+
+### 1. Decision summaries
+
+Source: existing `decisions` table. Use the `summary` column where
+present; fall back to the concatenation of `proposal` + `confirmation`
+texts trimmed to a representative window (first 500 tokens).
+
+Filtering: high-signal decisions only — confirmed (not just proposed),
+≥ 1-paragraph rationale, ≥ 1 week since first observation. Same
+filter applied by Slice 9 lessons extractor.
+
+Weight: 1.0 (baseline reference).
+
+### 2. Compaction span summaries
+
+Source: existing `compactions` table. Use the `prose_summary` column.
+
+Filtering: spans with non-empty `targets_active` or
+`targets_progressed` — i.e. spans where actual work was tracked. Empty
+spans (a single message followed by `/clear`) contribute noise without
+signal and are excluded.
+
+Weight: 0.8. Compaction summaries are LLM-distilled and slightly
+less reliable than decision summaries, which sit closer to source
+material.
+
+### 3. Patterns
+
+Source: `patterns` table (introduced in Slice 7).
+
+Filtering: patterns with occurrence ≥ 3 across ≥ 2 sessions. Single-
+occurrence patterns do not yet warrant cross-cluster placement.
+
+Weight: 1.2. Patterns are explicit recurrences, the highest-signal
+input.
+
+### 4. User-authored vault content
+
+Source: `docs` table where `kind = 'vault'` and the entity was
+ingested via `IngestVaultAnnotations` from a path outside `_mnemo/`.
+Only present when `vault_indexing_scope` is `"full"` or `"includes"`.
+
+Filtering: notes with ≥ 100 tokens of content (excluding frontmatter).
+Below-fence annotations on mnemo-generated pages are excluded from
+this stream — they are attributed to their parent entity, not treated
+as standalone documents.
+
+Weight: 1.5. User-authored content is the strongest available signal
+of human-meaningful structure and serves as anchor labels.
+
+### Stream merge
+
+All four streams are merged into a `corpus` view at clustering time:
+
+```
+corpus(doc_id, kind, entity_id, repo, text, ts, weight)
+  kind ∈ {decision, compaction, pattern, vault_user}
+```
+
+`doc_id` is `<kind>:<entity_id>`. `repo` is normalised to the
+short-project-name form already used in v1.
+
+---
+
+## Outbound API posture
+
+The embeddings engine makes outbound HTTP calls to a hosted embedding
+provider (Voyage AI, OpenAI, etc.). Per the precedent set by **T63
+(PR #92, cost reconciliation opt-in)**, every mnemo feature that
+performs unsolicited outbound traffic to hosted APIs defaults **off**
+and requires explicit opt-in via config — even when the relevant API
+key is present in the environment for other reasons.
+
+This rule applies to the embeddings engine. Specifically:
+
+- `vault_clustering.engine` defaults to `"heuristic"`. The heuristic
+  engine has no network dependencies.
+- A user opts into the embeddings engine by writing
+  `vault_clustering.engine: "embeddings"` (live via `mnemo_config`
+  or by editing `~/.mnemo/config.json`). Mere presence of a Voyage
+  API key in the environment is not enough.
+- If the user sets `engine: "embeddings"` but no provider key is
+  configured, the daemon logs a warning, falls back to the heuristic
+  engine for that pass, and reports the degraded state via
+  `mnemo_vault_status`.
+- The opt-in posture is documented in CLAUDE.md alongside the
+  other egress features (GitHub backfill, federation, cost
+  reconciliation) when this slice ships.
+
+This deliberately gives a worse default to new users than the
+embeddings engine would. Justification: the heuristic engine is
+explicitly designed to be non-toy (see Engine B below); the user can
+opt in to better quality with a one-line config change; respecting
+egress posture matters more than maximising default theme quality.
+
+## Engine A — embeddings (opt-in)
+
+### Vectorisation
+
+For each `corpus` row, compute a 1024-dimensional embedding via the
+configured provider. Default provider: Voyage AI `voyage-3-lite`
+(cheap, multilingual, 1024d output). Alternative: OpenAI
+`text-embedding-3-small` (1536d, truncated to 1024 via PCA). Provider
+chosen by `vault_clustering.embedding_provider`; falls back to
+heuristic engine if no key is set.
+
+Embeddings cached in a new `cluster_embeddings` table keyed by
+`(kind, entity_id, content_hash)`. Recompute only when the
+`content_hash` changes. Median user has on the order of 10³ docs;
+re-embedding cost is single-digit cents at provider rates.
+
+### Cluster algorithm
+
+HDBSCAN over the embedding matrix. Parameters:
+
+| Parameter              | Default | Rationale                                    |
+|------------------------|---------|----------------------------------------------|
+| `min_cluster_size`     | 3       | matches `min_cluster_weight` config          |
+| `min_samples`          | 2       | tolerant of slightly noisy clusters          |
+| `cluster_selection_epsilon` | 0.0 | strict — prefer many small clusters over megaclusters |
+| `metric`               | cosine  | standard for text embeddings                 |
+
+HDBSCAN chosen over k-means because:
+- No fixed cluster count assumption (the corpus has unknown topic
+  count).
+- Tolerates noise points (decisions/spans that don't belong in any
+  theme).
+- Density-based, so cluster labels are stable across runs given
+  stable inputs.
+
+### Cluster labelling
+
+Within each cluster, identify representative documents by inverse
+distance to cluster centroid. Take the top-5.
+
+Then:
+
+1. **If the cluster contains at least one `vault_user` document**
+   (scope `"full"` or `"includes"` enabled, user wrote a thematic
+   note that landed in this cluster), use the user document's title
+   as the cluster label. This is the ground-truth path: the user
+   wrote "Auth middleware redesign" once and now owns that label.
+
+2. **Otherwise**, generate a label via Claude Haiku 4.5 with the
+   prompt: "These are excerpts grouped by topical similarity. Label
+   the topic in ≤6 words, all lowercase, no punctuation:" followed
+   by the top-5 representative excerpts. Cap at 6 words, lowercase,
+   kebab-case for slug derivation.
+
+3. **If LLM labelling fails** (no API key, rate limit, etc.), fall
+   back to the most-frequent non-stopword bigram across the cluster's
+   top-5 excerpts. Crude but deterministic.
+
+### Stability
+
+Cluster IDs are generated as `theme_<sha1(sorted_member_doc_ids)[:8]>`.
+This means: if the same set of documents clusters together on the next
+pass, the ID is identical. A document joining/leaving changes the ID,
+which is the right semantic (a different set is a different theme).
+
+Renamed themes (same membership, new label) retain the same ID, so
+`_mnemo/themes/<slug>.md` paths churn only when membership churns.
+
+---
+
+## Engine B — heuristic (default)
+
+Same input streams. No embeddings. No LLM labelling.
+
+### Document representation
+
+For each document, compute the term-frequency vector over its content
+after:
+- Lowercase, strip punctuation.
+- Tokenize on whitespace.
+- Drop stopwords (standard English list + project-specific noise:
+  "session", "tool_use", "ok", "thanks", code-fence markers).
+- Stem via Porter stemmer.
+
+### Similarity
+
+Cosine similarity over TF-IDF vectors. IDF computed corpus-wide; recomputed at each clustering pass.
+
+### Cluster algorithm
+
+Single-link agglomerative clustering with threshold `similarity ≥ 0.35`
+(tuneable via `vault_clustering.heuristic_threshold`). Stop when no
+pair exceeds the threshold.
+
+This produces fewer, broader clusters than HDBSCAN — acceptable for
+the fallback. Documented limitation.
+
+### Labelling
+
+Most-frequent non-stopword bigram across the cluster's documents,
+weighted by document weight. Capitalise as title case for the page
+header. Slug from the same bigram, kebab-case.
+
+If no bigram repeats, fall back to most-frequent single non-stopword
+token.
+
+### When the heuristic engine wins
+
+- Zero external dependencies. Clustering works on an offline machine.
+- Deterministic. Same input → same output. Useful for tests.
+- Cheap. Median cluster pass is sub-second for 10³ documents.
+
+### When it loses
+
+- Synonym blindness. "Schema migration" and "DB migration" cluster
+  separately. Embeddings would merge them.
+- Domain drift. A repo with heavy jargon dominates corpus IDF and
+  warps clusters. Embeddings are more robust.
+- Label quality. Bigrams are choppier than LLM labels.
+
+---
+
+## Output
+
+### Tables (additive, append-only per T49 schema policy)
+
+All DDL below lands as additions to `internal/store/schema.sql` (the
+single source of truth post-T49, PR #82). sqlift's `AllowNone` gate
+admits the changes because each is a pure `CREATE TABLE` /
+`CREATE VIRTUAL TABLE`. No constraint tightening on existing tables;
+no drops; no type changes. Pre-migration backup (T61 Phase 1)
+automatically captures the prior state.
+
+```sql
+CREATE TABLE themes (
+  id              TEXT PRIMARY KEY,            -- theme_<sha1[:8]>
+  label           TEXT NOT NULL,
+  slug            TEXT NOT NULL UNIQUE,
+  source_engine   TEXT NOT NULL,               -- "embeddings" | "heuristic"
+  weight          REAL NOT NULL,               -- sum of member doc weights
+  member_count    INTEGER NOT NULL,
+  repos           TEXT NOT NULL,               -- JSON array of repo names
+  first_seen      TEXT NOT NULL,               -- ISO timestamp
+  last_computed   TEXT NOT NULL,
+  centroid_text   TEXT                         -- representative excerpt
+);
+
+CREATE TABLE theme_members (
+  theme_id        TEXT NOT NULL REFERENCES themes(id),
+  doc_kind        TEXT NOT NULL,               -- decision | compaction | pattern | vault_user
+  entity_id       TEXT NOT NULL,
+  repo            TEXT,
+  ts              TEXT,
+  distance        REAL,                        -- distance to centroid; for representative selection
+  PRIMARY KEY (theme_id, doc_kind, entity_id)
+);
+
+CREATE TABLE cluster_embeddings (
+  doc_kind        TEXT NOT NULL,
+  entity_id       TEXT NOT NULL,
+  content_hash    TEXT NOT NULL,
+  provider        TEXT NOT NULL,
+  vector          BLOB NOT NULL,               -- float32 packed
+  computed_at     TEXT NOT NULL,
+  PRIMARY KEY (doc_kind, entity_id, content_hash)
+);
+
+CREATE VIRTUAL TABLE themes_fts USING fts5(
+  label, slug, centroid_text,
+  content='themes', content_rowid='rowid'
+);
+```
+
+All four are append-only (no destructive drops, no constraint
+tightening). `themes` and `theme_members` are rewritten in full each
+clustering pass; `cluster_embeddings` accumulates and is GC'd by a
+separate pass when the underlying entity disappears.
+
+### Renderer
+
+`internal/vault/themes.go` (new) emits one Markdown file per row in
+`themes` where `weight ≥ vault_clustering.min_cluster_weight`. Page
+shape per the parent design:
+
+```markdown
+---
+type: theme
+tags: [mnemo, mnemo/theme]
+aliases: ["{{ .Label }}"]
+weight: {{ .Weight }}
+first-seen: {{ .FirstSeen | date "2006-01-02" }}
+last-touched: {{ .LastTouched | date "2006-01-02" }}
+repos: {{ .Repos | toJSON }}
+---
+
+# {{ .Label }}
+
+<!-- mnemo:generated {{ now }} -->
+
+## Summary
+{{ .CentroidText }}
+
+## Evidence
+{{ range .RepresentativeExcerpts }}
+- {{ .Date }} · {{ .Repo }} · "{{ .Excerpt }}"
+{{ end }}
+
+## Related
+{{ range .RelatedThemes }}- [[_mnemo/themes/{{ .Slug }}|{{ .Label }}]]
+{{ end }}
+
+## Underlying entities
+{{ range .Members }}- {{ .Kind }} · {{ .Repo }} · {{ .EntityID }}
+{{ end }}
+
+<!-- /mnemo:generated -->
+
+<!-- Your notes below this line — preserved across syncs. -->
+```
+
+### Cross-repo derivation
+
+A theme with `len(JSON(repos)) ≥ 2` AND `weight ≥ 4.0` triggers
+emission of a cross-repo page at `_mnemo/cross-repo/<slug>.md` in
+addition to the theme page. The cross-repo page renders the same
+theme through a different lens: groups evidence by repo, surfaces
+which-repos-first metadata, and is the page bridged into multi-repo
+MOCs.
+
+No separate `cross_repos` table — cross-repo pages are a derived
+view over `themes`.
+
+---
+
+## Cadence and triggering
+
+### Default
+
+`vault_clustering.recompute_interval` = `"24h"` (configured in parent
+design).
+
+Background goroutine inside `vault.Exporter` (or a sibling
+`vault.Clusterer`) ticks at the interval and runs a full clustering
+pass. Pass duration for a median user is on the order of seconds; for
+heavy users it should remain under one minute.
+
+### Worker lifecycle
+
+The clustering worker follows the **T61 backup worker pattern**
+(`internal/backup/worker.go`, PR #87):
+
+- Registered under the user's WaitGroup at `Registry.ForUser` time
+  via a dedicated `startClusterWorker` helper analogous to
+  `startBackupWorker`.
+- Inherits **T62 eager-start** (PR #89): the worker spins up at
+  daemon boot for the default user, not lazily on first MCP call.
+  A passive daemon with no Claude session attached still re-clusters
+  on schedule.
+- Hot-reload via `mnemo_config`: changes to `vault_clustering.engine`,
+  `recompute_interval`, or `min_cluster_weight` stop the existing
+  goroutine and restart with the new settings. Per-user `clusterCancel`
+  tracked on the `userEntry` struct alongside `vaultCancel` and
+  `reconcilerCancel`.
+- Quiescence not required (clustering reads only, does not write to
+  contended tables in the hot ingest path). Unlike the backup worker
+  it can run at any time.
+- Misconfiguration (bad interval, unknown engine) logs a warn and
+  skips the worker. Daemon never blocks on cluster setup failures.
+
+### Triggered by
+
+- Time tick at the configured interval.
+- Manual `mnemo_vault_recluster` MCP tool call (immediate run).
+- Significant corpus change (≥ N new high-signal entities since last
+  pass; default N=50) — opportunistic re-cluster outside the timer.
+
+### Concurrency
+
+Clustering and vault sync share the existing `syncMu` discipline from
+v1: a cluster pass takes a separate `clusterMu`, periodic syncs run
+during/around it without conflict. The renderer reads cluster output
+via a snapshot taken under `clusterMu`, so a sync writing themes
+sees a consistent view.
+
+### Cost telemetry
+
+Each pass records to a new `cluster_runs` table:
+- start/end timestamps
+- engine used
+- input doc count
+- output theme count
+- embedding API calls and approximate cost
+- failure mode if any
+
+Surfaced via `mnemo_vault_status` and queryable directly. Lets a
+user spot cost outliers without enabling DEBUG logging.
+
+---
+
+## User-facing controls
+
+### Configuration keys (additions to parent design)
+
+```json
+{
+  "vault_clustering": {
+    "engine": "heuristic",
+    "embedding_provider": "voyage",
+    "min_cluster_weight": 3,
+    "recompute_interval": "24h",
+    "heuristic_threshold": 0.35,
+    "max_themes": 200,
+    "max_cross_repo": 50
+  }
+}
+```
+
+| Key                                | Default      | Hot-reload? |
+|------------------------------------|--------------|-------------|
+| `vault_clustering.engine`          | `"heuristic"` (explicit opt-in to `"embeddings"`) | yes |
+| `vault_clustering.embedding_provider` | `"voyage"` | yes         |
+| `vault_clustering.min_cluster_weight` | `3`       | yes         |
+| `vault_clustering.recompute_interval` | `"24h"`   | yes         |
+| `vault_clustering.heuristic_threshold` | `0.35`   | yes         |
+| `vault_clustering.max_themes`      | `200`        | yes         |
+| `vault_clustering.max_cross_repo`  | `50`         | yes         |
+
+`max_themes` caps page emission to prevent a vault explosion when
+clustering accidentally produces 5000 micro-clusters. Themes ranked
+by weight; excess kept in the table but not rendered.
+
+### MCP tools
+
+- **`mnemo_vault_recluster`** — trigger an immediate clustering pass.
+  Returns the run report from `cluster_runs`. Parameters: `engine`
+  optional override.
+- **`mnemo_vault_themes_inspect`** — given a theme slug or ID,
+  return the full member list with distances, the centroid text,
+  the labelling source (user-anchored vs LLM vs bigram), and the
+  related-theme links. Lets a user understand why a cluster looks
+  the way it does.
+- **`mnemo_vault_themes_split`** — manual override: mark a theme
+  ID for splitting on the next pass. Persisted in a
+  `theme_overrides` table. Next clustering pass applies the
+  split-hint and reports outcomes. Inverse: `mnemo_vault_themes_merge`.
+
+The split/merge MCP tools are not in Slice 8's MVP — they are a
+follow-up after real-world cluster quality data is in hand.
+
+### Read paths
+
+- `mnemo_query` against `themes`, `theme_members`, `themes_fts` for
+  power users.
+- `_mnemo/themes/_index.md` lists all themes by weight, with
+  one-line summaries.
+- `mnemo_search` returns theme hits as a distinct result type
+  alongside session excerpts.
+
+---
+
+## Failure modes and mitigations
+
+### Mode 1 — singleton oversplitting
+
+Same topic appears as multiple themes ("schema migration", "DB
+migration", "database migration"). Symptom: `_mnemo/themes/_index.md`
+has near-duplicate entries.
+
+**Mitigation:** raise `min_cluster_size` from 3 to 5 in HDBSCAN. Or
+post-process: pairwise theme similarity (cosine over centroids); merge
+any pair with similarity > 0.9 in a deterministic second pass.
+Documented as a tunable.
+
+### Mode 2 — megacluster absorption
+
+One huge cluster covers most of the corpus ("everything about Go"),
+the rest are tiny. Symptom: weight distribution is bimodal with one
+dominant cluster.
+
+**Mitigation:** strict `cluster_selection_epsilon` (already 0.0).
+Stopword list extended with overused project tokens. If still
+occurring, partition the corpus by repo before clustering and merge
+themes post-hoc.
+
+### Mode 3 — drift in labels
+
+A theme's auto-label changes from "auth middleware redesign" to
+"session token storage" between passes despite identical membership.
+Symptom: `_mnemo/themes/<slug>.md` paths churn.
+
+**Mitigation:** label is cached per theme ID. Recompute only when
+membership changes. User-anchored labels (from vault_user docs) are
+sticky regardless of pass.
+
+### Mode 4 — embedding provider outage
+
+Embedding API down for hours. Symptom: clustering pass fails or
+stalls.
+
+**Mitigation:** pass fails gracefully, logs error, leaves prior
+`themes` snapshot in place. User sees a "last computed N hours ago"
+banner in `_mnemo/themes/_index.md`. Next successful pass updates.
+
+### Mode 5 — vault content dominates spurious clusters
+
+User has a sprawling vault with one large note tangentially mentioning
+many topics. That note ends up in every cluster as a representative,
+making themes look incoherent.
+
+**Mitigation:** per-document weight cap. A single document contributes
+at most weight 2.0 to any cluster regardless of configured stream
+weight. A user note in three clusters thus splits its influence.
+
+### Mode 6 — cluster IDs churn from minor edits
+
+A user edits one decision summary slightly; its embedding shifts
+marginally; the cluster it belongs to is now a different membership
+set; the cluster ID changes; the theme page moves.
+
+**Mitigation:** ID derivation uses the *sorted member set*, not the
+embeddings themselves. A minor text edit doesn't change membership;
+only addition/removal does. Edits to non-member documents don't
+affect ID.
+
+---
+
+## Open questions
+
+### Q1: How to surface user feedback into the clustering loop?
+
+If a user reads `_mnemo/themes/auth-redesign.md` and writes below the
+fence "this is actually two separate things — split into auth and
+session-mgmt", how does that propagate?
+
+Options:
+- **Manual MCP tool only** (current proposal): user invokes
+  `mnemo_vault_themes_split` with theme ID.
+- **Below-fence directive parsing**: a `mnemo: split` frontmatter
+  key or `<!-- mnemo:split -->` directive in user content is parsed
+  on next ingest. Lower friction but introduces a new contract.
+
+**Working answer:** manual tool in Slice 8 MVP. Directive parsing in
+follow-up if friction is high.
+
+### Q2: Should themes have lifecycle states (proposed/active/retired)?
+
+Today a theme either exists (membership ≥ threshold) or doesn't.
+But topics fade — a theme that was active six months ago may now be
+historical context, not current work.
+
+Options:
+- **Implicit retirement**: if no member has `ts` newer than 90 days,
+  theme moves to `_mnemo/themes/_archive/` automatically. Listed in
+  `_index.md` under "Past themes".
+- **Persistent indefinitely**: themes live forever; the user prunes
+  via tooling.
+
+**Working answer:** implicit retirement at 180 days; configurable
+via `vault_clustering.retire_after`. The user can pin themes via
+`mnemo_vault_themes_pin` to override.
+
+### Q3: Patterns-only clusters versus theme membership for patterns
+
+A pattern that recurs across 5 sessions in 3 repos: is it a
+standalone `_mnemo/patterns/<slug>.md` (Slice 7), a member of a
+broader theme (Slice 8), or both?
+
+**Working answer:** both. The pattern lives in `patterns/`,
+independently rendered. The theme containing it cites it under
+"Related" with a wikilink. Two views of the same underlying signal.
+
+### Q4: Translation / multilingual corpus
+
+A non-English user (or a polyglot one) generates content in multiple
+languages. Voyage AI's `voyage-3-lite` is multilingual; HDBSCAN over
+cosine distance is language-agnostic; LLM labelling via Haiku is
+multilingual. Heuristic engine's Porter stemmer is English-only.
+
+**Working answer:** embeddings engine handles multilingual natively.
+Heuristic engine is English-best-effort; document the limitation.
+Multilingual heuristic stemming is a follow-up.
+
+---
+
+## Acceptance criteria
+
+The clustering engine is considered shipped when:
+
+1. Both engines (embeddings and heuristic) produce valid `themes`
+   and `theme_members` rows for a test corpus.
+2. Default engine is `"heuristic"` regardless of API key presence.
+   The embeddings engine activates only on explicit
+   `vault_clustering.engine: "embeddings"` config (per T63 egress
+   posture).
+3. Themes are rendered as `_mnemo/themes/<slug>.md` pages with the
+   parent design's frontmatter and fence contract.
+4. Cross-repo derivation emits `_mnemo/cross-repo/<slug>.md` for
+   themes with `len(repos) ≥ 2` and `weight ≥ 4.0`.
+5. Cluster IDs are stable across runs given stable membership.
+6. `cluster_embeddings` cache prevents re-embedding unchanged
+   content.
+7. `cluster_runs` telemetry is queryable.
+8. `mnemo_vault_recluster` and `mnemo_vault_themes_inspect` MCP
+   tools work end-to-end.
+9. User-anchored labels (vault_user documents) win over LLM
+   labels when present.
+10. Embedding provider outage degrades gracefully — last snapshot
+    preserved.
+
+Split/merge tools (Q1) and lifecycle states (Q2) ship in a
+follow-up slice.
+
+---
+
+## Implementation outline
+
+Roughly in this order. Each is reviewable independently.
+
+1. **Schema** — add `themes`, `theme_members`, `cluster_embeddings`,
+   `themes_fts`, `cluster_runs` to `internal/store/schema.sql` (single
+   source of truth per T49, PR #82). sqlift `AllowNone` gate admits
+   the pure additions on next daemon start. Pre-migration backup
+   (T61 Phase 1) snapshots the prior state.
+2. **Corpus assembly** — `internal/store/cluster_corpus.go` produces
+   the `corpus` view from decisions/compactions/patterns/vault_user.
+   `vault_user` rows sourced from `docs` filtered by the active
+   `trees_of_interest` (T53, PR #91) for the user's vault scope.
+3. **Heuristic engine** — `internal/cluster/heuristic.go`. TF-IDF +
+   single-link. Deterministic. Self-tested with golden fixtures.
+   **This is the default engine** — ships first, lands the slice on
+   its own without any opt-in surface.
+4. **Worker registration** — `internal/registry/registry.go` gains
+   `startClusterWorker` modelled on `startBackupWorker` (T61, PR #87).
+   Wired through `Registry.ForUser` so it benefits from T62's
+   eager-start (PR #89). `clusterCancel` tracked per-user for
+   hot-reload via `mnemo_config`.
+5. **Embeddings engine (opt-in)** — `internal/cluster/embeddings.go`.
+   Voyage client, HDBSCAN binding (port from `gonum`-compatible
+   implementation), embedding cache. Documented in CLAUDE.md
+   alongside other egress features per T63's posture (PR #92).
+6. **Labelling** — `internal/cluster/label.go`. User-anchor → LLM →
+   bigram fallback chain.
+7. **Renderer** — `internal/vault/themes.go`,
+   `internal/vault/cross_repo.go`. Hooks into existing `Exporter.Sync`
+   loop.
+8. **MCP tools** — `mnemo_vault_recluster`, `mnemo_vault_themes_inspect`.
+   Wired in `internal/tools/tools.go`.
+9. **Telemetry** — `cluster_runs` writes from both engines; reporting in
+   `mnemo_vault_status`.
+10. **Tests** — golden corpus + expected clusters for both engines;
+    stability test (same input → same IDs); embedding cache hit/miss
+    tests; user-anchor labelling tests; opt-in posture test
+    (embeddings stays off without explicit config).
+
+Estimated effort: 2–3 weeks of focused work. The HDBSCAN port is the
+single largest sub-task; if a pure-Go HDBSCAN library that meets the
+schema/test bar is not available, fall back to a hierarchical
+clustering alternative (slightly worse quality, simpler to implement
+from scratch).
+
+---
+
+## Appendix: why not delegate everything to an LLM?
+
+A tempting shortcut: feed the entire corpus to an LLM and ask "group
+these into themes and label them." Tested mentally; rejected for
+these reasons:
+
+- **Cost scales linearly with corpus.** A median user with 10³
+  documents is several MB of context — multiple LLM calls per pass
+  at non-trivial cost. Embedding-based clustering is O(corpus) once,
+  not O(corpus × passes).
+- **No stability.** LLM clustering output is not deterministic.
+  Theme IDs would churn pass-to-pass even with identical input.
+- **No bounded recall.** The LLM may forget documents in long
+  context. Embedding clustering processes every document by
+  construction.
+- **Failure modes are opaque.** When LLM clustering produces a
+  weird grouping, you cannot inspect why. Embeddings give you a
+  centroid distance for every member.
+
+LLM use is confined to the labelling step, where it operates on a
+5-excerpt window and the failure is bounded.
+
+---
+
+## Appendix: relationship to existing infrastructure
+
+- **PR #74** (vault export v1) — shares the fence contract and
+  `IngestVaultAnnotations` ingest path. `vault_user` documents in the
+  clustering corpus are read through the same code path.
+- **PR #82 / T49** (sqlift additive-only schema) — every table in
+  this design lands as a pure addition to `internal/store/schema.sql`.
+  No constraint changes, no drops. sqlift's `AllowNone` gate is the
+  enforcement mechanism.
+- **PR #91 / T53** (trees_of_interest + doc_tree_refs) — `vault_user`
+  documents in the corpus are sourced from `docs` rows linked to the
+  trees registered by the parent design's Slice 4. Removing a tree
+  (e.g. dropping an entry from `vault_indexing_includes`) flows
+  naturally through to the corpus on the next clustering pass.
+- **PR #86 / #87 / T61** (backup primitive + periodic backup worker)
+  — clustering tables ride mnemo.db's standard snapshot. The
+  `cluster_embeddings` table is the largest of the new additions;
+  monitor its contribution to snapshot size in `cluster_runs`
+  telemetry. Pre-migration backup automatically captures pre-clustering
+  state when the schema additions land.
+- **PR #89 / T62** (eager-start default user workers) — the
+  clustering worker runs at boot for the default user. No first-MCP-
+  call latency.
+- **PR #92 / T63** (cost reconciliation opt-in) — the precedent for
+  this design's "Outbound API posture" section. The embeddings engine
+  is off by default; opt-in is explicit; the heuristic engine is
+  non-toy. Documentation update to CLAUDE.md ships with the slice.
+- **`docs/design/vault-library-wing.md`** (parent design) — Slice 8
+  is governed by this subordinate doc. Acceptance criterion 3 of the
+  parent design (themes/patterns/cross-repo/lessons/decisions/memories
+  all materialised) depends on this engine.

--- a/docs/design/vault-library-wing.md
+++ b/docs/design/vault-library-wing.md
@@ -1,0 +1,1050 @@
+# Vault Library Wing
+
+*Status: design draft — 2026-05-20.*
+*Supersedes the original vault export design (PR #74) and informs the next major
+version of `vault_path`.*
+
+---
+
+## TL;DR
+
+The current vault export (shipped in #74, #77, #78) materialises rows from
+mnemo's SQLite tables as Markdown — one note per session, per CI run, per PR.
+That projection is faithful to mnemo's internal schema but offers little to a
+human reading their PKM graph: it is wide, repetitive, and indistinguishable
+from a raw database dump.
+
+This design replaces the existing layout with a **well-fenced library wing**
+under `<vault>/_mnemo/`. The wing carries only second-order, human-meaningful
+abstractions — themes, patterns, cross-repo similarities, lessons — distilled
+from the underlying session corpus. Raw event data stays in SQLite, reachable
+on demand via the existing `mnemo_*` query tools.
+
+Three audiences are first-class: new users picking up mnemo today, existing
+users with no vault configured, and existing users who already have a vault
+populated by the v1 layout. All three converge on the same end state without
+forced data loss.
+
+---
+
+## Problem statement
+
+The v1 vault has four structural problems for a human consumer of a PKM graph.
+
+1. **Wrong abstraction layer.** A note like `sessions/abc-1234.md` containing
+   a 6000-token transcript is not knowledge — it is raw signal. Knowledge is
+   the recurring theme that surfaces *across* fifteen such sessions. The v1
+   vault writes the signal and leaves the knowledge extraction to the reader.
+
+2. **Vault footprint invades the user's namespace.** v1 writes
+   `<vault>/sessions/`, `<vault>/decisions/`, `<vault>/ci/`, etc. directly at
+   the vault root. For users with existing folder taxonomies (PARA, Johnny
+   Decimal, MOC-driven Obsidian setups) this collides with their structure.
+
+3. **One PKM shape assumed.** v1 emits Obsidian-flavoured wikilinks, YAML
+   frontmatter, and a flat per-entity folder layout. Logseq users get
+   semi-broken page references; users of plain-Markdown editors see foreign
+   syntax; Roam/Tana users get nothing useful.
+
+4. **Graph view is a hairball.** Every session note links to every decision
+   it surfaced, every PR it referenced, every CI run that followed. In
+   Obsidian graph view this produces a dense mesh with no readable structure
+   and no obvious entrypoint.
+
+Net: a user opening a vault populated by v1 cannot easily see what their
+graph "knows" — they see only what their sessions *contained*.
+
+---
+
+## Goals
+
+1. **Library wing, not roommate.** mnemo writes to exactly one subtree
+   (`<vault>/_mnemo/`). Nothing else in the vault is touched, ever.
+2. **Distilled, not dumped.** What the vault contains is the *output* of
+   semantic processing — themes, patterns, cross-repo similarities, lessons,
+   high-signal decisions, indexed memories. Not transcripts, not CI rows,
+   not PR feeds.
+3. **PKM-tool-agnostic.** Default rendering works in Obsidian, Logseq, Foam,
+   and plain-Markdown editors. A profile system handles tool-specific syntax
+   without forcing user configuration.
+4. **Readable graph.** The mnemo subgraph forms a tight hub-and-spoke
+   cluster with a single entrypoint, distinct tag namespace, and optional
+   user-anchored bridges into existing MOCs.
+5. **Zero forced migration.** Existing vault users do not lose annotations,
+   do not have files moved out from under them, and do not face a flag day.
+6. **Reversible.** Uninstall = delete `_mnemo/`. No mnemo metadata in the
+   user's own notes.
+
+---
+
+## Non-goals
+
+- **Bidirectional editing of mnemo-generated content.** Above-fence content
+  remains mnemo-owned and is regenerated on each sync. Below-fence content
+  is the human contract.
+- **Replacing the user's PKM tool.** mnemo does not become a PKM. It writes
+  a wing that a PKM consumes.
+- **Block-level fidelity.** Logseq block refs, Roam block refs, Tana fields,
+  and similar proprietary outliner constructs are not modelled. mnemo writes
+  notes; it does not pretend to be a native outliner.
+- **Parsing structured edits back into mnemo's relational graph.** User
+  content from the vault — below-fence annotations and (under opt-in scopes)
+  the user's broader notes — is full-text indexed for search and clustering
+  signal. Treating that content as structured edits to specific themes,
+  patterns, or decision rows (e.g. parsing `outcome:: shipped` as a field
+  update) is a future direction, out of scope here. See "Indexing scope"
+  below for what is read versus what is interpreted.
+- **Per-page access control.** Vault content reflects the local user's
+  sessions. Multi-user team scenarios are the domain of `team-mnemo` (T36),
+  not this design.
+
+---
+
+## User archetypes
+
+Every design decision below is justified against at least one of these.
+
+### A. New user, no PKM tool yet
+
+Installs mnemo, eventually wants somewhere to read its outputs. Has no
+existing vault. Configures `vault_path` to a fresh directory.
+
+**Needs:** a vault that is meaningful out of the box, with no configuration
+beyond the path. Opening the directory in Obsidian should "just work" —
+links resolve, graph view shows useful structure, tags are sensible.
+
+### B. New user, established PKM workflow
+
+Heavy Obsidian / Logseq / Foam / Roam user. Has hundreds or thousands of
+existing notes in their preferred taxonomy. Considers their vault their
+"second brain" and is allergic to tools that scribble in it.
+
+**Needs:** strict isolation (a single subtree they can ignore or quarantine),
+zero collisions with their existing folder/tag conventions, ability to opt
+specific mnemo content into their existing graph via bridges, easy removal.
+
+### C. Existing mnemo user, no vault configured
+
+Has been running mnemo for months purely as an MCP search backend. Never
+turned on vault export. Sees this announcement.
+
+**Needs:** continued zero-friction. Nothing must change for them unless they
+choose to opt in. If they later opt in, they get the v2 layout from day one
+with no migration to think about.
+
+### D. Existing mnemo user, vault enabled (v1 layout)
+
+Already configured `vault_path` against a vault populated by `<vault>/sessions/`,
+`<vault>/decisions/`, etc. May have hundreds of below-fence annotations
+across those files.
+
+**Needs:** their annotations survive. They are not forced to migrate on a
+specific day. They can see what is changing, why, and what to do at their
+own pace. The eventual cleanup is their decision, not mnemo's.
+
+### E. Power user
+
+Wants to override how mnemo renders entities — different folder layout
+inside `_mnemo/`, different frontmatter keys to integrate with their
+Dataview queries, different link syntax for an obscure PKM tool.
+
+**Needs:** template override mechanism that does not require recompiling
+mnemo or sending a PR.
+
+### F. Casual reader
+
+Looks at the vault once a week, scans high-level pages, occasionally clicks
+through to evidence. Will not learn YAML, will not configure profiles, will
+not write Dataview queries.
+
+**Needs:** the vault's most valuable content (themes, patterns, lessons) is
+visible from the root `index.md` with at most one click. Frontmatter and
+fences do not interfere with readability.
+
+---
+
+## Architecture
+
+### Layout
+
+```
+<vault>/
+├── (user notes — untouched, owned by user)
+└── _mnemo/
+    ├── index.md
+    ├── README.md
+    ├── MIGRATION.md          # written once when v1 layout detected
+    ├── themes/
+    │   ├── _index.md
+    │   └── <theme-slug>.md
+    ├── patterns/
+    │   ├── _index.md
+    │   └── <pattern-slug>.md
+    ├── cross-repo/
+    │   ├── _index.md
+    │   └── <topic-slug>.md
+    ├── lessons/
+    │   ├── _index.md
+    │   └── <lesson-slug>.md
+    ├── decisions/
+    │   ├── _index.md
+    │   └── <decision-slug>.md         # high-signal only, not raw dump
+    ├── memories/
+    │   ├── _index.md
+    │   └── <memory-slug>.md           # indexed across projects
+    └── legacy-annotations.md          # only if v1 annotations harvested
+```
+
+There is no `sessions/`, no `ci/`, no `prs/`, no `repos/`, no `commits/`,
+no `images/`. Those tables remain in SQLite and are queried on demand.
+
+### Tag namespace
+
+Every mnemo-generated note carries:
+
+```yaml
+tags: [mnemo, mnemo/<type>]
+```
+
+Where `<type>` is one of `theme`, `pattern`, `cross-repo`, `lesson`,
+`decision`, `memory`. This lets the user:
+
+- Colour the mnemo subgraph distinct from their own notes in graph view.
+- Filter all mnemo content out of search results (`-tag:mnemo`).
+- Build Dataview queries scoped to mnemo content
+  (`FROM "_mnemo" WHERE contains(tags, "mnemo/pattern")`).
+- Remove all mnemo content from any tag-based MOC by excluding `mnemo`.
+
+### Fence contract
+
+```markdown
+<!-- mnemo:generated 2026-05-19T10:23Z -->
+…mnemo-owned content above the fence, regenerated on each sync…
+<!-- /mnemo:generated -->
+
+…user annotations below this line, preserved indefinitely…
+```
+
+The fence is line-anchored (matches the fix from PR #74 sixth-pass review).
+A file with no fence is treated as user-owned and never overwritten (also
+preserved from v1).
+
+### Bridges
+
+Optional. Configured per user.
+
+```json
+{
+  "vault_bridges": {
+    "themes":   "10-areas/knowledge/Themes MOC.md",
+    "patterns": "10-areas/knowledge/Patterns.md"
+  }
+}
+```
+
+For each bridge, mnemo appends a fenced block to the named anchor file:
+
+```markdown
+<!-- mnemo:bridge:themes -->
+- [[_mnemo/themes/auth-middleware-redesign|Auth middleware redesign]]
+- [[_mnemo/themes/schema-migration-safety|Schema migration safety]]
+<!-- /mnemo:bridge:themes -->
+```
+
+Properties:
+
+- Above and below the bridge fence is user content, never touched.
+- Removing the bridge from config strips the fenced block on next sync; the
+  anchor file is otherwise left intact.
+- The anchor file may live anywhere in the vault; mnemo creates it if absent
+  but only when explicitly named in `vault_bridges` (no silent file creation).
+
+### PKM profile
+
+```json
+{ "vault_profile": "obsidian" }   // obsidian | logseq | foam | generic
+```
+
+Profile controls:
+
+| Concern              | obsidian       | logseq          | foam           | generic        |
+|----------------------|----------------|-----------------|----------------|----------------|
+| Link syntax          | `[[X\|alias]]` | `[[X]]`         | `[[X]]`        | `[X](X.md)`    |
+| Frontmatter format   | YAML           | YAML            | YAML           | YAML           |
+| Properties           | YAML           | YAML + `prop::` | YAML           | YAML           |
+| Journal awareness    | no             | yes (read-only) | no             | no             |
+| Filename casing      | kebab          | kebab           | kebab          | kebab          |
+
+Auto-detected at first sync from vault contents:
+
+- `<vault>/.obsidian/` present → `obsidian`
+- `<vault>/logseq/` present → `logseq`
+- `<vault>/.foam/` present → `foam`
+- Otherwise → `generic`
+
+User override via `vault_profile` config key always wins.
+
+### Templates (escape hatch)
+
+```
+~/.mnemo/vault_templates/
+├── theme.tmpl
+├── pattern.tmpl
+├── cross-repo.tmpl
+├── lesson.tmpl
+├── decision.tmpl
+├── memory.tmpl
+└── index.tmpl
+```
+
+Standard Go templates with the entity struct exposed. Missing template
+files fall back to the binary's embedded defaults. Documented in
+`internal/vault/README.md`.
+
+### Indexing scope
+
+`vault_path` describes where mnemo *writes*. This section governs what
+mnemo *reads* from inside that path. The two are decoupled by design: a
+user can give mnemo write access to a tiny output wing while keeping
+their broader knowledge base off-limits, or grant read access to their
+whole graph for richer clustering. The default is the stricter of the
+two and the user opts into more.
+
+#### Why this is its own concern
+
+The v1 implementation silently read everything under `vault_path`:
+below-fence annotations on mnemo-generated files *plus* fence-less
+standalone Markdown files anywhere in the vault. That was an acceptable
+shortcut when the vault was small and mnemo-owned, but it becomes a
+surprise consent issue once a user points `vault_path` at an existing
+PKM containing years of personal content. Configuring an output
+directory is not the same as granting full-corpus index rights.
+
+The library wing redesign is the right moment to make the read surface
+explicit, configurable, and reviewable.
+
+#### Scopes
+
+```json
+{
+  "vault_indexing_scope": "_mnemo_only",
+  "vault_indexing_includes": [],
+  "vault_indexing_ignore_file": ".mnemoignore"
+}
+```
+
+Accepted values for `vault_indexing_scope`:
+
+- `"_mnemo_only"` (default) — mnemo reads only `<vault>/_mnemo/`. This
+  covers below-fence annotations on generated pages plus any user
+  Markdown the user has placed inside the wing. Nothing outside the
+  wing is touched.
+- `"full"` — mnemo walks the entire `<vault>` tree (minus the standard
+  hidden-dir exclusions: `.obsidian/`, `.logseq/`, `.git/`, `.trash/`,
+  etc., already implemented in v1). User content surfaces in
+  `mnemo_search`, contributes to theme clustering, and acts as
+  ground-truth labels for clusters.
+- `"includes"` — mnemo walks `<vault>/_mnemo/` plus each path listed
+  in `vault_indexing_includes` (vault-relative, e.g.
+  `["areas/knowledge", "projects"]`). Surgical opt-in for users who
+  want to share specific subtrees without exposing the whole vault.
+
+`vault_indexing_ignore_file` is a vault-root-relative path to a
+gitignore-syntax file. Patterns matched relative to vault root are
+excluded regardless of scope. Default name `.mnemoignore`. Absent file
+means no extra exclusions.
+
+#### What "read" means
+
+Reading content from the vault has three effects:
+
+1. **`mnemo_search` results.** Indexed content appears as full-text
+   search hits alongside session excerpts. Visible to any Claude Code
+   session connected to the daemon.
+2. **Theme clustering input.** Content contributes vectors/tokens to
+   the clustering pipeline. Human-written theme notes can anchor and
+   label clusters that would otherwise be LLM-labelled.
+3. **Bridge back-references (future).** Once user content is indexed,
+   bridges can show "this anchor MOC references _mnemo/themes/X" both
+   ways.
+
+Reading does *not* mean:
+
+- Sending content to any external service unless the user has
+  explicitly enabled an embedding provider with an API key.
+- Modifying user files. Mnemo's write surface remains `<vault>/_mnemo/`
+  plus configured bridge files only.
+- Cross-account exposure. Index lives in the local daemon's SQLite;
+  team-mnemo's sharing model governs any multi-user case.
+
+#### Comparison of the three scopes
+
+| Capability                                 | `_mnemo_only` | `includes`     | `full`           |
+|--------------------------------------------|---------------|----------------|------------------|
+| Below-fence annotations indexed            | yes           | yes            | yes              |
+| Standalone notes inside `_mnemo/` indexed  | yes           | yes            | yes              |
+| User's broader vault notes in `mnemo_search` | no          | within includes | yes             |
+| User content informs theme clustering      | no            | within includes | yes              |
+| Configuration burden                       | none          | low (1 key)    | none             |
+| Surprise-consent risk                      | none          | low            | non-trivial      |
+| Storage / FTS index size                   | bounded       | proportional   | scales w/ vault  |
+| Suitability for vaults with private content | safest       | safe with care | requires `.mnemoignore` |
+
+#### Behaviour at v1 → v2 migration
+
+The v1 implementation effectively ran in `"full"` mode (without the
+opt-in). For existing v1-vault users, we cannot silently narrow scope:
+they may rely on `mnemo_search` returning hits from notes they
+deliberately placed in their vault.
+
+Migration rule:
+
+- **New vaults (`_mnemo/` did not exist at upgrade time).** Default
+  `vault_indexing_scope = "_mnemo_only"`. Strictest by default.
+- **Existing v1 vaults (`_mnemo/` absent, root-level mnemo dirs
+  present).** Default `vault_indexing_scope = "full"` for continuity.
+  `_mnemo/MIGRATION.md` describes the indexing scope explicitly and
+  documents how to narrow it via `mnemo_config`.
+- **Existing v2 vaults (both `_mnemo/` and root-level dirs from a
+  prior partial migration).** Honour the existing config; if unset,
+  default to `"full"` for safety.
+
+In all cases, `mnemo_vault_status` reports the active scope and, when
+scope is `"full"` or `"includes"`, the number of indexed user files
+outside `_mnemo/` so the user can audit what mnemo can see.
+
+#### Per-note opt-out alternative (deferred)
+
+A YAML frontmatter key like `mnemo: ignore` on individual notes would
+provide note-level granularity without forcing folder reorganization.
+Implementable on top of `.mnemoignore` (frontmatter parser already
+runs during ingest classification). Deferred to a follow-up — the
+folder-level mechanism handles the 90% case and ships first.
+
+#### Implications for clustering
+
+If the user enables `"full"` (or scoped `"includes"`), the clustering
+engine in Slice 8 gains a strong signal:
+
+- A user-written note titled "Auth middleware redesign" with body text
+  describing the architecture is a near-perfect cluster label.
+- Cluster IDs become stable across runs because the label is anchored
+  in human content, not in LLM-generated text that drifts pass to
+  pass.
+- Cross-repo themes get qualitatively better: the user's own
+  high-level notes already span repos by topic, so they bridge
+  sessions that the embedding model might cluster only weakly.
+
+Slice 8's design document (`docs/design/vault-clustering.md`, to be
+written) treats `vault_indexing_scope` as a first-class input.
+
+### Information model
+
+mnemo extracts six abstraction types. Each has a source, an extraction
+recipe, and a representation in the wing.
+
+#### 1. Themes (`themes/`)
+
+**Source.** Decisions + compaction span summaries + targets, grouped by
+topical similarity.
+
+**Extraction.** Embedding-based clustering. For each decision summary and
+each compaction prose summary, compute a vector embedding (via the
+already-present image embedder infrastructure repurposed for text, or an
+external embedding service when `ANTHROPIC_API_KEY` is set). Run a streaming
+clustering algorithm (HDBSCAN or online k-means) over the corpus at sync
+time. Clusters of weight ≥ 3 (i.e. at least three contributing sessions or
+spans) become themes. Each cluster gets an auto-generated label by feeding
+the top-N representative excerpts to an LLM with a "label this theme in
+≤6 words" prompt.
+
+**Update.** Recomputed on a long cadence (daily, default) because clustering
+is order-dependent and noisy on short windows.
+
+#### 2. Patterns (`patterns/`)
+
+**Source.** Output of `mnemo_discover_patterns` (already implemented but
+currently live-queried only), persisted to a new `patterns` table.
+
+**Extraction.** Each pattern row records: pattern type (e.g.
+`direct_jsonl_read`, `repeated_query_shape`), occurrence count, repos
+affected, first/last seen timestamps, representative excerpts. Threshold for
+emission: occurrence ≥ 3 across ≥ 2 sessions.
+
+**Update.** Recomputed on a medium cadence (hourly) — pattern detection is
+cheap and benefits from freshness.
+
+#### 3. Cross-repo (`cross-repo/`)
+
+**Source.** Themes whose repo set has size ≥ 2.
+
+**Extraction.** Derived view over themes. Cross-repo page is auto-generated
+when a theme's `repos` field has length ≥ 2 and `weight` ≥ 4 (i.e. the
+similarity is not a one-off).
+
+**Update.** Follows the theme update cadence.
+
+#### 4. Lessons (`lessons/`)
+
+**Source.** Feedback-type auto-memories + confirmed decisions where the
+confirmation paragraph contains validation language ("yes exactly", "that
+worked", "perfect, keep doing that") or the decision was followed by a
+durable code change that survived ≥ 2 weeks.
+
+**Extraction.** Heuristic: filter by signal, then cluster by topic (reuses
+the theme clustering engine). Cluster label = "<one-sentence lesson>".
+
+**Update.** Long cadence (daily).
+
+#### 5. Decisions (`decisions/`, filtered)
+
+**Source.** Existing `decisions` table.
+
+**Extraction.** Not all decisions become vault pages. Filter to high-signal
+decisions: those that are confirmed (not just proposed), have a rationale
+of ≥ 1 paragraph, and survived ≥ 1 week without reversal. Low-signal
+decisions remain queryable via `mnemo_decisions` but do not pollute the
+vault.
+
+**Update.** Per-decision lazy emission as new decisions cross the
+high-signal threshold.
+
+#### 6. Memories (`memories/`)
+
+**Source.** Auto-memory files from `~/.claude/projects/*/memory/`.
+
+**Extraction.** Direct projection (already in v1, kept). Filename
+disambiguated with `<project>-<name>.md` to avoid Obsidian title collisions
+(already in v1, kept).
+
+**Update.** File-watch-triggered (already in v1, kept).
+
+### Page shape
+
+Every entity page follows this skeleton:
+
+```markdown
+---
+type: theme
+tags: [mnemo, mnemo/theme]
+aliases: ["Auth middleware redesign"]
+weight: 7
+first-seen: 2025-09-12
+last-touched: 2026-05-18
+repos: [mnemo, foo, bar]
+---
+
+# Auth middleware redesign
+
+<!-- mnemo:generated 2026-05-19T10:23Z -->
+
+## Summary
+Three repos converged on rip-and-replace pattern driven by legal review of
+session-token storage. Decisions across mnemo, foo, and bar all favoured
+clean rewrites over incremental patching.
+
+## Evidence
+- 2026-03-15 · mnemo · "legal flagged session-token storage in cookies"
+- 2026-04-02 · foo · "compliance review demanded same change"
+- 2026-04-28 · bar · "auth rewrite scheduled for Q2"
+
+## Related
+- [[_mnemo/patterns/legal-driven-rewrites|Legal-driven rewrites]]
+- [[_mnemo/lessons/compliance-over-ergonomics|Compliance over ergonomics]]
+
+## Underlying decisions
+- mnemo · 2026-03-15 · `decision-id-abc1234`
+- foo · 2026-04-02 · `decision-id-def5678`
+
+<!-- /mnemo:generated -->
+
+<!-- Your notes below this line — preserved across syncs. -->
+```
+
+Session-level evidence is rendered as inline quoted excerpts with `date ·
+repo · "quote"` rather than a wikilink to a session page. Session pages no
+longer exist. The session UUID is retrievable via `mnemo_chain` if the
+reader wants drill-down.
+
+### Graph topology
+
+```
+USER GRAPH                  BRIDGES                 _MNEMO WING
+
+Daily/2026-05-19 ─┐                                  _mnemo/index.md
+Projects/work ────┼── Themes MOC ──(bridge)──→  themes/_index
+Reading/papers ───┤                                  ├→ theme-A ──┐
+Areas/career ─────┘                                  ├→ theme-B   │ (theme→pattern)
+                                                     └→ theme-C   ▼
+                                                              patterns/_index
+                                                                 ├→ pattern-1
+                                                                 └→ pattern-2 ──→ cross-repo/topic-X
+                                                                                  └→ lessons/lesson-Y
+```
+
+Properties:
+
+- One entrypoint into the wing: `_mnemo/index.md`. Removable in one delete.
+- Internal links form hub-spoke. The user's graph view never shows a
+  hairball cluster of mnemo notes.
+- Bridges are the only edges crossing from the user's subgraph into the
+  mnemo subgraph. Each is opt-in and configurable.
+- `#mnemo` tag is the user's filter handle for the entire wing.
+
+---
+
+## Configuration surface
+
+```json
+{
+  "vault_path": "~/Documents/PKM",
+  "vault_profile": "obsidian",
+  "vault_layout": "v2",
+  "vault_bridges": {
+    "themes":   "10-areas/knowledge/Themes MOC.md",
+    "patterns": "10-areas/knowledge/Patterns.md"
+  },
+  "vault_indexing_scope": "_mnemo_only",
+  "vault_indexing_includes": [],
+  "vault_indexing_ignore_file": ".mnemoignore",
+  "vault_clustering": {
+    "engine": "embeddings",
+    "min_cluster_weight": 3,
+    "recompute_interval": "24h"
+  }
+}
+```
+
+| Key                          | Default                          | Hot-reload? |
+|------------------------------|----------------------------------|-------------|
+| `vault_path`                 | `""` (disabled)                  | yes (#77)   |
+| `vault_profile`              | auto-detect, fall back to obsidian | yes      |
+| `vault_layout`               | `"v2"` for new vaults; `"both"` for v1-populated vaults | yes |
+| `vault_bridges`              | `{}`                             | yes         |
+| `vault_indexing_scope`       | `"_mnemo_only"` for new vaults; `"full"` for v1-populated vaults | yes |
+| `vault_indexing_includes`    | `[]`                             | yes         |
+| `vault_indexing_ignore_file` | `".mnemoignore"`                 | yes         |
+| `vault_clustering.engine`    | `"heuristic"` (explicit opt-in to `"embeddings"`, per T63 egress posture) | yes |
+| `vault_clustering.min_cluster_weight` | `3`                     | yes         |
+| `vault_clustering.recompute_interval` | `"24h"`                 | yes         |
+
+`vault_layout` accepted values:
+
+- `"v2"` — write to `_mnemo/` only. Stop writing v1 paths.
+- `"both"` — write to both `_mnemo/` and v1 root-level dirs. Used during
+  migration window.
+- `"v1"` — write to v1 root-level dirs only. Available as an emergency
+  escape hatch; not advertised; removed in a later release.
+
+---
+
+## Migration story
+
+Follows the three-phase deprecation pattern from `CLAUDE.md` (schema policy
+section), adapted for filesystem rather than schema.
+
+### Phase 1 — additive (this release)
+
+- `_mnemo/` wing introduced. New abstraction extractors land.
+- `vault_layout` config key added.
+- On startup, for each user with a configured `vault_path`:
+  - If `_mnemo/` exists and any v1 root-level dirs (`sessions/`, `decisions/`,
+    etc.) exist → assume in-progress migration; honour configured `vault_layout`.
+  - If v1 dirs exist and `_mnemo/` does not → new release on existing vault;
+    auto-default `vault_layout` to `"both"`; emit `_mnemo/MIGRATION.md`
+    explaining the change, what to expect, and how to opt fully in.
+  - If neither → new vault; default `vault_layout` to `"v2"`.
+- v1 paths continue to be written when `vault_layout` is `"both"` or `"v1"`.
+  Above-fence content stays fresh. Below-fence annotations are preserved
+  exactly as in v1.
+- `mnemo_vault_status` reports the active layout, the location of each
+  abstraction subdir, and the count of v1 leftovers if any.
+
+### Phase 2 — soak (several releases)
+
+- User opts into pure v2 via `mnemo_config(op=write, patch={"vault_layout": "v2"})`.
+- v1 paths stop being written. Existing v1 files are not deleted.
+- A new sweep runs at the moment of opt-in: walk all v1 root-level dirs,
+  harvest below-fence content from each file, and aggregate into
+  `_mnemo/legacy-annotations.md` (one section per source file, with the
+  original path and harvested annotation text). The user's annotations
+  remain reachable through search even if they later `rm -rf <vault>/sessions/`
+  manually.
+- `mnemo_vault_status` reports "v1 dirs present but unused; safe to delete
+  after verifying legacy-annotations.md".
+
+### Phase 3 — garbage collection (user-initiated)
+
+- New MCP tool: `mnemo_vault_gc_legacy`.
+- Parameters: `confirm: bool`, `dry_run: bool` (default true), optional
+  scope filters (`include: ["sessions","ci"]`).
+- Effect when run with `confirm=true, dry_run=false`: deletes the named v1
+  root-level dirs after a final pre-flight that verifies
+  `legacy-annotations.md` covers every below-fence annotation it would
+  destroy.
+- Idempotent. Reports what was removed.
+
+No automatic deletion. The user owns the timing.
+
+### Per-archetype migration experience
+
+- **Archetype A (new user).** Never sees v1. `vault_layout` defaults to `"v2"`.
+- **Archetype B (new user, established PKM).** Same as A. The new
+  `_mnemo/` isolation makes their existing graph safe by construction.
+- **Archetype C (existing mnemo user, no vault).** No change. If they later
+  configure `vault_path`, they land on `"v2"` immediately.
+- **Archetype D (existing mnemo user, v1 vault).** Phase 1 release: sees
+  `MIGRATION.md` appear at next sync. Continues to use v1 dirs by default
+  until they choose. Phase 2: opts into `"v2"` at their pace; annotations
+  harvested. Phase 3: optionally runs `mnemo_vault_gc_legacy` to clean up.
+- **Archetype E (power user).** Drops templates into
+  `~/.mnemo/vault_templates/` once layout v2 stabilises. No interaction
+  with the migration path.
+- **Archetype F (casual reader).** Opens `_mnemo/index.md`. Finds themes,
+  patterns, lessons. Does nothing else.
+
+---
+
+## Implementation roadmap
+
+Nine slices. Each is independently shippable, reviewable, and reversible.
+
+### Slice 1 — `_mnemo/` namespace + layout config
+
+Plumbs the new directory root and the `vault_layout` config key. No new
+abstractions yet. v1 writers retained, gated on `vault_layout`. Adds
+`_mnemo/index.md` and `_mnemo/README.md` as static-ish content.
+
+*Value:* nothing user-visible yet, but establishes the namespace and lets
+later slices write into it. Required precondition for everything else.
+
+### Slice 2 — move decisions + memories under `_mnemo/`
+
+Re-render the two existing abstractions (decisions, memories) under their
+new paths inside `_mnemo/`. Above-fence content gets the new frontmatter
+shape. Old v1 decision/memory files are still written when
+`vault_layout="both"`.
+
+*Value:* the two existing semantic exports become available in the new
+layout. Validates the rendering shape, frontmatter, and graph topology
+before more abstractions are added.
+
+### Slice 3 — drop session/CI/PR/repo writers from `_mnemo/`
+
+When `vault_layout="v2"`, do not write session, CI, PR, or repo-index pages
+to `_mnemo/`. v1 paths continue to honour the old behaviour under
+`vault_layout="both"` or `"v1"`.
+
+*Value:* validates the principle that raw signal stays in SQLite. The user
+opting into v2 immediately sees a calmer, smaller wing.
+
+### Slice 4 — indexing scope + `.mnemoignore`
+
+Introduce `vault_indexing_scope`, `vault_indexing_includes`, and
+`vault_indexing_ignore_file` config keys. Refactor `IngestVaultAnnotations`
+to walk only the configured scope. Implement gitignore-syntax matcher
+against the `.mnemoignore` file. Wire migration defaults: new vaults
+default to `"_mnemo_only"`; existing v1-populated vaults default to
+`"full"` for continuity. Report active scope in `mnemo_vault_status`.
+
+Reuse `trees_of_interest` + `doc_tree_refs` (landed via T53, PR #91)
+for the multi-tree case. Each configured scope produces one or more
+tree roots:
+
+- `"_mnemo_only"` registers exactly one tree at `<vault>/_mnemo/`.
+- `"full"` registers one tree at `<vault>` with the hidden-dir
+  exclusions already enforced by the walker.
+- `"includes"` registers `<vault>/_mnemo/` plus one tree per
+  `vault_indexing_includes` entry. Trees may overlap (a configured
+  include path that is an ancestor of `_mnemo/`); the existing T53
+  semantics share content rows and dedupe naturally.
+
+Removing a path from `vault_indexing_includes` removes its tree
+references; orphaned content rows are GC'd by the same mechanism
+that handles other tree removals.
+
+*Value:* fixes the silent-permissive-read behaviour of v1. Archetype B
+(heavy PKM) gets the isolation guarantee that the wing's name implies.
+Power users and engaged readers (A, F) opt into `"full"` for the richer
+feedback loop. Lands before Slice 6 (bridges) and Slice 8 (clustering),
+which both depend on a well-defined read surface. Building on T53
+instead of inventing a parallel mechanism keeps the data model lean
+and reuses tested code.
+
+### Slice 5 — PKM profile + auto-detect
+
+Introduce the `vault_profile` config key, the per-profile renderer hooks,
+and the auto-detect-from-vault-contents logic.
+
+*Value:* Logseq/Foam/generic users get a usable wing.
+
+### Slice 6 — bridges
+
+`vault_bridges` config key. Fenced-block writer with the safety constraints
+described above. New MCP tool: `mnemo_vault_bridge_list` to inspect active
+bridges.
+
+*Value:* Archetype B (heavy PKM users) get their main need met. Without
+bridges, mnemo content is segregated; with bridges, it surfaces in user
+MOCs without invading.
+
+### Slice 7 — patterns (persisted + rendered)
+
+Promote `mnemo_discover_patterns` from live-queried to persisted. New
+`patterns` table (additive, append-only per schema policy). Renderer
+emits `_mnemo/patterns/` pages.
+
+*Value:* first new abstraction. Patterns are the cheapest abstraction to
+extract (purely heuristic) and the highest signal per unit effort.
+
+### Slice 8 — themes + cross-repo (clustering engine)
+
+The research-shaped slice. Embedding-based clustering over decisions +
+compaction summaries, plus indexed user content when scope permits. New
+`themes` table (additive). Cross-repo pages derived from themes with
+repo set ≥ 2.
+
+This slice carries the most risk and warrants its own subordinate design
+document (`docs/design/vault-clustering.md`) once Slice 7 lands.
+
+*Value:* the core promise of the redesign. Without themes, the wing is a
+better-organised v1; with themes, it is genuinely new.
+
+### Slice 9 — lessons + GC tool
+
+Lessons extractor (feedback memories + confirmed-and-surviving decisions).
+`mnemo_vault_gc_legacy` tool. `_mnemo/legacy-annotations.md` harvester.
+
+*Value:* completes the abstraction set and gives Archetype D users a
+clean migration path off v1.
+
+### Templates (cross-cutting)
+
+Shipped between Slice 3 and Slice 5 as a refactor: the renderer is
+restructured to load templates from `~/.mnemo/vault_templates/` with
+embedded defaults. No user-facing change at landing; unblocks Archetype E
+once layout v2 is stable.
+
+---
+
+## Risks and open questions
+
+### Indexing-scope consent migration (Slice 4)
+
+v1 effectively shipped in `"full"` scope without an opt-in. Some users
+may rely on `mnemo_search` returning hits from notes they deliberately
+authored in their vault. Silently narrowing scope on upgrade would
+break their workflow without warning. Conversely, leaving scope wide
+open by default for existing vaults perpetuates the consent issue we
+are trying to fix.
+
+**Resolution:** the migration rule documented under "Indexing scope"
+above splits the default by vault state. New vaults default
+`"_mnemo_only"`; existing v1 vaults default `"full"`. `MIGRATION.md`
+explicitly states the scope and shows the one-line `mnemo_config`
+call to narrow it. `mnemo_vault_status` always reports active scope
+and indexed-file count outside `_mnemo/`, so the user can audit at
+any time. No silent narrowing on existing vaults.
+
+### Sensitive content in `"full"` scope
+
+A user enables `"full"` scope on a vault that contains private
+journals, financial notes, or other sensitive content. That content
+becomes returnable from `mnemo_search` invoked by any Claude Code
+session connected to the daemon.
+
+**Resolution:** the consent burden lives at the config layer.
+`.mnemoignore` provides folder-level excludes; per-note opt-out via
+frontmatter is the documented follow-up. `mnemo_vault_status` reports
+which subtrees are currently indexed so the user can review. The
+broader principle: the local daemon serves the local user; mnemo
+does not transmit indexed content off-machine unless the user has
+configured a federation peer (T36) or enabled an embedding provider.
+
+### Clustering quality risk (Slice 8)
+
+Themes are the riskiest abstraction. Bad clusters look like:
+
+- Singletons that should have merged ("schema migration" and "DB migration"
+  as two themes).
+- Mega-clusters absorbing unrelated content ("everything about Go" as one
+  theme).
+- Labels that are vague or misleading ("various topics").
+
+**Mitigation:** ship Slice 8 behind a `vault_clustering.engine=heuristic`
+fallback (TF-IDF + jaccard over n-grams, no embeddings). Document the
+known failure modes. Allow `min_cluster_weight` tuning. Provide
+`mnemo_vault_themes_inspect` for users to see cluster membership and
+flag misclusters.
+
+### Privacy of cross-repo content
+
+Themes can surface text from one repo's sessions in pages cited from
+another repo's view. For solo users this is fine. For multi-tenant
+deployments (team-mnemo, T36), the cross-repo surface area becomes a
+policy question.
+
+**Resolution:** out of scope here. team-mnemo's access model governs that
+case. For single-user vaults, all content is the same user's, so the
+question does not arise.
+
+### Embedding cost
+
+Computing embeddings for every decision summary and compaction span at
+each clustering pass is bounded but not free. A user with 1000 sessions ×
+several decisions each is plausible.
+
+**Resolution:** cache embeddings keyed by (entity_kind, entity_id,
+content_hash). Recompute only on content change. Estimated cost for the
+median user is single-digit cents per re-cluster. For users without an
+embedding API key, the heuristic engine handles the corpus.
+
+### Profile auto-detect false positives
+
+A vault containing `.obsidian/` because the user opened it once in Obsidian
+but actually uses Logseq daily would be mis-detected.
+
+**Resolution:** `vault_profile` config key always wins. Profile detection
+result is logged at startup. Future enhancement: detect more strongly by
+looking for tool-specific *content* signatures (Logseq `journals/` with
+recent edits, Obsidian `.obsidian/workspace.json` with recent activity).
+
+### `_mnemo/` collides with user's own folder
+
+A user with an existing folder literally named `_mnemo/` (vanishingly
+unlikely but possible).
+
+**Resolution:** on startup, if `<vault>/_mnemo/` exists and contains no
+mnemo-generated files (i.e. no `index.md` with the mnemo fence), abort
+with an error. Require the user to rename or move their folder, or point
+`vault_path` elsewhere. Never overwrite.
+
+### Migration ambiguity
+
+A user has both `_mnemo/` (from a previous run) and v1 root-level dirs
+(from an even earlier run). Which is current?
+
+**Resolution:** treat as `vault_layout="both"` until the user explicitly
+sets it. `MIGRATION.md` documents the state and asks them to choose.
+
+---
+
+## Success metrics
+
+These determine whether the design delivered its promised value once
+shipped. Reviewable post-launch.
+
+- **For new users:** ≥ 90% of new vault configurations land on `v2` without
+  any `vault_*` config beyond `vault_path`. Validated by surveying
+  `mnemo_config` calls in the first 30 days post-release.
+- **For existing v1 users:** 0 reports of lost annotations during Phase 1
+  migration. Validated by post-release issue tracker scan.
+- **Graph readability:** Archetype B users (heavy PKM) report that the
+  `_mnemo/` wing is "isolatable" and "doesn't pollute my graph" in user
+  feedback. Validated qualitatively.
+- **Abstraction value:** Archetype F users (casual readers) report opening
+  the vault at least weekly and finding non-trivial insights in themes or
+  lessons. Validated qualitatively.
+- **Template usage:** at least one community-contributed template lands in
+  the wild within 6 months. Validates the escape hatch was real.
+- **Migration adoption:** ≥ 70% of existing v1 users have opted into
+  `vault_layout="v2"` within 6 months of Phase 1 release.
+
+---
+
+## Out of scope / future directions
+
+- **Structured edit ingestion.** Currently below-fence annotations are
+  full-text indexed. A future iteration could parse structured fields
+  (e.g. `outcome:: shipped`) and feed them back into mnemo's graph as
+  human-verified labels.
+- **Bidirectional bridge content.** Bridges are one-way (mnemo → anchor
+  file). Allowing a bridge to also surface back-references from mnemo
+  content to the anchor would close the loop, at the cost of complexity.
+- **Team vault.** Multi-user wings governed by team-mnemo's access model.
+  Out of scope for this design.
+- **Tana / Reflect / Heptabase profiles.** Proprietary formats. Possible
+  via the template mechanism once core profiles ship.
+- **Block-level outliner support.** Logseq/Roam block refs. Distinct
+  representational model; not pursued.
+- **Vault-as-input override layer.** Slice 4 makes the vault readable as
+  clustering signal under `"full"` or `"includes"` scopes. A stronger
+  step — treating specific curated user notes (e.g. hand-written
+  `_mnemo/themes/foo.md` augmentations or user-promoted MOC pages) as
+  *authoritative overrides* that pin cluster labels, merge clusters, or
+  veto auto-extracted themes — is a follow-up to Slice 8. Requires a
+  shape for "user assertion" markers in user content (frontmatter keys
+  or fenced directives) and conflict resolution rules.
+- **Per-note `mnemo: ignore` frontmatter.** Folder-level `.mnemoignore`
+  ships first; per-note opt-out lands as a follow-up once a clear
+  shape is settled.
+
+---
+
+## Acceptance criteria
+
+The work covered by this design is considered complete when all of the
+following are true:
+
+1. `<vault>/_mnemo/` is the only directory written by mnemo for new vault
+   configurations.
+2. Existing v1 vaults can be migrated to v2 with zero annotation loss and
+   user-paced timing.
+3. Themes, patterns, cross-repo, lessons, decisions (filtered), and
+   memories are all materialised under `_mnemo/`.
+4. The wing renders correctly in Obsidian, Logseq, Foam, and a plain
+   Markdown editor without per-tool configuration.
+5. Bridges work end-to-end against at least Obsidian and Logseq.
+6. Template overrides work for at least one entity type end-to-end.
+7. `mnemo_vault_status` reports layout, profile, indexing scope,
+   abstraction counts, count of indexed user files outside `_mnemo/`,
+   and any v1 leftovers.
+8. `mnemo_vault_gc_legacy` removes v1 leftovers after annotation safety
+   check.
+9. Indexing scope defaults to `"_mnemo_only"` on new vaults and `"full"`
+   on v1-populated vaults at upgrade; both behaviours covered by tests.
+10. `.mnemoignore` (gitignore syntax) is honoured at vault root in
+    `"full"` and `"includes"` scopes; verified by tests including
+    nested-pattern cases.
+
+---
+
+## Appendix: relationship to existing infrastructure
+
+- **PR #74** (vault export) — supersedes the layout but reuses the fence
+  contract, the file-watch ingest, the path-canonicalisation logic, and
+  the rendering primitives. Slice 2 above is a refactor of #74's renderers,
+  not a rewrite.
+- **PR #77** (`mnemo_config` hot-reload) — every config key introduced
+  here uses the existing hot-reload machinery. `vault_path`, `vault_profile`,
+  `vault_layout`, `vault_bridges`, `vault_clustering.*` are all eligible
+  for live reconfiguration.
+- **PR #78** (path-exclusion registry) — `_mnemo/` registers itself as a
+  path exclusion at user init, exactly as `vault_path` does today. No
+  re-ingest of mnemo's own output.
+- **PR #82 / T49** (sqlift-mediated additive-only schema) — every new
+  table in this design (and in the subordinate clustering design) ships
+  via append-only DDL only. `internal/store/schema.sql` is the single
+  source of truth; sqlift's `AllowNone` gate is the enforcement
+  mechanism.
+- **PR #91 / T53** (trees_of_interest + doc_tree_refs) — the
+  scope-as-trees model in Slice 4 reuses these tables. Each scope
+  becomes one or more tree roots; overlapping trees share content rows
+  via doc_tree_refs.
+- **PR #86 / #87 / T61** (backup primitive + periodic backup worker) —
+  clustering tables (`themes`, `theme_members`, `cluster_embeddings`,
+  `cluster_runs`) and indexing-scope tables ride the standard mnemo.db
+  snapshot. No separate backup mechanism required. Periodic backups
+  enforce retention.
+- **PR #89 / T62** (eager-start default user workers at daemon boot) —
+  the clustering background worker and any other vault-library workers
+  inherit boot-time startup automatically when registered under the
+  user's WaitGroup. No lazy-on-first-MCP-call surprises.
+- **PR #92 / T63** (cost reconciliation opt-in via explicit config) —
+  establishes the precedent for outbound-API features: default off,
+  explicit opt-in. The clustering design honours this for the
+  embeddings engine. See `docs/design/vault-clustering.md`.
+- **`docs/design/team-mnemo.md`** (T36) — orthogonal. The library wing
+  describes single-user vault output; team-mnemo describes multi-user
+  shared indices. The two can coexist; a team-mnemo deployment can expose
+  a `_mnemo/` wing per user against a shared backend.

--- a/docs/design/vault-library-wing.md
+++ b/docs/design/vault-library-wing.md
@@ -1,8 +1,28 @@
 # Vault Library Wing
 
-*Status: design draft — 2026-05-20.*
+*Status: design draft — 2026-05-20 (rev 2026-05-22, review pass 1).*
 *Supersedes the original vault export design (PR #74) and informs the next major
 version of `vault_path`.*
+
+**Tracking.** Per project convention, this RFC is anchored to a parent
+bullseye target with one sub-target per slice. The bullseye targets are
+the followable unit; this document is the design source they reference.
+
+- **🎯T64** — parent (Vault library wing redesign)
+- **🎯T64.1** — indexing scope + `.mnemoignore` (consent fix)
+- **🎯T64.2** — `_mnemo/` namespace + `vault_layout` config
+- **🎯T64.3** — move decisions + memories under `_mnemo/`
+- **🎯T64.4** — drop session/CI/PR/repo writers (closes MVP v2)
+- **🎯T64.5** — PKM profile + mtime-based auto-detect
+- **🎯T64.6** — bridges
+- **🎯T64.7** — patterns (persisted + rendered)
+- **🎯T64.8** — themes + cross-repo (clustering engine; subordinate
+  design `docs/design/vault-clustering.md`)
+- **🎯T64.9** — lessons + GC tool
+
+Full target definitions in `docs/targets.md`. Status, weight, and
+rework history are queryable via `mnemo_targets` and
+`mnemo_rework_history`.
 
 ---
 
@@ -24,6 +44,23 @@ Three audiences are first-class: new users picking up mnemo today, existing
 users with no vault configured, and existing users who already have a vault
 populated by the v1 layout. All three converge on the same end state without
 forced data loss.
+
+### MVP v2 boundary
+
+The full nine-slice arc takes weeks to months even with agent assistance.
+The first four slices form a coherent, independently shippable **MVP v2**:
+
+1. Slice 1 — indexing scope + `.mnemoignore` (fixes the v1 silent
+   full-vault read; the only real shipped *bug* in v1).
+2. Slice 2 — `_mnemo/` namespace + layout config.
+3. Slice 3 — move decisions + memories under `_mnemo/`.
+4. Slice 4 — drop session/CI/PR/repo writers from `_mnemo/`.
+
+After MVP v2 the wing is calm, scoped, and consent-correct. Themes,
+patterns, lessons, bridges, and the clustering engine (Slices 5–9) are
+independent follow-ups that ship when ready. The MVP boundary lets the
+consent fix land promptly without waiting for the clustering engine to
+prove out.
 
 ---
 
@@ -173,9 +210,11 @@ fences do not interfere with readability.
 └── _mnemo/
     ├── index.md
     ├── README.md
-    ├── MIGRATION.md          # written once when v1 layout detected
+    ├── MIGRATION.md          # write-once when v1 layout detected; opt-in regen via mnemo_vault_migration_doc
     ├── themes/
     │   ├── _index.md
+    │   ├── _archive/
+    │   │   └── <theme-slug>.md            # auto-retired themes (config: retire_after)
     │   └── <theme-slug>.md
     ├── patterns/
     │   ├── _index.md
@@ -197,6 +236,17 @@ fences do not interfere with readability.
 
 There is no `sessions/`, no `ci/`, no `prs/`, no `repos/`, no `commits/`,
 no `images/`. Those tables remain in SQLite and are queried on demand.
+
+**Naming note.** Collection directories are plural nouns (`themes/`,
+`patterns/`, `lessons/`, `decisions/`, `memories/`) with one
+deliberate exception: `cross-repo/` reads as an adjectival
+qualifier ("cross-repo views over themes") rather than a noun in
+its own right. Renaming to `cross-repo-themes/` was considered and
+rejected for verbosity; renaming the others to a singular form
+would be more disruptive than the inconsistency is worth.
+Implementers should treat `cross-repo` as a derived view, not a
+peer of `themes`. See `docs/design/vault-clustering.md` for the
+derivation rule.
 
 ### Tag namespace
 
@@ -229,6 +279,33 @@ The fence is line-anchored (matches the fix from PR #74 sixth-pass review).
 A file with no fence is treated as user-owned and never overwritten (also
 preserved from v1).
 
+#### MIGRATION.md — write-once exception
+
+`_mnemo/MIGRATION.md` is an explicit exception to the regen-above-fence
+contract. It is **written once** at the moment of v1-detection on a
+vault, then never touched again by mnemo. Specifically:
+
+- The file is created with no fence. Once on disk, it is treated as
+  fully user-owned content from mnemo's point of view.
+- mnemo does not regenerate MIGRATION.md on subsequent syncs, even if
+  v1 dirs disappear or the layout changes.
+- If the user deletes `_mnemo/MIGRATION.md`, mnemo does **not**
+  recreate it. The deletion is taken as "I have read this; move on."
+- A user who wants the doc back can invoke
+  `mnemo_vault_migration_doc(write: true)`, which idempotently writes
+  the current state-of-vault snapshot to `_mnemo/MIGRATION.md`. The
+  same tool with `write: false` returns the snapshot without writing,
+  for users who prefer to read it via MCP rather than the filesystem.
+
+This rule lives outside the standard fence contract because the doc's
+contract is "say something once, then get out of the user's way." A
+regenerating MIGRATION.md would nag indefinitely; a content-less file
+would be confusing if the user re-opened the vault months later. The
+write-once shape captures both intents cleanly.
+
+The exception is local to MIGRATION.md. Every other file in `_mnemo/`
+honours the standard fence contract.
+
 ### Bridges
 
 Optional. Configured per user.
@@ -259,6 +336,74 @@ Properties:
 - The anchor file may live anywhere in the vault; mnemo creates it if absent
   but only when explicitly named in `vault_bridges` (no silent file creation).
 
+#### Bridge edge cases
+
+The behaviour of the bridge writer is fully specified for the awkward
+cases — none of these are theoretical, all of them can happen in real
+vaults.
+
+- **Bridge configured, fence absent from anchor file.** mnemo appends
+  a new `<!-- mnemo:bridge:<name> -->` block at the end of the anchor
+  file (after a single blank line separator). The user's existing
+  content above is untouched. On every subsequent sync the writer
+  re-locates the named fence; once present, future writes happen
+  in-place.
+- **Bridge configured, fence present but moved by the user.** The
+  writer locates the fence by its `<!-- mnemo:bridge:<name> -->`
+  delimiter pair, not by line offset, so a user reordering or
+  relocating the block within the file is honoured. Two competing
+  blocks with the same name in one file are not allowed: on
+  encountering them, mnemo logs an error, leaves the file alone, and
+  reports the conflict via `mnemo_vault_status`.
+- **Bridge configured, anchor file missing.** mnemo creates the file
+  with just the bridge fence inside and a one-line header (e.g.
+  `# Themes MOC`). Filenames containing spaces / non-ASCII work
+  exactly as on the filesystem; no normalisation. Parent
+  directories are created as needed.
+- **Bridge configured, anchor file unwritable** (read-only, perm
+  error, symlink loop, etc.). The writer logs a warn-level error
+  with the path and reason, skips the bridge for this pass, and
+  surfaces the failure in `mnemo_vault_status`. No retry storm.
+- **Two bridges target the same anchor file.** Each bridge gets its
+  own uniquely named fence (`mnemo:bridge:themes`,
+  `mnemo:bridge:patterns`). Order in the file follows order of first
+  appearance: if a fence does not yet exist, it is appended after
+  the existing mnemo blocks. The two bridges never share a fence.
+- **Bridge name in config does not match any configured entity
+  collection.** A bridge maps a *collection name* (e.g. `themes`,
+  `patterns`, `cross-repo`, `lessons`, `decisions`, `memories`) to an
+  anchor path. Bridge names outside this enum (typos, future
+  collections, custom names) are **skipped with a warning** — the
+  unknown bridge is not written, the error is surfaced via
+  `mnemo_vault_status` and a structured log line, and the daemon
+  proceeds with the rest of the valid bridges. This is fail-soft:
+  one typo does not break the others. The daemon never blocks
+  startup on bridge config.
+- **Bridge removed from config after blocks were written.** Next
+  sync strips the corresponding fenced block but leaves the anchor
+  file otherwise intact. The file is not deleted even if the bridge
+  block was the entire content.
+
+#### Per-collection bridge content
+
+Bridge bodies differ by collection. The default renderings are:
+
+- `themes`, `patterns`, `cross-repo`, `lessons`, `decisions` — flat
+  bulleted list of wikilinks to the collection's pages, sorted by
+  weight (or last-touched for decisions), capped at
+  `vault_bridges.max_links` (default 50) per bridge to avoid the
+  bridge becoming its own hairball.
+- `memories` — grouped by source project; subsections of the form
+  `### <project-name>` followed by the wikilinks to that project's
+  memories. Because memories use `<project>-<name>.md` filename
+  namespacing, the bridge is the place where they become navigable
+  by project. Capped per project at `vault_bridges.max_links`.
+
+Templates from `~/.mnemo/vault_templates/v2/bridge_<collection>.tmpl`
+override the per-collection rendering. Standard template
+error-handling rules apply (load-time validation, no silent
+fallback).
+
 ### PKM profile
 
 ```json
@@ -275,31 +420,89 @@ Profile controls:
 | Journal awareness    | no             | yes (read-only) | no             | no             |
 | Filename casing      | kebab          | kebab           | kebab          | kebab          |
 
-Auto-detected at first sync from vault contents:
+Auto-detected at first sync from vault contents. Detection by **mere
+presence** of a tool's dot-directory is brittle — multi-tool PKM users
+(notably Logseq + Obsidian against the same directory) are common,
+and `.obsidian/` can persist after a single exploratory open
+months ago. mnemo uses recency-of-modification of the canonical signal
+files instead:
 
-- `<vault>/.obsidian/` present → `obsidian`
-- `<vault>/logseq/` present → `logseq`
-- `<vault>/.foam/` present → `foam`
-- Otherwise → `generic`
+| Tool      | Signal file                              |
+|-----------|------------------------------------------|
+| obsidian  | `<vault>/.obsidian/workspace.json`       |
+| logseq    | `<vault>/logseq/config/config.edn`       |
+| foam      | `<vault>/.foam/settings.json`            |
 
-User override via `vault_profile` config key always wins.
+Detection rule:
+
+1. Stat each signal file. Files that do not exist are dropped.
+2. If exactly one signal file exists → that tool's profile.
+3. If multiple signal files exist → pick the one whose mtime is most
+   recent. Ties (≤ 1 hour apart) → prefer `obsidian` (most common),
+   then `logseq`, then `foam`. Log the chosen tool + the alternative
+   so the user can spot a mis-detection.
+4. If none exist → `generic`.
+
+User override via `vault_profile` config key always wins; auto-detect
+only seeds the value when the user has not configured one.
+
+The detection result is recorded in `mnemo_vault_status` alongside
+the signal file path and its mtime, so the user can immediately see
+why a given profile was picked.
 
 ### Templates (escape hatch)
 
 ```
 ~/.mnemo/vault_templates/
-├── theme.tmpl
-├── pattern.tmpl
-├── cross-repo.tmpl
-├── lesson.tmpl
-├── decision.tmpl
-├── memory.tmpl
-└── index.tmpl
+└── v2/
+    ├── theme.tmpl
+    ├── pattern.tmpl
+    ├── cross-repo.tmpl
+    ├── lesson.tmpl
+    ├── decision.tmpl
+    ├── memory.tmpl
+    └── index.tmpl
 ```
 
-Standard Go templates with the entity struct exposed. Missing template
-files fall back to the binary's embedded defaults. Documented in
-`internal/vault/README.md`.
+Standard Go templates with the entity struct exposed. The shape of the
+exposed entity struct is **versioned** by the parent directory (`v2/`
+here). When the entity shape changes incompatibly in a future
+release, mnemo will look in `v3/` (or whatever the new version is)
+without silently rotting user templates: a `v2/theme.tmpl` written
+today continues to render its v2 entity shape if mnemo still ships
+the v2 renderer, otherwise it is reported as out-of-date and the
+embedded default is used until the user upgrades it.
+
+#### Load-time validation, not silent fallback
+
+Behaviour when mnemo reads `~/.mnemo/vault_templates/v2/*.tmpl` at
+startup and on every hot-reload:
+
+- **File absent** → embedded default used. Quiet, expected. Logged at
+  debug level.
+- **File present, parses cleanly** → user template used.
+- **File present, fails to parse / fails to execute against a probe
+  entity** → error logged at warn level with the parse error and the
+  template path. The vault sync worker for that specific entity type
+  is **not** started until the template is fixed (or the file is
+  removed). Other entity types continue rendering with their
+  templates. The failure is surfaced in `mnemo_vault_status` so the
+  user can see exactly which template is broken without grepping
+  logs.
+
+Silent fall-through to the embedded default on a malformed user
+template is explicitly rejected: a user who has invested in a custom
+template wants to know it broke, not have mnemo quietly render with
+an unrelated shape and leave them puzzled about why their Dataview
+queries stopped working.
+
+Each template is executed once against a synthesised probe entity at
+startup as part of validation. A template that parses but blows up
+on execution (e.g. referencing a missing field) is caught here
+rather than at first render.
+
+Documented in `internal/vault/README.md` alongside the probe-entity
+shape so users can author against a stable contract.
 
 ### Indexing scope
 
@@ -353,6 +556,19 @@ Accepted values for `vault_indexing_scope`:
 gitignore-syntax file. Patterns matched relative to vault root are
 excluded regardless of scope. Default name `.mnemoignore`. Absent file
 means no extra exclusions.
+
+**Scope of `.mnemoignore`.** Patterns apply throughout the configured
+scope, including inside `_mnemo/`. A user who wants to exclude a
+specific generated page from the search index (e.g. an experimental
+theme they have not curated yet) can add `_mnemo/themes/draft-*.md`
+to the ignore file. The ignore file is **not** itself indexed.
+
+Only one `.mnemoignore` is consulted (the one named by
+`vault_indexing_ignore_file`, default `<vault>/.mnemoignore`). Nested
+`.mnemoignore` files inside subdirectories are not honoured — keep
+all patterns in the root file. This matches the gitignore-syntax
+intent but not gitignore's nested-file behaviour; the simplification
+is documented in `MIGRATION.md` for upgraders.
 
 #### What "read" means
 
@@ -431,9 +647,13 @@ engine in Slice 8 gains a strong signal:
 - Cluster IDs become stable across runs because the label is anchored
   in human content, not in LLM-generated text that drifts pass to
   pass.
-- Cross-repo themes get qualitatively better: the user's own
-  high-level notes already span repos by topic, so they bridge
-  sessions that the embedding model might cluster only weakly.
+- Cross-repo themes get qualitatively better: user-authored notes
+  in the vault are not attributed to any specific repo, so they
+  function as topical magnets that pull together session content
+  from multiple repos that the embedding model might otherwise
+  cluster only weakly. (Vault content contributes to a cluster's
+  topical centre but does not contribute to its `repos` field; the
+  repo set comes from the session-attributed members.)
 
 Slice 8's design document (`docs/design/vault-clustering.md`, to be
 written) treats `vault_indexing_scope` as a first-class input.
@@ -445,18 +665,22 @@ recipe, and a representation in the wing.
 
 #### 1. Themes (`themes/`)
 
-**Source.** Decisions + compaction span summaries + targets, grouped by
-topical similarity.
+**Source.** Decisions + compaction span summaries + persisted patterns
+(Slice 7) + indexed user vault content (when scope permits), grouped by
+topical similarity. Full spec lives in
+`docs/design/vault-clustering.md`.
 
-**Extraction.** Embedding-based clustering. For each decision summary and
-each compaction prose summary, compute a vector embedding (via the
-already-present image embedder infrastructure repurposed for text, or an
-external embedding service when `ANTHROPIC_API_KEY` is set). Run a streaming
-clustering algorithm (HDBSCAN or online k-means) over the corpus at sync
-time. Clusters of weight ≥ 3 (i.e. at least three contributing sessions or
-spans) become themes. Each cluster gets an auto-generated label by feeding
-the top-N representative excerpts to an LLM with a "label this theme in
-≤6 words" prompt.
+**Extraction.** Two-engine clustering pipeline. The **heuristic engine**
+(TF-IDF + single-link agglomerative) is the **default and the realistic
+engine** that ships with Slice 8 — fully local, no external dependencies.
+An opt-in **embeddings engine** (per T63 egress posture; explicit
+`vault_clustering.engine: "embeddings"` plus a provider key) swaps the
+TF-IDF vectorisation for hosted-provider embeddings but reuses the
+single-link clustering downstream. HDBSCAN is reserved for a follow-up
+slice once a pure-Go binding meets the quality bar. Clusters of weight ≥
+3 become themes. Labelling chain: user-anchored title (if a qualifying
+`vault_user` member passes the quality gates) → optional LLM label
+(separate egress opt-in) → bigram fallback.
 
 **Update.** Recomputed on a long cadence (daily, default) because clustering
 is order-dependent and noisy on short windows.
@@ -566,6 +790,22 @@ repo · "quote"` rather than a wikilink to a session page. Session pages no
 longer exist. The session UUID is retrievable via `mnemo_chain` if the
 reader wants drill-down.
 
+The "Underlying decisions" heading in the example above is theme-
+specific. Each entity type uses its own heading for the
+provenance section:
+
+| Entity type  | Provenance heading       |
+|--------------|--------------------------|
+| theme        | "Underlying decisions" (when sourced from decisions/compactions) or "Underlying entities" (mixed) |
+| pattern      | "Occurrences"            |
+| cross-repo   | "Per-repo evidence"      |
+| lesson       | "Source decisions"       |
+| decision     | "Proposal & confirmation" |
+| memory       | (no provenance section — the page *is* the memory) |
+
+Templates pick the heading by entity type; the embedded defaults
+encode the table above. Custom templates can override per-entity.
+
 ### Graph topology
 
 ```
@@ -591,6 +831,131 @@ Properties:
   mnemo subgraph. Each is opt-in and configurable.
 - `#mnemo` tag is the user's filter handle for the entire wing.
 
+### Worked example: post-Slice-8 vault for a real corpus
+
+A reader cannot fully picture the design without seeing one
+end-to-end output against plausible input. Concrete scenario: a
+user has been running mnemo for six months across three repos
+(`mnemo`, `foo`, `bar`), uses Obsidian, and has opted into
+`vault_indexing_scope: "full"` and `vault_clustering.engine:
+"embeddings"` with Voyage.
+
+After the first post-Slice-8 sync, `<vault>/_mnemo/` looks like:
+
+```
+_mnemo/
+├── index.md
+├── README.md
+├── themes/
+│   ├── _index.md
+│   ├── auth-middleware-redesign.md         ← user-anchored label
+│   ├── schema-migration-safety.md          ← LLM label
+│   ├── test-flake-investigations.md
+│   └── ci-runner-tuning.md
+├── patterns/
+│   ├── _index.md
+│   ├── direct-jsonl-reads.md               ← from Slice 7 patterns
+│   └── repeated-decision-queries.md
+├── cross-repo/
+│   ├── _index.md
+│   └── auth-middleware-redesign.md         ← same slug as themes/, mirrored
+├── lessons/
+│   ├── _index.md
+│   ├── compliance-over-ergonomics.md
+│   └── prefer-bundled-prs-for-area-refactors.md
+├── decisions/
+│   ├── _index.md
+│   └── (12 high-signal decisions across 3 repos)
+└── memories/
+    ├── _index.md
+    ├── mnemo-vault_library_wing.md
+    ├── mnemo-user_preferences.md
+    └── (10 more, one per source memory file)
+```
+
+Excerpt from `_mnemo/themes/auth-middleware-redesign.md` (the
+user-anchored case — the user already had a note titled "Auth
+middleware redesign" in their vault, body ≥ 200 tokens, no
+daily-note filename, title shared "auth" with the cluster centroid):
+
+```markdown
+---
+type: theme
+tags: [mnemo, mnemo/theme]
+aliases: ["Auth middleware redesign"]
+weight: 11.4
+first-seen: 2025-12-04
+last-touched: 2026-05-18
+repos: [mnemo, foo, bar]
+label-source: vault_user
+label-source-path: 10-areas/engineering/Auth middleware redesign.md
+---
+
+# Auth middleware redesign
+
+<!-- mnemo:generated 2026-05-22T14:01:55Z -->
+
+## Summary
+Three repos converged on rip-and-replace pattern driven by legal review of
+session-token storage. Decisions across mnemo, foo, and bar all favoured
+clean rewrites over incremental patching.
+
+## Evidence
+- 2026-03-15 · mnemo · "legal flagged session-token storage in cookies"
+- 2026-04-02 · foo · "compliance review demanded same change"
+- 2026-04-28 · bar · "auth rewrite scheduled for Q2"
+- 2026-05-09 · mnemo · "session token format finalised"
+- 2026-05-14 · foo · "rip and replace landed without rollback"
+
+## Related
+- [[_mnemo/patterns/repeated-decision-queries|Repeated decision queries]]
+- [[_mnemo/lessons/compliance-over-ergonomics|Compliance over ergonomics]]
+- [[_mnemo/cross-repo/auth-middleware-redesign|Auth middleware redesign (cross-repo view)]]
+
+## Underlying decisions
+- mnemo · 2026-03-15 · `decision-id-abc1234`
+- foo · 2026-04-02 · `decision-id-def5678`
+- bar · 2026-04-28 · `decision-id-ghi9012`
+
+<!-- /mnemo:generated -->
+
+<!-- Your notes below this line — preserved across syncs. -->
+```
+
+Excerpt from `mnemo_vault_status` for the same session (truncated
+to the relevant fields):
+
+```json
+{
+  "vault_layout":   { "active": "v2", "first_seen": "2026-05-18T...", "days_in_both": 0 },
+  "indexing_scope": { "active": "full", "external_files_indexed": 1284 },
+  "abstractions":   { "themes": { "rendered": 4 }, "lessons": { "rendered": 2 } },
+  "last_cluster_run": { "engine": "embeddings", "estimated_cost": 0.04 }
+}
+```
+
+Bridge anchor file `10-areas/knowledge/Themes MOC.md` after the
+sync (user content untouched above, mnemo block appended once):
+
+```markdown
+# Themes MOC
+(user's own MOC notes here, unchanged)
+
+<!-- mnemo:bridge:themes -->
+- [[_mnemo/themes/auth-middleware-redesign|Auth middleware redesign]]
+- [[_mnemo/themes/schema-migration-safety|Schema migration safety]]
+- [[_mnemo/themes/test-flake-investigations|Test flake investigations]]
+- [[_mnemo/themes/ci-runner-tuning|CI runner tuning]]
+<!-- /mnemo:bridge:themes -->
+```
+
+This is what a reviewer can hold in their head while reading the
+rest of the design. The numbers in this example (4 themes,
+`weight: 11.4`, `external_files_indexed: 1284`) are illustrative
+and do not need to match other example snippets elsewhere in the
+doc — each example was crafted for its surrounding context, not
+woven into a single coherent fictional corpus.
+
 ---
 
 ## Configuration surface
@@ -608,7 +973,7 @@ Properties:
   "vault_indexing_includes": [],
   "vault_indexing_ignore_file": ".mnemoignore",
   "vault_clustering": {
-    "engine": "embeddings",
+    "engine": "heuristic",
     "min_cluster_weight": 3,
     "recompute_interval": "24h"
   }
@@ -620,6 +985,7 @@ Properties:
 | `vault_path`                 | `""` (disabled)                  | yes (#77)   |
 | `vault_profile`              | auto-detect, fall back to obsidian | yes      |
 | `vault_layout`               | `"v2"` for new vaults; `"both"` for v1-populated vaults | yes |
+| `vault_layout.soak_warn_after` | `"720h"` (30 days; soak window before "both"-layout warning fires) | yes |
 | `vault_bridges`              | `{}`                             | yes         |
 | `vault_indexing_scope`       | `"_mnemo_only"` for new vaults; `"full"` for v1-populated vaults | yes |
 | `vault_indexing_includes`    | `[]`                             | yes         |
@@ -627,6 +993,11 @@ Properties:
 | `vault_clustering.engine`    | `"heuristic"` (explicit opt-in to `"embeddings"`, per T63 egress posture) | yes |
 | `vault_clustering.min_cluster_weight` | `3`                     | yes         |
 | `vault_clustering.recompute_interval` | `"24h"`                 | yes         |
+| `vault_clustering.retire_after` | `"4320h"` (180 days)            | yes         |
+| `vault_clustering.max_themes` | `200`                               | yes         |
+| `vault_clustering.max_cross_repo` | `50`                            | yes         |
+| `vault_bridges.max_links`    | `50`                                 | yes         |
+| `vault_legacy_annotations.max_file_kb` | `512` (split aggregate when exceeded) | yes |
 
 `vault_layout` accepted values:
 
@@ -634,7 +1005,385 @@ Properties:
 - `"both"` — write to both `_mnemo/` and v1 root-level dirs. Used during
   migration window.
 - `"v1"` — write to v1 root-level dirs only. Available as an emergency
-  escape hatch; not advertised; removed in a later release.
+  escape hatch; not advertised; **removed in the release after the
+  Slice 9 GC tool reaches General Availability** (i.e. once the
+  user-paced migration path is fully proven). Until then, setting
+  this value logs a warning each sync ("vault_layout=v1 is the
+  emergency escape hatch and will be removed in release X.Y").
+  The removal slice replaces the value with a hard error at config
+  load and is tracked as its own bullseye sub-target.
+
+#### Soak-time TTL for `"both"`
+
+`"both"` is meant as a migration window, not a steady state. A user who
+upgrades and forgets sits in dual-write indefinitely, doubling
+mnemo's footprint inside the vault and producing two parallel
+graph hairballs (one for the v1 root-level dirs, one for `_mnemo/`).
+
+To prevent silent indefinite dual-write:
+
+- A `vault_layout_first_seen` timestamp is written to `~/.mnemo/state.json`
+  the first sync mnemo observes the active layout (separate from
+  `~/.mnemo/config.json` so the user does not edit it).
+- While `vault_layout == "both"`:
+  - The first sync after **30 days** of soak emits a structured warning
+    log: `vault_layout="both" for N days — opt into "v2" or run
+    mnemo_vault_gc_legacy to finish migrating`.
+  - `mnemo_vault_status` surfaces `vault_layout`, `days_in_both`, and a
+    recommendation (`"opt into v2"`, `"run gc_legacy"`, `"still within
+    soak"`) on every call. The user sees the state without enabling
+    debug logging.
+  - The warning repeats on a weekly cadence afterwards, never
+    auto-promoting the layout. The user retains the timing decision.
+- The soak window is configurable via `vault_layout.soak_warn_after`
+  (default `"720h"` = 30 days). A user who genuinely wants long-running
+  dual-write sets the value higher; the warning is suppressed
+  accordingly.
+
+The recommendation surface is one-way (warn, never auto-narrow): the v1
+data may still be load-bearing for a workflow we cannot infer. The
+"`both` during soak" review question raised on PR #95 is resolved by
+this TTL/visibility mechanism plus the explicit `gc_legacy` tool —
+there is no auto-deletion, but there is no silent forever-dual-write
+either.
+
+#### Recommendation state machine
+
+The `mnemo_vault_status.vault_layout.recommendation` string takes
+one of four values, deterministic from observable state:
+
+| Observed state                                                                 | Recommendation       |
+|--------------------------------------------------------------------------------|----------------------|
+| `vault_layout == "both"` AND `hours_in_both < soak_warn_after_hours`           | `"still within soak"` |
+| `vault_layout == "both"` AND `hours_in_both ≥ soak_warn_after_hours`           | `"opt into v2"`       |
+| `vault_layout == "v2"` AND v1 root-level dirs still present in the vault       | `"run gc_legacy"`     |
+| any other state                                                                | `""` (empty)          |
+
+`hours_in_both` is derived from `state.json.vault_layout_first_seen.both`;
+`soak_warn_after_hours` is the parsed duration of
+`vault_layout.soak_warn_after` (default `"720h"`). The comparison
+is done in hours throughout to avoid integer-day rounding errors
+near the soak boundary. `days_in_both` exposed on the status response
+is `hours_in_both ÷ 24` rounded to the nearest integer.
+
+The empty-recommendation row covers: `vault_layout == "v1"` (no
+migration owed); `vault_layout == "v2"` with no v1 leftovers
+(migration complete); `vault_layout == "both"` with no v1 dirs
+present yet (transient first-sync state — v1 dirs get created on
+the same sync; subsequent sync flips to one of the warn rows).
+
+Transitions are observation-driven: the recommendation is
+recomputed each `mnemo_vault_status` call and each sync. There is
+no persistent state machine in the daemon — the recommendation is
+a pure function of the observable state. A user who runs
+`gc_legacy` and removes the v1 dirs gets the empty recommendation
+on the next status call, no manual reset needed.
+
+---
+
+## Operational invariants
+
+A small set of invariants the implementation honours across the whole
+design. Each is testable in CI.
+
+### Daemon-managed state file (`state.json`)
+
+`~/.mnemo/state.json` is a daemon-managed sidecar that holds
+runtime-derived state that should not pollute the user-editable
+`config.json` but must survive daemon restarts. It is created on
+first daemon boot post-Slice 1 with empty defaults; it is read on
+every boot and written atomically (`tmp + rename`) whenever a
+tracked field changes.
+
+Schema (additive only — new fields appear over time, old ones never
+disappear silently):
+
+```json
+{
+  "version": 1,
+  "vault_path": "~/Documents/PKM",
+  "vault_layout_first_seen": {
+    "v1":   "2025-11-04T09:12:33Z",
+    "both": "2026-05-22T14:01:55Z",
+    "v2":   null
+  },
+  "indexing_scope_first_seen": {
+    "_mnemo_only": null,
+    "full":        "2025-11-04T09:12:33Z",
+    "includes":    null
+  },
+  "embedding_fingerprint": null,
+  "last_cluster_run_id": 184,
+  "broken_templates": [],
+  "bridge_errors":    []
+}
+```
+
+`embedding_fingerprint` is `null` when the active clustering engine
+is `"heuristic"`. When the user opts into `"embeddings"`, the
+fingerprint object materialises on the next pass:
+
+```json
+"embedding_fingerprint": {
+  "provider": "voyage",
+  "model":    "voyage-3-lite",
+  "version":  "2025-09",
+  "last_used": "2026-05-22T14:01:55Z"
+}
+```
+
+`vault_path` records the path mnemo wrote against on the most
+recent sync. The "`vault_path` change semantics" rule compares the
+new config-loaded `vault_path` against this recorded value to
+detect a change and reset the soak-TTL counters.
+
+`last_cluster_run_id` mirrors `cluster_runs.id` for the most
+recent successful pass; the daemon uses it on boot to detect
+whether a pass was in progress at last shutdown without scanning
+the table.
+
+Properties:
+
+- Single-user. The library wing serves the local daemon's single
+  user; team-mnemo (T36) maintains its own per-user sidecars in a
+  different location.
+- Forbidden as a configuration surface. Users edit `config.json`,
+  never `state.json`. `mnemo_vault_status` exposes a read view if
+  the user wants to inspect.
+- Atomic writes. Implementations write `~/.mnemo/.state.json.tmp`
+  on the same filesystem, `fsync`, then `rename` over
+  `~/.mnemo/state.json`. The tempfile uses the same leading-dot
+  convention as the in-vault rendered files. A daemon crash
+  mid-write leaves at most one stale `.state.json.tmp`, swept on
+  next boot before any new write begins.
+- Version handling. The top-level `version` integer governs
+  schema-shape changes that go beyond additive-field. Rules:
+  - Daemon reads `state.json` with `version == X`. If `X` equals
+    the daemon's known version, proceed normally.
+  - If `X` is below the daemon's known version, the daemon
+    upgrades the file in place (migration functions registered per
+    version step; rewrite atomically; bump `version`).
+  - If `X` is above the daemon's known version (running an older
+    binary against newer state), the daemon refuses to write
+    `state.json` for this boot and runs in **read-only state mode**
+    — soak-TTL counters report against the recorded data but no
+    new layout transitions are persisted. Logs prominent warning
+    so the user can choose to upgrade the binary or revert the
+    state file from backup. Refusing-to-write prevents the older
+    daemon from silently dropping fields it does not understand.
+- Forward compatibility within a version. Unknown top-level keys
+  inside a known `version` are preserved on rewrite (read as
+  opaque, written back verbatim) so a newer daemon's additions
+  survive a downgrade-then-upgrade cycle.
+- Concurrency. Only one daemon process per user is supported; a
+  second process attempting to start with `state.json` already
+  locked aborts with a clear error rather than racing.
+
+### Sync atomicity
+
+The renderer never leaves the vault in a torn state. Every generated
+file follows the same write protocol:
+
+1. Render the new content in memory (including the regenerated
+   above-fence block and the preserved below-fence content read at
+   the start of the cycle).
+2. Write to a sibling tempfile `.<name>.mnemo.tmp` in the target
+   directory. The leading-dot prefix is intentional: most PKM tools
+   (Obsidian, Logseq, Foam) skip dotfiles when building their note
+   index and graph view, so a half-written `.foo.md.mnemo.tmp` does
+   not transiently appear as a broken note even if the user's PKM
+   tool scans the directory during the rename window.
+3. `fsync` the tempfile.
+4. `rename` over the destination — atomic on every supported
+   filesystem.
+5. Remove any stale `.<name>.mnemo.tmp` from a prior crashed run on
+   startup, before any new write begins.
+
+The bridge writer follows the same protocol against the anchor
+file with one additional rule: the anchor file is rewritten **as a
+whole**, not edited in place. The writer reads the existing anchor
+file, splices the new fenced block(s) into the read content
+(preserving every byte outside the bridge fences), writes the
+spliced result to a sibling `.<name>.mnemo.tmp`, fsyncs, and
+renames. Atomic-rename gives whole-file atomicity; the in-memory
+splice gives fence-boundary correctness. A reader of the anchor
+file at any moment sees either the old whole or the new whole,
+never a mix.
+
+Concurrent reads from the user's PKM tool always observe a
+complete file with matching fences. A daemon crash mid-sync
+leaves at most one extra `.tmp` file, swept on next boot.
+
+### `vault_path` change semantics
+
+Hot-reload of `vault_path` is permitted (via `mnemo_config`) with
+explicit semantics:
+
+- The old `vault_path` is **not** auto-migrated to the new location.
+  Files at the old path remain where they are; mnemo simply stops
+  writing there.
+- The new path is treated as a fresh vault: the same auto-detect
+  rules run (v1 dirs present? `_mnemo/` present? profile signal
+  files?). Defaults seed accordingly.
+- `state.json` records the change in `vault_layout_first_seen` /
+  `indexing_scope_first_seen` against the new path's detected
+  layout, so soak-TTL counters reset.
+- `mnemo_vault_status` reports the change at the next call. A
+  warning surfaces if the old path still contains a `_mnemo/`
+  wing — the user is informed but mnemo takes no action.
+
+The "don't auto-migrate" rule is deliberate: cross-path moves can
+cross filesystems / mountpoints / sync providers (Dropbox, iCloud)
+where mnemo cannot guarantee write semantics. A user who wants the
+content moved does so themselves before pointing `vault_path`.
+
+### `_mnemo/` self-exclusion from ingest
+
+The path-exclusion registry (PR #78) is updated on every
+`vault_path` change to include the new `_mnemo/` location. This
+prevents mnemo from re-ingesting its own output as session corpus —
+a v1 footgun. The exclusion is observable via
+`mnemo_vault_status.excluded_paths`.
+
+### Back-pressure on clustering pass output
+
+Several sections demand caps (`max_themes`, `max_cross_repo`,
+`vault_bridges.max_links`). The implementation enforces them
+**before** the expensive work:
+
+- Embedding pass cost is bounded by the total corpus size at the
+  active (provider, model, model_version) fingerprint — every
+  embed call corresponds to one cache miss, never speculative
+  over-embedding. Caps on cluster count do not prevent corpus
+  vectorisation (every member of every cluster still needs a
+  vector) — they prevent unbounded *page emission* and *LLM
+  labelling*, which are the next two bullets.
+- Renderer hard-caps page emission per pass: themes ranked by
+  weight, excess kept in the `themes` table but not rendered. The
+  capped themes are listed in `_mnemo/themes/_index.md` under
+  "Below cap (not rendered)" so the user sees the cap is binding.
+- LLM labelling is invoked at most `max_themes` times per pass;
+  excess clusters use the bigram fallback even if LLM labelling is
+  otherwise enabled.
+- Bridge writer truncates lists at `vault_bridges.max_links` and
+  appends a "(N more, see <collection>/_index.md)" trailing line so
+  the truncation is visible.
+
+### `mnemo_vault_status` response schema
+
+The status tool is the single canonical surface for everything the
+design demands users be able to observe. It is consulted in dozens
+of places throughout this doc; the schema lives here so
+implementers do not have to grep.
+
+```json
+{
+  "vault_path": "~/Documents/PKM",
+  "vault_path_exists": true,
+  "vault_profile": {
+    "active":         "obsidian",
+    "source":         "auto-detect",
+    "signal_file":    ".obsidian/workspace.json",
+    "signal_mtime":   "2026-05-15T08:11:02Z",
+    "alternatives":   [
+      { "profile": "logseq", "signal_mtime": "2024-11-03T17:55:08Z" }
+    ]
+  },
+  "vault_layout": {
+    "active":          "both",
+    "first_seen":      "2026-05-01T09:12:33Z",
+    "days_in_both":    22,
+    "recommendation":  "still within soak",
+    "soak_warn_after_hours": 720
+  },
+  "indexing_scope": {
+    "active":         "full",
+    "includes":       [],
+    "ignore_file":    ".mnemoignore",
+    "external_files_indexed": 1284
+  },
+  "abstractions": {
+    "themes":     { "rendered": 47,  "archived": 6, "below_cap": 0 },
+    "patterns":   { "rendered": 18,  "below_cap": 0 },
+    "cross-repo": { "rendered": 11 },
+    "lessons":    { "rendered": 23 },
+    "decisions":  { "rendered": 156 },
+    "memories":   { "rendered": 84 }
+  },
+  "v1_leftovers": { "sessions": 412, "ci": 53, "prs": 89, "repos": 7 },
+  "last_cluster_run": {
+    "id":             184,
+    "started_at":     "2026-05-22T13:58:30Z",
+    "ended_at":       "2026-05-22T13:58:32Z",
+    "engine":         "heuristic",
+    "estimated_cost": 0.0,
+    "trigger":        "interval"
+  },
+  "embedding_fingerprint": null,
+  "broken_templates":  [],
+  "bridge_errors":     [],
+  "excluded_paths":    ["~/Documents/PKM/_mnemo", "~/Documents/PKM/.git"],
+  "warnings":          []
+}
+```
+
+The `embedding_fingerprint` field is `null` whenever the active
+clustering engine is `"heuristic"` (matching the `state.json` rule
+above). When the user opts into `"embeddings"`, the field
+materialises:
+
+```json
+"embedding_fingerprint": {
+  "provider":  "voyage",
+  "model":     "voyage-3-lite",
+  "version":   "2025-09",
+  "last_used": "2026-05-22T13:58:32Z"
+}
+```
+
+`abstractions.themes` reports both `rendered` (live in
+`_mnemo/themes/`) and `archived` (live in `_mnemo/themes/_archive/`
+per the retirement rule).
+
+Entry shapes for the array fields:
+
+```json
+"broken_templates": [
+  {
+    "template_path": "~/.mnemo/vault_templates/v2/theme.tmpl",
+    "entity_type":   "theme",
+    "phase":         "parse" | "execute",
+    "error":         "undefined field .Repos at line 14"
+  }
+]
+
+"bridge_errors": [
+  {
+    "name":         "themes",
+    "anchor_path":  "10-areas/knowledge/Themes MOC.md",
+    "reason":       "unknown_collection" | "anchor_unwritable" | "duplicate_fence" | "anchor_create_failed",
+    "detail":       "permission denied (ENOENT on parent)"
+  }
+]
+
+"warnings": [
+  {
+    "code":      "embedding_model_changed",
+    "message":   "embedding model changed from voyage-3-lite to voyage-3; clusters will be regenerated",
+    "since":     "2026-05-22T14:01:55Z"
+  }
+]
+```
+
+All fields are stable across daemon restarts insofar as the
+underlying state permits. New fields are additive; old fields never
+disappear silently.
+
+`warnings[]` is the bucket for one-off transient signals — broken
+state, recent crash recovery, soak past the warning threshold.
+Implementers should prefer surfacing structured state in the typed
+fields above and reserve `warnings[]` for things that genuinely do
+not fit.
 
 ---
 
@@ -651,9 +1400,15 @@ section), adapted for filesystem rather than schema.
   - If `_mnemo/` exists and any v1 root-level dirs (`sessions/`, `decisions/`,
     etc.) exist → assume in-progress migration; honour configured `vault_layout`.
   - If v1 dirs exist and `_mnemo/` does not → new release on existing vault;
-    auto-default `vault_layout` to `"both"`; emit `_mnemo/MIGRATION.md`
-    explaining the change, what to expect, and how to opt fully in.
+    auto-default `vault_layout` to `"both"`; **write-once** emit
+    `_mnemo/MIGRATION.md` explaining the change, what to expect, and how
+    to opt fully in. The MIGRATION.md doc is never regenerated; once
+    written or deleted by the user, mnemo does not touch it again.
   - If neither → new vault; default `vault_layout` to `"v2"`.
+- On every startup that observes a layout transition (especially into
+  `"both"`), update `~/.mnemo/state.json` with `vault_layout_first_seen`
+  for that layout value, used by the "both" soak-TTL warning logic
+  documented under the configuration section.
 - v1 paths continue to be written when `vault_layout` is `"both"` or `"v1"`.
   Above-fence content stays fresh. Below-fence annotations are preserved
   exactly as in v1.
@@ -670,6 +1425,16 @@ section), adapted for filesystem rather than schema.
   original path and harvested annotation text). The user's annotations
   remain reachable through search even if they later `rm -rf <vault>/sessions/`
   manually.
+  - **Pagination.** If the aggregate would exceed
+    `vault_legacy_annotations.max_file_kb` (default 512 KB), the
+    sweep splits into numbered files
+    (`legacy-annotations-001.md`, `-002.md`, …) grouped by source
+    subdir (`sessions/`, `ci/`, `prs/`, …) so the per-file table
+    of contents stays navigable. An index page
+    `_mnemo/legacy-annotations.md` lists the parts when split.
+    Files that contain zero below-fence content are omitted from
+    the aggregate entirely (a v1 dir of pure generated content
+    has nothing to harvest).
 - `mnemo_vault_status` reports "v1 dirs present but unused; safe to delete
   after verifying legacy-annotations.md".
 
@@ -698,8 +1463,8 @@ No automatic deletion. The user owns the timing.
   until they choose. Phase 2: opts into `"v2"` at their pace; annotations
   harvested. Phase 3: optionally runs `mnemo_vault_gc_legacy` to clean up.
 - **Archetype E (power user).** Drops templates into
-  `~/.mnemo/vault_templates/` once layout v2 stabilises. No interaction
-  with the migration path.
+  `~/.mnemo/vault_templates/v2/` once layout v2 stabilises. No
+  interaction with the migration path.
 - **Archetype F (casual reader).** Opens `_mnemo/index.md`. Finds themes,
   patterns, lessons. Does nothing else.
 
@@ -709,36 +1474,10 @@ No automatic deletion. The user owns the timing.
 
 Nine slices. Each is independently shippable, reviewable, and reversible.
 
-### Slice 1 — `_mnemo/` namespace + layout config
+Slices 1–4 form the **MVP v2** boundary — coherent and shippable on its
+own. Slices 5–9 are independent follow-ups, not a single arc.
 
-Plumbs the new directory root and the `vault_layout` config key. No new
-abstractions yet. v1 writers retained, gated on `vault_layout`. Adds
-`_mnemo/index.md` and `_mnemo/README.md` as static-ish content.
-
-*Value:* nothing user-visible yet, but establishes the namespace and lets
-later slices write into it. Required precondition for everything else.
-
-### Slice 2 — move decisions + memories under `_mnemo/`
-
-Re-render the two existing abstractions (decisions, memories) under their
-new paths inside `_mnemo/`. Above-fence content gets the new frontmatter
-shape. Old v1 decision/memory files are still written when
-`vault_layout="both"`.
-
-*Value:* the two existing semantic exports become available in the new
-layout. Validates the rendering shape, frontmatter, and graph topology
-before more abstractions are added.
-
-### Slice 3 — drop session/CI/PR/repo writers from `_mnemo/`
-
-When `vault_layout="v2"`, do not write session, CI, PR, or repo-index pages
-to `_mnemo/`. v1 paths continue to honour the old behaviour under
-`vault_layout="both"` or `"v1"`.
-
-*Value:* validates the principle that raw signal stays in SQLite. The user
-opting into v2 immediately sees a calmer, smaller wing.
-
-### Slice 4 — indexing scope + `.mnemoignore`
+### Slice 1 — indexing scope + `.mnemoignore` (consent fix)
 
 Introduce `vault_indexing_scope`, `vault_indexing_includes`, and
 `vault_indexing_ignore_file` config keys. Refactor `IngestVaultAnnotations`
@@ -746,6 +1485,15 @@ to walk only the configured scope. Implement gitignore-syntax matcher
 against the `.mnemoignore` file. Wire migration defaults: new vaults
 default to `"_mnemo_only"`; existing v1-populated vaults default to
 `"full"` for continuity. Report active scope in `mnemo_vault_status`.
+
+This slice lands **first**, ahead of any `_mnemo/` namespace work, because
+it is the only slice in the plan that fixes a real shipped *bug* — v1's
+silent full-vault read without user consent. The fix is independently
+correct even before the rest of the redesign exists. New vaults get the
+default `"_mnemo_only"` scope (which trivially reads nothing while
+`_mnemo/` does not yet exist); existing v1 vaults keep `"full"` semantics
+for continuity. Either way, the user-visible behaviour is the right one
+from day one of the v2 release window.
 
 Reuse `trees_of_interest` + `doc_tree_refs` (landed via T53, PR #91)
 for the multi-tree case. Each configured scope produces one or more
@@ -771,12 +1519,52 @@ which both depend on a well-defined read surface. Building on T53
 instead of inventing a parallel mechanism keeps the data model lean
 and reuses tested code.
 
+### Slice 2 — `_mnemo/` namespace + layout config
+
+Plumbs the new directory root and the `vault_layout` config key. No new
+abstractions yet. v1 writers retained, gated on `vault_layout`. Adds
+`_mnemo/index.md` and `_mnemo/README.md` as static-ish content.
+
+*Value:* nothing user-visible yet, but establishes the namespace and lets
+later slices write into it. Required precondition for everything below
+Slice 4.
+
+### Slice 3 — move decisions + memories under `_mnemo/`
+
+Re-render the two existing abstractions (decisions, memories) under their
+new paths inside `_mnemo/`. Above-fence content gets the new frontmatter
+shape. Old v1 decision/memory files are still written when
+`vault_layout="both"`.
+
+*Value:* the two existing semantic exports become available in the new
+layout. Validates the rendering shape, frontmatter, and graph topology
+before more abstractions are added.
+
+### Slice 4 — drop session/CI/PR/repo writers from `_mnemo/`
+
+When `vault_layout="v2"`, do not write session, CI, PR, or repo-index pages
+to `_mnemo/`. v1 paths continue to honour the old behaviour under
+`vault_layout="both"` or `"v1"`.
+
+*Value:* validates the principle that raw signal stays in SQLite. The user
+opting into v2 immediately sees a calmer, smaller wing.
+
+**Slices 1–4 are the MVP v2 boundary.** After Slice 4, the wing is
+consent-correct, namespaced, and free of raw-signal noise. Each of
+Slices 5–9 below ships independently afterwards.
+
 ### Slice 5 — PKM profile + auto-detect
 
 Introduce the `vault_profile` config key, the per-profile renderer hooks,
-and the auto-detect-from-vault-contents logic.
+and the auto-detect logic. Detection uses **mtime of the canonical
+signal files** (`.obsidian/workspace.json`, `logseq/config/config.edn`,
+`.foam/settings.json`), not directory presence — see "PKM profile" in
+the Architecture section for the full rule. The detected profile, the
+signal file path, and its mtime are recorded in `mnemo_vault_status`.
 
-*Value:* Logseq/Foam/generic users get a usable wing.
+*Value:* Logseq/Foam/generic users get a usable wing. Multi-tool PKM
+users (Obsidian + Logseq on the same directory) are detected by
+recent-activity, not first-open accident.
 
 ### Slice 6 — bridges
 
@@ -791,21 +1579,52 @@ MOCs without invading.
 ### Slice 7 — patterns (persisted + rendered)
 
 Promote `mnemo_discover_patterns` from live-queried to persisted. New
-`patterns` table (additive, append-only per schema policy). Renderer
-emits `_mnemo/patterns/` pages.
+`patterns` table (additive, append-only per schema policy):
+
+```sql
+CREATE TABLE patterns (
+  id              TEXT PRIMARY KEY,         -- pattern_<sha1(type+canonical_signature)[:8]>
+  pattern_type    TEXT NOT NULL,            -- "direct_jsonl_read" | "repeated_query_shape" | ...
+  signature       TEXT NOT NULL,            -- canonicalised input snippet that defines the pattern
+  occurrence_count INTEGER NOT NULL,
+  session_count   INTEGER NOT NULL,         -- distinct sessions where pattern observed
+  repos           TEXT NOT NULL,            -- JSON array of repo names
+  first_seen      TEXT NOT NULL,
+  last_seen       TEXT NOT NULL,
+  representative_excerpts TEXT NOT NULL,    -- JSON array of excerpt strings
+  computed_at     TEXT NOT NULL
+);
+
+CREATE VIRTUAL TABLE patterns_fts USING fts5(
+  pattern_type, signature, representative_excerpts,
+  content='patterns', content_rowid='rowid'
+);
+```
+
+Renderer emits `_mnemo/patterns/` pages for patterns meeting the
+`occurrence ≥ 3` and `session_count ≥ 2` threshold (carried over
+from the live `mnemo_discover_patterns` filter).
 
 *Value:* first new abstraction. Patterns are the cheapest abstraction to
 extract (purely heuristic) and the highest signal per unit effort.
+Slice 8's clustering corpus (`vault-clustering.md` Inputs §3) reads
+this table directly.
 
 ### Slice 8 — themes + cross-repo (clustering engine)
 
-The research-shaped slice. Embedding-based clustering over decisions +
-compaction summaries, plus indexed user content when scope permits. New
-`themes` table (additive). Cross-repo pages derived from themes with
-repo set ≥ 2.
+The research-shaped slice. Two-engine clustering pipeline over
+decisions + compaction summaries + persisted patterns (Slice 7) +
+indexed user content when scope permits. The **heuristic engine**
+(TF-IDF + single-link agglomerative) is the default and ships first;
+the **embeddings engine** is opt-in (per T63 egress posture) and
+reuses single-link clustering downstream of vectorisation. HDBSCAN
+is deferred. New tables: `themes`, `theme_members`,
+`cluster_embeddings`, `themes_fts`, `cluster_runs`, `theme_overrides`,
+`theme_pins` (additive). Cross-repo pages derived from themes with
+repo set ≥ 2 and weight ≥ 4.0.
 
-This slice carries the most risk and warrants its own subordinate design
-document (`docs/design/vault-clustering.md`) once Slice 7 lands.
+This slice carries the most risk and is governed by the subordinate
+design document `docs/design/vault-clustering.md`.
 
 *Value:* the core promise of the redesign. Without themes, the wing is a
 better-organised v1; with themes, it is genuinely new.
@@ -813,23 +1632,46 @@ better-organised v1; with themes, it is genuinely new.
 ### Slice 9 — lessons + GC tool
 
 Lessons extractor (feedback memories + confirmed-and-surviving decisions).
-`mnemo_vault_gc_legacy` tool. `_mnemo/legacy-annotations.md` harvester.
+`mnemo_vault_gc_legacy` tool. `mnemo_vault_migration_doc` tool (opt-in
+regen of MIGRATION.md per the fence-contract exception).
+`_mnemo/legacy-annotations.md` harvester.
 
 *Value:* completes the abstraction set and gives Archetype D users a
 clean migration path off v1.
 
+### MCP tool inventory (cross-slice)
+
+Every new MCP tool introduced by this design, indexed by the slice
+that owns it. Implementers should treat this as the canonical
+checklist — an item missing from a slice's PR is a slice not done.
+
+| Tool                                | Slice | Purpose                                                 |
+|-------------------------------------|-------|---------------------------------------------------------|
+| (config keys via existing `mnemo_config`) | 1 | indexing-scope keys land via the existing hot-reload  |
+| `mnemo_vault_status` (extended)     | 1+    | reports active layout, profile, scope, indexed-file count outside `_mnemo/`, soak-TTL recommendation, broken-template list, bridge errors, last `cluster_runs` row. Single canonical surface — see "`mnemo_vault_status` response schema" below. |
+| `mnemo_vault_bridge_list`           | 6     | inspect active bridges and their anchor files           |
+| `mnemo_vault_recluster`             | 8     | trigger an immediate clustering pass. Params: `engine` optional override (`"heuristic"`/`"embeddings"`); `force_reembed: bool` (default false) to invalidate the active-fingerprint cache rows and re-embed cleanly — useful when a provider silently revises a model under the same version string. Returns the new `cluster_runs` row. |
+| `mnemo_vault_themes_inspect`        | 8     | full member list + distances + centroid + labelling source for a theme slug or ID |
+| `mnemo_vault_themes_split`          | 8+    | mark theme for split on next pass; persisted in `theme_overrides` |
+| `mnemo_vault_themes_merge`          | 8+    | inverse of split                                        |
+| `mnemo_vault_themes_pin`            | 8+    | mark theme as never-auto-retire; persisted in `theme_pins` |
+| `mnemo_vault_gc_legacy`             | 9     | user-initiated deletion of v1 root-level dirs after annotation-safety check |
+| `mnemo_vault_migration_doc`         | 9     | opt-in regen of `_mnemo/MIGRATION.md` (write-once exception to the fence contract) |
+
 ### Templates (cross-cutting)
 
-Shipped between Slice 3 and Slice 5 as a refactor: the renderer is
-restructured to load templates from `~/.mnemo/vault_templates/` with
-embedded defaults. No user-facing change at landing; unblocks Archetype E
+Shipped between Slice 4 and Slice 5 as a refactor: the renderer is
+restructured to load templates from `~/.mnemo/vault_templates/v2/`
+with embedded defaults. Validation runs at startup; broken
+user templates surface in `mnemo_vault_status` rather than silently
+falling back. No user-facing change at landing; unblocks Archetype E
 once layout v2 is stable.
 
 ---
 
 ## Risks and open questions
 
-### Indexing-scope consent migration (Slice 4)
+### Indexing-scope consent migration (Slice 1)
 
 v1 effectively shipped in `"full"` scope without an opt-in. Some users
 may rely on `mnemo_search` returning hits from notes they deliberately
@@ -871,9 +1713,12 @@ Themes are the riskiest abstraction. Bad clusters look like:
   theme).
 - Labels that are vague or misleading ("various topics").
 
-**Mitigation:** ship Slice 8 behind a `vault_clustering.engine=heuristic`
-fallback (TF-IDF + jaccard over n-grams, no embeddings). Document the
-known failure modes. Allow `min_cluster_weight` tuning. Provide
+**Mitigation:** Slice 8 ships with the heuristic engine
+(`vault_clustering.engine="heuristic"`) as the **default and the
+realistic engine**, not a fallback. The embeddings engine is an opt-in
+addition. The heuristic engine is explicitly designed to be non-toy
+(see `docs/design/vault-clustering.md` Engine B). Document the known
+failure modes. Allow `min_cluster_weight` tuning. Provide
 `mnemo_vault_themes_inspect` for users to see cluster membership and
 flag misclusters.
 
@@ -885,8 +1730,17 @@ deployments (team-mnemo, T36), the cross-repo surface area becomes a
 policy question.
 
 **Resolution:** out of scope here. team-mnemo's access model governs that
-case. For single-user vaults, all content is the same user's, so the
-question does not arise.
+case. For single-user vaults, all content is the same user's — but
+that does not mean it is all of the same *domain*. A solo user's
+vault commonly mixes work, personal, and side-project content; a
+theme that surfaces a cluster spanning work decisions and personal
+journal notes can be unwelcome even if technically owned by the
+same user. `.mnemoignore` is the user's only knob for this case:
+add `personal/`, `journal/`, or similar to keep them out of the
+clustering corpus. `mnemo_vault_status.indexing_scope.external_files_indexed`
+exposes how many user notes are reaching the corpus so the user
+can audit the surface area. Per-note `mnemo: ignore` (out-of-scope
+follow-up) will be the finer-grained knob.
 
 ### Embedding cost
 
@@ -894,20 +1748,25 @@ Computing embeddings for every decision summary and compaction span at
 each clustering pass is bounded but not free. A user with 1000 sessions ×
 several decisions each is plausible.
 
-**Resolution:** cache embeddings keyed by (entity_kind, entity_id,
-content_hash). Recompute only on content change. Estimated cost for the
-median user is single-digit cents per re-cluster. For users without an
-embedding API key, the heuristic engine handles the corpus.
+**Resolution:** cache embeddings keyed by `(doc_kind, entity_id,
+content_hash, provider, model, model_version)`. Recompute only when any
+of those change; a model swap leaves the prior rows in the cache for
+revert. Estimated cost for the median user is single-digit cents per
+re-cluster. For users who do not opt into the embeddings engine, the
+heuristic engine handles the corpus with zero external calls.
 
 ### Profile auto-detect false positives
 
-A vault containing `.obsidian/` because the user opened it once in Obsidian
-but actually uses Logseq daily would be mis-detected.
+A vault containing `.obsidian/` because the user opened it once in
+Obsidian but actually uses Logseq daily would be mis-detected by a
+mere-presence check.
 
-**Resolution:** `vault_profile` config key always wins. Profile detection
-result is logged at startup. Future enhancement: detect more strongly by
-looking for tool-specific *content* signatures (Logseq `journals/` with
-recent edits, Obsidian `.obsidian/workspace.json` with recent activity).
+**Resolution:** detection is by **mtime of the canonical signal file**,
+not directory presence (see "PKM profile" above). The
+most-recently-modified signal file wins; ties tip towards Obsidian.
+Result is recorded in `mnemo_vault_status` with the signal file path
+and mtime so the user can audit. `vault_profile` config key always
+overrides regardless of auto-detect.
 
 ### `_mnemo/` collides with user's own folder
 
@@ -924,15 +1783,25 @@ with an error. Require the user to rename or move their folder, or point
 A user has both `_mnemo/` (from a previous run) and v1 root-level dirs
 (from an even earlier run). Which is current?
 
-**Resolution:** treat as `vault_layout="both"` until the user explicitly
-sets it. `MIGRATION.md` documents the state and asks them to choose.
+**Resolution:** two orthogonal keys, two defaults:
+
+- `vault_layout` — defaults to `"both"` until the user explicitly sets
+  it. Continued dual-write is the safe choice; the soak-TTL warning
+  kicks in after 30 days.
+- `vault_indexing_scope` — if unset, defaults to `"full"` (continuity
+  with the v1 vault's effective read scope).
+
+These resolve independently because they govern different surfaces
+(write vs. read). `MIGRATION.md` documents both states and shows the
+one-line `mnemo_config` calls to commit either way.
 
 ---
 
 ## Success metrics
 
 These determine whether the design delivered its promised value once
-shipped. Reviewable post-launch.
+shipped. All are **[metric]** rather than gates — reviewable in the
+post-launch retro, not blocking on slice landing.
 
 - **For new users:** ≥ 90% of new vault configurations land on `v2` without
   any `vault_*` config beyond `vault_path`. Validated by surveying
@@ -967,7 +1836,7 @@ shipped. Reviewable post-launch.
   via the template mechanism once core profiles ship.
 - **Block-level outliner support.** Logseq/Roam block refs. Distinct
   representational model; not pursued.
-- **Vault-as-input override layer.** Slice 4 makes the vault readable as
+- **Vault-as-input override layer.** Slice 1 makes the vault readable as
   clustering signal under `"full"` or `"includes"` scopes. A stronger
   step — treating specific curated user notes (e.g. hand-written
   `_mnemo/themes/foo.md` augmentations or user-promoted MOC pages) as
@@ -984,28 +1853,79 @@ shipped. Reviewable post-launch.
 ## Acceptance criteria
 
 The work covered by this design is considered complete when all of the
-following are true:
+following are true. Each item is marked **[gate]** (ship-blocking,
+CI-testable) or **[metric]** (post-launch signal, validated
+qualitatively or via survey). A slice does not ship without its
+gates passing; metrics are reviewed in the post-launch retro.
 
-1. `<vault>/_mnemo/` is the only directory written by mnemo for new vault
-   configurations.
-2. Existing v1 vaults can be migrated to v2 with zero annotation loss and
-   user-paced timing.
-3. Themes, patterns, cross-repo, lessons, decisions (filtered), and
-   memories are all materialised under `_mnemo/`.
-4. The wing renders correctly in Obsidian, Logseq, Foam, and a plain
-   Markdown editor without per-tool configuration.
-5. Bridges work end-to-end against at least Obsidian and Logseq.
-6. Template overrides work for at least one entity type end-to-end.
-7. `mnemo_vault_status` reports layout, profile, indexing scope,
-   abstraction counts, count of indexed user files outside `_mnemo/`,
-   and any v1 leftovers.
-8. `mnemo_vault_gc_legacy` removes v1 leftovers after annotation safety
-   check.
-9. Indexing scope defaults to `"_mnemo_only"` on new vaults and `"full"`
-   on v1-populated vaults at upgrade; both behaviours covered by tests.
-10. `.mnemoignore` (gitignore syntax) is honoured at vault root in
-    `"full"` and `"includes"` scopes; verified by tests including
-    nested-pattern cases.
+1. **[gate]** `<vault>/_mnemo/` is the only directory written by mnemo
+   for new vault configurations.
+2. **[gate]** Existing v1 vaults can be migrated to v2 with zero
+   annotation loss and user-paced timing.
+3. **[gate]** Themes, patterns, cross-repo, lessons, decisions
+   (filtered), and memories are all materialised under `_mnemo/`.
+4. **[gate]** The wing renders correctly in Obsidian, Logseq, Foam, and
+   a plain Markdown editor without per-tool configuration. Verified by
+   golden-file tests per profile.
+5. **[gate]** Bridges work end-to-end against at least Obsidian and
+   Logseq.
+6. **[gate]** Template overrides work for at least one entity type
+   end-to-end.
+7. **[gate]** `mnemo_vault_status` returns the full schema documented in
+   "Operational invariants → `mnemo_vault_status` response schema",
+   including layout, profile, indexing scope, abstraction counts,
+   `external_files_indexed`, `v1_leftovers`, `embedding_fingerprint`,
+   `broken_templates`, `bridge_errors`.
+8. **[gate]** `mnemo_vault_gc_legacy` removes v1 leftovers after
+   annotation safety check.
+9. **[gate]** Indexing scope defaults to `"_mnemo_only"` on new vaults
+   and `"full"` on v1-populated vaults at upgrade; both behaviours
+   covered by tests.
+10. **[gate]** `.mnemoignore` (gitignore syntax) is honoured at vault
+    root in `"full"` and `"includes"` scopes; verified by tests
+    including nested-pattern cases and patterns inside `_mnemo/`.
+11. **[gate]** MVP v2 (Slices 1–4) is independently shippable and
+    reviewable as a coherent release. Slice 1 (indexing-scope consent
+    fix) lands ahead of any `_mnemo/` namespace work.
+12. **[gate]** `vault_layout="both"` triggers a structured warning +
+    status surface after the configured soak window (default 30 days).
+    The warning never auto-promotes or auto-deletes; the user owns the
+    timing.
+13. **[gate]** PKM profile auto-detect uses mtime of signal files
+    (`.obsidian/workspace.json`, `logseq/config/config.edn`,
+    `.foam/settings.json`), not directory presence. Tied vaults log
+    the alternative.
+14. **[gate]** `_mnemo/MIGRATION.md` is write-once and not regenerated.
+    `mnemo_vault_migration_doc` (Slice 9) exists for opt-in
+    regeneration.
+15. **[gate]** Custom templates live in `~/.mnemo/vault_templates/v2/`
+    and are validated at startup. A malformed user template surfaces
+    in `mnemo_vault_status.broken_templates` and does not silently
+    fall through to the embedded default.
+16. **[gate]** Bridge edge cases (missing fence, two bridges per
+    anchor, unknown bridge name, unwritable anchor) all have specified
+    behaviour matching the doc; verified by tests.
+17. **[gate]** Sync atomicity protocol holds: a daemon crashed
+    mid-write leaves no torn `<file>.md` and at most one
+    `.<name>.mnemo.tmp` per affected directory, cleaned on next boot.
+18. **[gate]** `state.json` survives daemon restart, supports forward-
+    and backward-compatible field set, and is never read or written
+    by user-facing config flows.
+19. **[gate]** Hot-reload of `vault_path` does not auto-migrate the old
+    location, seeds fresh defaults for the new path, and surfaces a
+    warning if a `_mnemo/` wing remains at the old path.
+20. **[gate]** Back-pressure: `max_themes`, `max_cross_repo`,
+    `vault_bridges.max_links` short-circuit the expensive paths
+    (embedding, LLM labelling, rendering) and not just the final
+    output stage.
+21. **[gate]** `_mnemo/` is registered with the path-exclusion
+    registry (PR #78) on every `vault_path` change, observable via
+    `mnemo_vault_status.excluded_paths`.
+22. **[gate]** Themes whose most recent member `ts` exceeds
+    `vault_clustering.retire_after` (default 180 days) move to
+    `_mnemo/themes/_archive/` on the next clustering pass. Themes
+    listed in `theme_pins` are never auto-retired regardless of age.
+    `mnemo_vault_themes_pin` adds and removes pins.
 
 ---
 
@@ -1028,7 +1948,7 @@ following are true:
   source of truth; sqlift's `AllowNone` gate is the enforcement
   mechanism.
 - **PR #91 / T53** (trees_of_interest + doc_tree_refs) — the
-  scope-as-trees model in Slice 4 reuses these tables. Each scope
+  scope-as-trees model in Slice 1 reuses these tables. Each scope
   becomes one or more tree roots; overlapping trees share content rows
   via doc_tree_refs.
 - **PR #86 / #87 / T61** (backup primitive + periodic backup worker) —

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -1,0 +1,161 @@
+# Convergence Targets
+
+Active targets tracked by mnemo's convergence machinery. Each
+target is a desired end-state with a status, a weight, and a
+description. Sub-targets (`T<n>.<m>`) belong to their parent and
+ship independently.
+
+---
+
+### 🎯T64 Vault library wing redesign (v2)
+
+- **Status**: identified
+- **Weight**: 10
+
+Parent target for the vault library wing redesign described in
+`docs/design/vault-library-wing.md`. Replaces the v1 raw-row export
+(PR #74, #77, #78) with a fenced `<vault>/_mnemo/` wing carrying
+second-order abstractions (themes, patterns, cross-repo,
+lessons, filtered decisions, memories). Subordinate clustering
+engine design lives in `docs/design/vault-clustering.md`.
+
+Ships as nine independently reviewable slices (T64.1–T64.9). MVP
+v2 boundary is T64.1–T64.4 — the wing is consent-correct,
+namespaced, and free of raw-signal noise after that subset lands.
+T64.5–T64.9 are independent follow-ups, not a single arc.
+
+### 🎯T64.1 Indexing scope + .mnemoignore (consent fix)
+
+- **Status**: identified
+- **Weight**: 3
+
+Introduce `vault_indexing_scope` (`"_mnemo_only"` | `"full"` |
+`"includes"`), `vault_indexing_includes`, and
+`vault_indexing_ignore_file` config keys. Refactor
+`IngestVaultAnnotations` to walk only the configured scope.
+Implement gitignore-syntax matcher.
+
+Lands ahead of any `_mnemo/` namespace work because it is the only
+slice in the plan that fixes a real shipped *bug* — v1's silent
+full-vault read without user consent. New vaults default
+`"_mnemo_only"`; existing v1 vaults default `"full"` for
+continuity. Reuses T53 `trees_of_interest` + `doc_tree_refs`.
+Reports active scope via `mnemo_vault_status`.
+
+### 🎯T64.2 `_mnemo/` namespace + vault_layout config
+
+- **Status**: identified
+- **Weight**: 2
+
+Plumb the new directory root and the `vault_layout` config key
+(`"v2"` | `"both"` | `"v1"`). v1 writers retained, gated on
+`vault_layout`. Add `_mnemo/index.md`, `_mnemo/README.md`, and the
+write-once `_mnemo/MIGRATION.md` exception for v1-detected vaults.
+Track `vault_layout_first_seen` in `~/.mnemo/state.json` for the
+soak-TTL warning. Surface `vault_layout`, `days_in_both`, and
+recommendation state in `mnemo_vault_status`.
+
+### 🎯T64.3 Move decisions + memories under _mnemo/
+
+- **Status**: identified
+- **Weight**: 2
+
+Re-render the two existing v1 abstractions (decisions, memories)
+under `_mnemo/decisions/` and `_mnemo/memories/`. Above-fence
+content gets the new frontmatter shape per the design's page
+shape. Old v1 decision/memory files still written when
+`vault_layout="both"`. Validates the rendering shape, frontmatter,
+graph topology, and atomic write protocol before more abstractions
+land.
+
+### 🎯T64.4 Drop session/CI/PR/repo writers from _mnemo/
+
+- **Status**: identified
+- **Weight**: 1
+
+When `vault_layout="v2"`, do not write session, CI, PR, or
+repo-index pages to `_mnemo/`. v1 paths continue under
+`vault_layout="both"` or `"v1"`. Validates the principle that raw
+signal stays in SQLite and is queried on demand. Marks the **MVP
+v2 boundary** — the wing is now calm, scoped, and
+consent-correct.
+
+### 🎯T64.5 PKM profile + auto-detect (mtime)
+
+- **Status**: identified
+- **Weight**: 2
+
+Introduce `vault_profile` config key (`"obsidian"` | `"logseq"` |
+`"foam"` | `"generic"`), per-profile renderer hooks, and
+auto-detect logic. Detection uses **mtime of the canonical signal
+files** (`.obsidian/workspace.json`, `logseq/config/config.edn`,
+`.foam/settings.json`), not directory presence — addresses
+multi-tool PKM users (Obsidian + Logseq on the same directory).
+Record detected profile + signal file + mtime in
+`mnemo_vault_status`.
+
+### 🎯T64.6 Bridges
+
+- **Status**: identified
+- **Weight**: 2
+
+`vault_bridges` config key mapping collection name → anchor-file
+path. Whole-file atomic write of bridge fences
+(`<!-- mnemo:bridge:<name> -->` … `<!-- /mnemo:bridge:<name> -->`)
+into named anchor files. Fail-soft on unknown collection names,
+duplicate fences, unwritable anchors, missing anchors (created on
+demand), bridge removal (strip block, leave file). Per-collection
+default renderings; templates can override per
+`bridge_<collection>.tmpl`. New MCP tool: `mnemo_vault_bridge_list`.
+
+### 🎯T64.7 Patterns (persisted + rendered)
+
+- **Status**: identified
+- **Weight**: 3
+
+Promote `mnemo_discover_patterns` from live-queried to persisted.
+New `patterns` + `patterns_fts` tables (additive, append-only per
+T49 schema policy). Renderer emits `_mnemo/patterns/` pages for
+patterns meeting `occurrence ≥ 3` AND `session_count ≥ 2`. First
+new abstraction; cheapest to extract; prerequisite for T64.8
+(patterns are one of four clustering inputs).
+
+### 🎯T64.8 Themes + cross-repo (clustering engine)
+
+- **Status**: identified
+- **Weight**: 5
+
+Two-engine clustering pipeline per `docs/design/vault-clustering.md`.
+Heuristic engine (TF-IDF + single-link agglomerative, fully local)
+is the default. Embeddings engine (Voyage AI vectors + same
+single-link downstream) is opt-in per T63 egress posture; HDBSCAN
+deferred until a pure-Go binding meets the correctness bar.
+
+New tables: `themes`, `theme_members`, `cluster_embeddings`,
+`themes_fts`, `cluster_runs`, `theme_overrides`, `theme_pins`.
+Cross-repo pages derived from themes with `len(repos) ≥ 2` AND
+`weight ≥ 4.0`. Label quality gates (centroid-closest, ≥200-token
+body, daily-note filename exclusion, title-content coherence).
+Theme retirement at `retire_after` (180 days default); pin via
+`mnemo_vault_themes_pin`. Two-key egress matrix
+(embeddings + LLM labelling independent opt-ins). New MCP tools:
+`mnemo_vault_recluster` (with `force_reembed`),
+`mnemo_vault_themes_inspect`, `mnemo_vault_themes_pin`. Stubs for
+`themes_split` / `themes_merge`.
+
+The research-shaped slice; carries the most risk. Subordinate
+design document is the canonical spec.
+
+### 🎯T64.9 Lessons + GC tool
+
+- **Status**: identified
+- **Weight**: 3
+
+Lessons extractor (feedback-type auto-memories + confirmed
+decisions surviving ≥ 2 weeks; clustered via the same engine as
+T64.8). New MCP tools: `mnemo_vault_gc_legacy` (user-initiated
+deletion of v1 root-level dirs after annotation-safety check),
+`mnemo_vault_migration_doc` (opt-in regen of write-once
+MIGRATION.md). `_mnemo/legacy-annotations.md` harvester with
+`max_file_kb` pagination. Completes the abstraction set and gives
+existing v1-vault users a clean off-ramp.


### PR DESCRIPTION
## Summary

Two design docs proposing the next major iteration of `vault_path`. **No code changes — design-only RFC.** v1's flat root-level vault export (PRs #74, #77, #78) becomes a fenced library wing under `<vault>/_mnemo/` carrying semantic abstractions extracted across sessions, repos, and projects rather than raw row dumps from SQLite tables.

- **`docs/design/vault-library-wing.md`** — parent design (~9-slice roadmap, 6 user archetypes, 3-phase migration aligned with project schema-policy pattern).
- **`docs/design/vault-clustering.md`** — subordinate design for Slice 8 (themes + cross-repo clustering engine; heuristic default, embeddings opt-in).

## Motivation

v1 has four structural problems for a human consumer of a PKM graph:

1. **Wrong abstraction layer** — exports one note per session/CI run/PR. That is signal, not knowledge.
2. **Invades the vault namespace** — `<vault>/sessions/`, `<vault>/decisions/`, etc. at vault root collide with PARA / Johnny Decimal / MOC-driven layouts.
3. **One PKM shape assumed** — Obsidian wikilinks, YAML frontmatter, flat folders. Logseq users get partial breakage; plain-Markdown users get foreign syntax.
4. **Hairball graph view** — every session links to every decision/CI/PR. No readable structure.

The redesign replaces the v1 layout with a hub-and-spoke library wing carrying only second-order abstractions (themes, patterns, cross-repo, lessons, filtered decisions, memories). Raw event data stays in SQLite, queryable via existing `mnemo_*` tools.

## Alignment with recent work

The docs reference and build on:

- **#74 / #77 / #78** — v1 vault export, hot-reload, path exclusion. Fence contract and ingest path reused.
- **#82 (T49)** — sqlift `AllowNone` schema policy. All new tables land in `internal/store/schema.sql` as pure additions.
- **#91 (T53)** — `trees_of_interest` + `doc_tree_refs`. Indexing scope's `"includes"` mode reuses this directly; no parallel mechanism invented.
- **#86 / #87 (T61)** — backup primitive + periodic worker. Clustering tables ride the standard snapshot; clustering worker follows the backup worker registration pattern.
- **#89 (T62)** — eager-start default user workers. Clustering worker inherits this.
- **#92 (T63)** — cost reconciliation opt-in posture. The embeddings clustering engine honours this principle: off by default, explicit opt-in via `vault_clustering.engine: "embeddings"`, API key presence alone is not enough.

## What's in the parent design

- Six user archetypes (new no-PKM, new heavy-PKM, existing no-vault, existing v1-vault, power user, casual reader). Every design decision justified against at least one.
- Architecture: single write subtree, `#mnemo/<type>` tag namespace, opt-in bridges (one-way), PKM profile (obsidian|logseq|foam|generic) with auto-detect, template override escape hatch.
- Indexing scope decoupled from write path. `"_mnemo_only"` default for new vaults; `"full"` for existing v1 vaults (continuity). `"includes"` mode for surgical opt-in. `.mnemoignore` gitignore-syntax exclude.
- Information model: themes, patterns, cross-repo, lessons, filtered decisions, memories.
- Three-phase migration: additive → soak → user-initiated GC. v1 annotations harvested into `legacy-annotations.md` at opt-in. `mnemo_vault_gc_legacy` is user-initiated, not automatic.
- 9-slice roadmap with value statement per slice. 10 acceptance criteria. Risk register with 6 entries. Success metrics post-launch.

## What's in the clustering design

- Two engines:
  - **Heuristic (default)** — TF-IDF + single-link agglomerative. Fully local, deterministic. Non-toy.
  - **Embeddings (opt-in)** — Voyage AI / OpenAI + HDBSCAN. Per T63 posture, requires explicit config opt-in.
- Four input streams with weights: decisions (1.0), compactions (0.8), patterns (1.2), vault_user (1.5).
- Cluster IDs stable via sha1-of-sorted-members. Minor edits don't churn IDs; membership changes do.
- User-anchored labels (from vault_user docs) win over LLM labels — user wrote "Auth middleware redesign" once, owns the label.
- Schema additions: `themes`, `theme_members`, `cluster_embeddings`, `themes_fts`, `cluster_runs`. All append-only.
- Worker lifecycle follows T61 backup worker pattern; inherits T62 eager-start; hot-reload via `mnemo_config`.
- 6 failure modes with mitigations, 4 open questions with working answers.

## Discussion questions

I'd particularly value input on:

1. **Migration default for existing v1 vaults** — design proposes `vault_layout="both"` on first sync post-upgrade (write to both paths until user opts into pure v2). Is the additional disk footprint during the soak window acceptable, or should we narrow sooner?
2. **`"full"` scope continuity for existing v1 vault users** — v1 was effectively `"full"` (silent). Design proposes preserving this for existing vaults to avoid losing search hits the user relies on. Alternative: narrow on upgrade with a one-time `MIGRATION.md` notice and let the user opt back in. Which trade-off do you prefer?
3. **Embeddings provider** — design suggests Voyage AI as default opt-in provider (multilingual, cheap, 1024d). Should we go provider-agnostic from day one, or ship Voyage-only and add providers later?
4. **Patterns persistence (Slice 7)** — promoting `mnemo_discover_patterns` from live-queried to persisted requires a new `patterns` table. Acceptable, or should patterns stay derived and clustering operate on the live query output?
5. **Bridge syntax** — design proposes `<!-- mnemo:bridge:<name> -->` fenced blocks appended to user-named anchor files. Any objection to this shape, or preference for a different marker?

## Test plan

Design-only RFC. No code to test yet. Acceptance criteria and per-slice value statements in the docs serve as a forward-looking test plan; concrete tests will land with each slice PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)