### PR TITLE
Release v0.42.0 (fix release.yml deepparser handling)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: marcelocantos/sqldeep
+          ref: v0.22.0
           path: sqldeep
+          submodules: recursive
 
       - name: Install sqlite3 headers (Windows)
         # sqlift's bundled sqlift.cpp does #include <sqlite3.h>; MinGW
@@ -114,10 +116,20 @@ jobs:
           CXX: ${{ matrix.cxx }}
           AR: ${{ matrix.ar }}
         run: |
-          mkdir -p build
-          "$CXX" -std=c++20 -Wall -Wextra -Wpedantic -Idist -Ivendor/include -c dist/sqldeep.cpp -o build/sqldeep.o
+          # sqldeep v0.22.0+ pulls liteparser/arena from the vendored
+          # deepparser submodule. Mirror sqldeep's own mkfile rules:
+          # compile each deepparser .c into build/deepparser/, compile
+          # sqldeep.o with -Ivendor/deepparser/src, then pack everything
+          # into libsqldeep.a so downstream cgo links cleanly.
+          mkdir -p build/deepparser
+          DP_SRC=vendor/deepparser/src
+          DP_CFLAGS="-Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -O2 -DNDEBUG -I${DP_SRC}"
+          for f in arena liteparser lp_tokenize lp_unparse parse; do
+            "$CC" $DP_CFLAGS -c "${DP_SRC}/${f}.c" -o "build/deepparser/${f}.o"
+          done
+          "$CXX" -std=c++20 -Wall -Wextra -Wpedantic -Idist -Ivendor/include -I${DP_SRC} -c dist/sqldeep.cpp -o build/sqldeep.o
           "$CC" -w -Idist -Ivendor/include -c dist/sqldeep_xml.c -o build/sqldeep_xml.o
-          "$AR" rcs build/libsqldeep.a build/sqldeep.o
+          "$AR" rcs build/libsqldeep.a build/sqldeep.o build/deepparser/*.o
 
       - uses: actions/setup-go@v5
         with:
@@ -213,13 +225,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: marcelocantos/sqldeep
+          ref: v0.22.0
           path: sqldeep
+          submodules: recursive
       - name: Build sqldeep
+        working-directory: sqldeep
         run: |
-          cd sqldeep && mkdir -p build
-          c++ -std=c++20 -Wall -Wextra -Wpedantic -Idist -Ivendor/include -c dist/sqldeep.cpp -o build/sqldeep.o
+          mkdir -p build/deepparser
+          DP_SRC=vendor/deepparser/src
+          DP_CFLAGS="-Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -O2 -DNDEBUG -I${DP_SRC}"
+          for f in arena liteparser lp_tokenize lp_unparse parse; do
+            cc $DP_CFLAGS -c "${DP_SRC}/${f}.c" -o "build/deepparser/${f}.o"
+          done
+          c++ -std=c++20 -Wall -Wextra -Wpedantic -Idist -Ivendor/include -I${DP_SRC} -c dist/sqldeep.cpp -o build/sqldeep.o
           cc -w -Idist -Ivendor/include -c dist/sqldeep_xml.c -o build/sqldeep_xml.o
-          ar rcs build/libsqldeep.a build/sqldeep.o
+          ar rcs build/libsqldeep.a build/sqldeep.o build/deepparser/*.o
       - uses: actions/setup-go@v5
         with:
           go-version-file: mnemo/go.mod

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.41.0"
+	version              = "0.42.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
## Summary

Two-in-one release-prep PR for v0.42.0:

1. **Fix `release.yml`'s sqldeep build to match `ci.yml`.** PR #97 bumped sqldeep v0.19.0 → v0.22.0, which added a `vendor/deepparser` submodule. `ci.yml` was updated to fetch the submodule and compile the deepparser sources; `release.yml`'s two sqldeep build sites (the build matrix and the test job) were missed, causing v0.41.0's release workflow to fail with `liteparser.h: No such file or directory`. Both jobs now mirror `ci.yml`: pin sqldeep@v0.22.0, `submodules: recursive`, compile each `deepparser/*.c`, pack into `libsqldeep.a`.

2. **Bump version to v0.42.0.** v0.41.0 shipped a git tag and an empty GitHub release (no binaries, no Homebrew formula). v0.40.0 stays the user-installable version. v0.42.0 carries the same payload as v0.41.0 plus the workflow fix.

The release notes (attached to the GitHub release) cover the v0.40.0 → v0.42.0 delta, which is identical to v0.40.0 → v0.41.0 plus this workflow fix.

## Test plan

- [x] `go test -tags sqlite_fts5 ./...` — green locally (from prior run, unchanged)
- [ ] CI green (this is the meaningful proof — the new release.yml is the one we're verifying)
