### PR TITLE
🎯T65 cross-session agent-to-agent messaging target

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1125,7 +1125,7 @@ targets:
     status: set_aside
     value: 0.0
     cost: 0.0
-    set_aside_reason: 'Won''t fix — wrong shape for the actual use case. Acceptance was a pull-based message bus assuming long-lived listener sessions. Real use case is cross-repo agent coordination ("A finishes its bit, B resumes") which Claude Code agents can''t satisfy via pull (no event loop between turns) or via RemoteTrigger composition (RemoteTrigger spawns sessions on Anthropic''s hosted infrastructure, which can''t reach localhost mnemo without the federated mTLS endpoint AND can''t push back to local sessions either). PR #59 was opened, then closed during the design discussion. Retired-then-set-aside because the original retire was premature: the work landed on a feature branch that we then killed before merging, so no production change. If a future design surfaces a primitive that genuinely fits the coordination use case, raise it as a fresh target rather than reviving this one.'
+    set_aside_reason: 'Won''t fix — wrong shape for the actual use case. Acceptance was a pull-based message bus assuming long-lived listener sessions. Real use case is cross-repo agent coordination ("A finishes its bit, B resumes") which Claude Code agents can''t satisfy via pull (no event loop between turns) or via RemoteTrigger composition (RemoteTrigger spawns sessions on Anthropic''s hosted infrastructure, which can''t reach localhost mnemo without the federated mTLS endpoint AND can''t push back to local sessions either). PR #59 was opened, then closed during the design discussion. Retired-then-set-aside because the original retire was premature: the work landed on a feature branch that we then killed before merging, so no production change. **Superseded by 🎯T65 (2026-05-23)** — same use case, redesigned around directory-addressed inbox notes and `/loop` for wait-on-event, with the MCP layer kept precise (required canonicalized path) and convenience pushed into the skill layer. T65 is the live target; do not revive T42.'
     acceptance:
     - mnemo exposes mnemo_message_post(topic, body, reply_to?) — posts a message to a topic
     - mnemo exposes mnemo_message_recv(topic, since?, mark_read?) — pulls messages from a topic, optionally marking read
@@ -1747,7 +1747,7 @@ targets:
     - T61
     - T62
     - T63
-    origin: PR #95 (RFC)
+    origin: PR
     discovered: 2026-05-22
   T64.1:
     name: Indexing scope + .mnemoignore (consent fix)
@@ -1761,11 +1761,10 @@ targets:
     - IngestVaultAnnotations refactored to walk only the configured scope; pre-PR-95 silent full-vault read is gone.
     - New vaults default to "_mnemo_only"; existing v1 vaults default to "full" for continuity.
     - mnemo_vault_status surfaces the active scope.
-    context: |-
-      The only sub-target that fixes a real shipped bug — v1's silent full-vault read happened without user consent. Lands ahead of any `_mnemo/` namespace work for that reason. Reuses 🎯T53 trees_of_interest + doc_tree_refs for the "includes" mode rather than inventing a parallel mechanism.
+    context: The only sub-target that fixes a real shipped bug — v1's silent full-vault read happened without user consent. Lands ahead of any `_mnemo/` namespace work for that reason. Reuses 🎯T53 trees_of_interest + doc_tree_refs for the "includes" mode rather than inventing a parallel mechanism.
     depends_on:
     - T53
-    origin: PR #95 (RFC)
+    origin: PR
     discovered: 2026-05-22
   T64.2:
     name: '`_mnemo/` namespace + vault_layout config'
@@ -1779,11 +1778,10 @@ targets:
     - state.json tracks vault_layout_first_seen for soak-TTL warning purposes.
     - mnemo_vault_status surfaces vault_layout, days_in_both, and a recommendation string (one of "still within soak", "opt into v2", "run gc_legacy", or empty).
     - vault_layout="both" past the configurable soak window (default 720h) emits a weekly structured warning; the layout never auto-narrows.
-    context: |-
-      Plumbs the new directory root and the layout config knob. v1 writers retained, gated on vault_layout. The MIGRATION.md write-once exception lives here (rule scoped to MIGRATION.md only; every other file in _mnemo/ honours the standard fence contract).
+    context: Plumbs the new directory root and the layout config knob. v1 writers retained, gated on vault_layout. The MIGRATION.md write-once exception lives here (rule scoped to MIGRATION.md only; every other file in _mnemo/ honours the standard fence contract).
     depends_on:
     - T64.1
-    origin: PR #95 (RFC)
+    origin: PR
     discovered: 2026-05-22
   T64.3:
     name: Move decisions + memories under _mnemo/
@@ -1791,15 +1789,14 @@ targets:
     value: 2.0
     cost: 0.0
     acceptance:
-    - decisions/ and memories/ pages render under _mnemo/decisions/ and _mnemo/memories/ with the design's new frontmatter shape and #mnemo/decision / #mnemo/memory tag namespace.
+    - decisions/ and memories/ pages render under _mnemo/decisions/ and _mnemo/memories/ with the design's new frontmatter shape and
     - Old v1 decision/memory files still written when vault_layout="both".
     - The atomic write protocol (tempfile + fsync + rename) is in place and survives a daemon crash mid-write.
-    - Sync atomicity gate from parent acceptance #17 passes.
-    context: |-
-      Re-renders the two existing v1 abstractions under the new wing. Validates the rendering shape, frontmatter, graph topology, and atomic write protocol before any genuinely new abstractions (themes, patterns, lessons, cross-repo) land.
+    - Sync atomicity gate from parent acceptance
+    context: Re-renders the two existing v1 abstractions under the new wing. Validates the rendering shape, frontmatter, graph topology, and atomic write protocol before any genuinely new abstractions (themes, patterns, lessons, cross-repo) land.
     depends_on:
     - T64.2
-    origin: PR #95 (RFC)
+    origin: PR
     discovered: 2026-05-22
   T64.4:
     name: Drop session/CI/PR/repo writers from _mnemo/
@@ -1808,13 +1805,12 @@ targets:
     cost: 0.0
     acceptance:
     - When vault_layout="v2", session, CI, PR, and repo-index pages are NOT written to _mnemo/. v1 paths continue under vault_layout="both" or "v1".
-    - acceptance #1 of the parent design passes — _mnemo/ is the only directory written, and it contains only the abstraction shapes, not raw event dumps.
+    - acceptance
     - Marks the MVP v2 boundary — the wing is now calm, scoped, and consent-correct.
-    context: |-
-      Validates the principle that raw signal stays in SQLite and is queried on demand. After this slice lands, T64 is half-cashed: the wing is correct in shape and consent, but the new abstractions (themes, patterns, lessons, cross-repo) are still missing. The remaining sub-targets land those.
+    context: 'Validates the principle that raw signal stays in SQLite and is queried on demand. After this slice lands, T64 is half-cashed: the wing is correct in shape and consent, but the new abstractions (themes, patterns, lessons, cross-repo) are still missing. The remaining sub-targets land those.'
     depends_on:
     - T64.3
-    origin: PR #95 (RFC)
+    origin: PR
     discovered: 2026-05-22
   T64.5:
     name: PKM profile + auto-detect (mtime-based)
@@ -1826,11 +1822,10 @@ targets:
     - 'Per-profile renderer hooks plumbed for link syntax + properties differences (Obsidian alias links, Logseq prop:: syntax, etc.).'
     - Auto-detect uses mtime of canonical signal files (.obsidian/workspace.json, logseq/config/config.edn, .foam/settings.json) rather than directory presence; tie-break ≤ 1 hour → obsidian → logseq → foam.
     - mnemo_vault_status reports the detected profile, the signal file path, its mtime, and any alternative profiles whose signal files exist.
-    context: |-
-      Mere directory presence is too brittle — multi-tool PKM users (notably Obsidian + Logseq on the same directory) are common, and a single exploratory open months ago can persist .obsidian/ forever. Recency-of-modification on the canonical signal file is the better signal.
+    context: Mere directory presence is too brittle — multi-tool PKM users (notably Obsidian + Logseq on the same directory) are common, and a single exploratory open months ago can persist .obsidian/ forever. Recency-of-modification on the canonical signal file is the better signal.
     depends_on:
     - T64.2
-    origin: PR #95 (RFC)
+    origin: PR
     discovered: 2026-05-22
   T64.6:
     name: Bridges
@@ -1844,11 +1839,10 @@ targets:
     - vault_bridges.max_links capping applies per bridge (default 50); memories bridge groups by source project.
     - bridge_<collection>.tmpl template overrides supported; standard template error handling applies.
     - mnemo_vault_bridge_list MCP tool reports active bridges, anchor paths, and any errors.
-    context: |-
-      Optional, opt-in pointer from the user's existing PKM structure into the wing. One-way: anchor file points at _mnemo/ pages, never the reverse. Anchor files live outside _mnemo/; a bridge pointing at a path inside _mnemo/ should be rejected at config time (not yet specified — flag as a residual issue).
+    context: 'Optional, opt-in pointer from the user''s existing PKM structure into the wing. One-way: anchor file points at _mnemo/ pages, never the reverse. Anchor files live outside _mnemo/; a bridge pointing at a path inside _mnemo/ should be rejected at config time (not yet specified — flag as a residual issue).'
     depends_on:
     - T64.2
-    origin: PR #95 (RFC)
+    origin: PR
     discovered: 2026-05-22
   T64.7:
     name: Patterns (persisted + rendered)
@@ -1860,11 +1854,10 @@ targets:
     - mnemo_discover_patterns promoted from live-queried to backed by the persisted table.
     - Renderer emits _mnemo/patterns/ pages for patterns meeting occurrence ≥ 3 AND session_count ≥ 2.
     - Patterns become one of four input streams to the clustering engine (T64.8) with weight 1.2 per the clustering doc.
-    context: |-
-      The cheapest new abstraction to extract — pattern detection already exists as a live query. Promoting to persisted gives clustering a deterministic input and lets patterns survive across sessions. Prerequisite for T64.8.
+    context: The cheapest new abstraction to extract — pattern detection already exists as a live query. Promoting to persisted gives clustering a deterministic input and lets patterns survive across sessions. Prerequisite for T64.8.
     depends_on:
     - T64.4
-    origin: PR #95 (RFC)
+    origin: PR
     discovered: 2026-05-22
   T64.8:
     name: Themes + cross-repo (clustering engine)
@@ -1882,11 +1875,10 @@ targets:
     - New tables — themes, theme_members, cluster_embeddings, themes_fts, cluster_runs, theme_overrides, theme_pins — all additive per 🎯T49.
     - New MCP tools — mnemo_vault_recluster, mnemo_vault_themes_inspect, mnemo_vault_themes_pin — work end-to-end. Stubs for themes_split / themes_merge land config-rejecting placeholders.
     - All 19 acceptance criteria in docs/design/vault-clustering.md pass.
-    context: |-
-      The research-shaped slice; carries the most risk. Subordinate design doc (docs/design/vault-clustering.md) is the canonical spec. Heuristic engine ships fully offline. Embeddings engine is opt-in per 🎯T63 egress posture; labelling engine is an independent opt-in (two-key matrix). HDBSCAN deferred to a follow-up slice.
+    context: The research-shaped slice; carries the most risk. Subordinate design doc (docs/design/vault-clustering.md) is the canonical spec. Heuristic engine ships fully offline. Embeddings engine is opt-in per 🎯T63 egress posture; labelling engine is an independent opt-in (two-key matrix). HDBSCAN deferred to a follow-up slice.
     depends_on:
     - T64.7
-    origin: PR #95 (RFC)
+    origin: PR
     discovered: 2026-05-22
   T64.9:
     name: Lessons + GC tool
@@ -1899,12 +1891,51 @@ targets:
     - mnemo_vault_gc_legacy is user-initiated, never automatic, and refuses to run if the annotation-safety check identifies unmigrated user content in v1 root-level dirs.
     - 'mnemo_vault_migration_doc(write: true / false) supports idempotent regen of the write-once MIGRATION.md (write:false returns the snapshot without writing).'
     - _mnemo/legacy-annotations.md harvester paginates above max_file_kb.
-    context: |-
-      Completes the abstraction set and gives existing v1-vault users a clean off-ramp. After this slice lands the full nine-slice arc is done — the wing is calm, scoped, abstraction-rich, and has a user-controlled migration path.
+    context: Completes the abstraction set and gives existing v1-vault users a clean off-ramp. After this slice lands the full nine-slice arc is done — the wing is calm, scoped, abstraction-rich, and has a user-controlled migration path.
     depends_on:
     - T64.8
-    origin: PR #95 (RFC)
+    origin: PR
     discovered: 2026-05-22
+  T65:
+    name: mnemo provides cross-session agent-to-agent messaging via directory-addressed inbox notes
+    status: identified
+    value: 5.0
+    cost: 5.0
+    acceptance:
+    - '`mnemo_note_post(inbox, body, from_session?, from_repo?)` MCP tool — `inbox` and `body` are required; `inbox` is a directory path (absolute or relative to the calling session''s initial cwd); `from_session` and `from_repo` default from the MCP connection identity.'
+    - '`mnemo_note_recv(inbox, unread_only=true, mark_read=true, limit?)` MCP tool — `inbox` required; defaults return only unread notes and mark them read.'
+    - '`mnemo_note_list(inbox?, days=30)` MCP tool — browses without consuming; omitting `inbox` lists every inbox touched in the window.'
+    - 'Inbox canonicalization is identical on both sides: reject if the path contains `~`; if relative, join with the calling session''s initial cwd (derived from connection identity, NOT pwd); apply `filepath.EvalSymlinks` (lexical `..`/`.` collapse + symlink resolution + existence check); store the resolved absolute path. Two callers writing `~/work/foo`, `/Users/.../work/foo/`, and `./foo/../foo` from a parent session at `~/work/` all resolve to the same inbox row.'
+    - Posting to a non-existent directory returns a clear error; the `notes` row is not inserted.
+    - New `notes` table with columns `(id, inbox, body, from_session, from_repo, posted_at, read_at NULLABLE)` plus an FTS5 index on `body`. Additive, append-only per 🎯T49 schema policy.
+    - 'Two Claude Code sessions in different repos can demonstrably round-trip a note end-to-end via the MCP tools alone — no hook, no auto-detection, no slash-command involvement. Producer in `~/work/.../mnemo` writes `mnemo_note_post(inbox: "../ytt", body: "…")`; consumer in `~/work/.../ytt` reads `mnemo_note_recv(inbox: "/Users/.../work/.../ytt")` and sees the note.'
+    - '`/inbox` skill (consumer-side convenience) calls `mnemo_self` to derive the current session''s initial cwd, then invokes `mnemo_note_recv(inbox: <root>)` and formats results. `/inbox <path>` overrides the derivation.'
+    - '`/post <inbox> <body>` skill (producer-side convenience) is a thin wrapper over `mnemo_note_post`.'
+    - Documentation explains the `/loop /inbox` pattern for the wait-on-event case (e.g. consumer is blocked on a release that's ~30 minutes away; runs `/loop /inbox` and lets the skill self-pace via ScheduleWakeup until the note arrives). mnemo itself does not implement long-polling; the wait primitive lives in the harness.
+    context: |-
+      Replaces (does not revive) the set-aside 🎯T42 "mnemo provides a cross-session message bus for Claude Code agents". T42's pull-based bus assumed long-lived listener sessions; Claude Code is turn-driven, has no event loop between turns, so pull-without-wakeup doesn't deliver. T65 reframes around two principles that fit the harness:
+
+      1. **Producer-write + consumer-pull, both user-triggered.** The user is on both sides of the typical use case ("A finishes its bit, B picks up") so neither side needs surprise notification. The pain T65 removes is the cmd-c / cmd-tab / cmd-v copy-paste routine, not "B doesn't know a message arrived." The producer types one tool call; the consumer types `/inbox`.
+
+      2. **Wait semantics live in `/loop`, not in mnemo.** For the half-hour-away case the consumer runs `/loop /inbox`; the skill self-paces via ScheduleWakeup until something arrives. mnemo's MCP layer stays synchronous.
+
+      The MCP layer is intentionally precise: `inbox` is a required canonicalized directory path; no defaulting from cwd, no implicit repo resolution. Convenience (deriving "this session's inbox") lives in the skill layer. This mirrors bullseye's split — `bullseye_put` takes explicit `cwd:`; convenience belongs to `/cv` and friends.
+
+      Inbox addressing by session-root directory rather than free string is what makes the system collision-free: two repos named `foo` in different paths get distinct inboxes; relative paths resolve against the session's initial cwd (NOT pwd, which drifts when an agent `cd`'s mid-session) so `to: "../ytt"` from a session rooted at `~/work/.../mnemo` posts to `~/work/.../ytt`. Symlink resolution + lexical `..` collapse + existence check all fall out of one `filepath.EvalSymlinks` call.
+
+      Use case (from 2026-05-23 design discussion):
+      - Session A is running a `/release` flow inside mnemo. Session B is in a downstream repo (e.g. `ytt`) blocked on the new mnemo version landing.
+      - A finishes: `mnemo_note_post(inbox: "../ytt", body: "mnemo v0.42 published, brew formula updated")`.
+      - B types `/loop /inbox` and walks away. /loop self-paces (cache-aware ScheduleWakeup) until the note arrives, then injects it and continues the dependent work.
+
+      Mark-read-retain semantics — notes are searchable via `mnemo_search` after delivery, matching mnemo's other append-only ingest streams. Eventual auto-prune can be added later if growth becomes an issue; not in the MVP.
+
+      Federation (🎯T15) is deferred: directory paths are local-host today. Cross-host inboxes would need a `host:` qualifier; raise a follow-up target when federation absorbs this primitive.
+    depends_on:
+    - T25
+    - T49
+    origin: '2026-05-23 design discussion (this session); supersedes the abandoned mid-flight T64 from 2026-05-21 which lost its slot to PR #95''s vault-library-wing parent'
+    discovered: 2026-05-23
   T7:
     name: Agent-defined query templates
     status: achieved


### PR DESCRIPTION
## Summary

Files **🎯T65 "mnemo provides cross-session agent-to-agent messaging via directory-addressed inbox notes"** as a fresh successor to the set-aside 🎯T42. Updates T42's set-aside reason to point at T65.

**No code yet** — this is the design-frozen target. Implementation lands in follow-up PRs.

## Design (frozen this session)

| Tool | Signature |
|---|---|
| \`mnemo_note_post\` | \`inbox: required string, body: required string, from_session?, from_repo?\` |
| \`mnemo_note_recv\` | \`inbox: required string, unread_only=true, mark_read=true, limit?\` |
| \`mnemo_note_list\` | \`inbox?: string, days=30\` |

**Inbox canonicalization** (identical on both sides):

1. Reject if \`inbox\` contains \`~\` (ambiguous in MCP context).
2. If relative, join with the calling session's **initial cwd** (derived from connection identity — *not* pwd, which drifts mid-session).
3. \`filepath.EvalSymlinks\` collapses lexical \`..\`, follows symlinks, errors if the path doesn't exist.
4. Store the resolved absolute path.

\`~/work/foo/\`, \`/Users/marcelo/.../work/foo\`, and \`./foo/../foo\` from a parent session at \`~/work/\` all resolve to the same row.

**Schema**: new \`notes(id, inbox, body, from_session, from_repo, posted_at, read_at NULLABLE)\` table + FTS5 on \`body\`. Additive, append-only per 🎯T49.

**Convenience layer** (skills, not tools): \`/inbox\` derives "this session's root" via \`mnemo_self\` and calls recv; \`/post <inbox> <body>\` is a thin producer wrapper.

**Wait semantics live in \`/loop\`**: \`/loop /inbox\` for the half-hour-away release case. mnemo itself stays synchronous.

## Why this isn't a T42 revival

T42 was a pull-based message bus assuming long-lived listener sessions. Claude Code is turn-driven with no event loop between turns, so pull-without-wakeup didn't deliver. T65 reframes around the actual workflow:

- The user is on both sides of the typical handoff (\"A finishes its bit, B picks up\") — neither side needs surprise notification. The pain is the cmd-c/cmd-tab/cmd-v copy-paste routine.
- Addressing by session-root directory (not free string, not topic) makes the system collision-free across same-named repos and stable against mid-session \`cd\`.
- Long-polling stays *out* of the MCP layer; \`/loop\` is the wait primitive.

The MCP layer is intentionally precise (required canonicalized path); convenience and defaulting live in the skill layer. Mirrors bullseye's \`bullseye_put cwd:\` / \`/cv\` split.

## Test plan

- [x] \`bullseye_list(cwd=...)\` shows T65 as Identified, T42 still SetAside with updated reason.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)