### PR TITLE
Release v0.41.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.40.0"
+	version              = "0.41.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
## Summary

Version bump for v0.41.0. Release notes covering the eight commits since v0.40.0 (T63 cost reconciliation opt-in, T59 compactor activity-driven, T60 daemon_connections sweep, T56 sqldeep dispatch drop, T53 trees-of-interest references, sqldeep v0.19→v0.22 bump, vault RFC, bullseye.yaml reconciliation) are attached to the GitHub release.

## Test plan

- [x] `go test -tags sqlite_fts5 ./...` — green locally
- [ ] CI green
