### PR TITLE
🎯T64.2: _mnemo/ namespace + vault_layout config

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1769,7 +1769,7 @@ targets:
     achieved: 2026-05-23
   T64.2:
     name: '`_mnemo/` namespace + vault_layout config'
-    status: identified
+    status: achieved
     value: 2.0
     cost: 0.0
     acceptance:
@@ -1784,6 +1784,7 @@ targets:
     - T64.1
     origin: PR
     discovered: 2026-05-22
+    achieved: 2026-05-24
   T64.3:
     name: Move decisions + memories under _mnemo/
     status: identified

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -168,6 +168,17 @@ func (r *Registry) ForUser(username string) (*store.Store, error) {
 		if err != nil {
 			slog.Warn("vault: exporter creation failed", "path", vaultPath, "err", err)
 		} else {
+			vp := vaultPath
+			exp.SetLayoutResolver(func() string {
+				return r.CurrentConfig().ResolvedVaultLayout(vp)
+			})
+			exp.SetSoakWarnAfterResolver(func() time.Duration {
+				d, err := r.CurrentConfig().VaultLayout.EffectiveSoakWarnAfter()
+				if err != nil {
+					return 0
+				}
+				return d
+			})
 			vaultExp = exp
 		}
 	}
@@ -793,6 +804,16 @@ func (r *Registry) swapVault(username string, e *userEntry, newPath string) erro
 		logger.Warn("vault: exporter creation failed on reload", "path", newPath, "err", err)
 		return fmt.Errorf("vault.New(%q): %w", newPath, err)
 	}
+	exp.SetLayoutResolver(func() string {
+		return r.CurrentConfig().ResolvedVaultLayout(newPath)
+	})
+	exp.SetSoakWarnAfterResolver(func() time.Duration {
+		d, err := r.CurrentConfig().VaultLayout.EffectiveSoakWarnAfter()
+		if err != nil {
+			return 0
+		}
+		return d
+	})
 	r.mu.Lock()
 	e.vault = exp
 	vctx := r.startVaultWorkers(username, e)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -172,13 +172,7 @@ func (r *Registry) ForUser(username string) (*store.Store, error) {
 			exp.SetLayoutResolver(func() string {
 				return r.CurrentConfig().ResolvedVaultLayout(vp)
 			})
-			exp.SetSoakWarnAfterResolver(func() time.Duration {
-				d, err := r.CurrentConfig().VaultLayout.EffectiveSoakWarnAfter()
-				if err != nil {
-					return 0
-				}
-				return d
-			})
+			exp.SetSoakWarnAfterResolver(r.soakWarnAfterResolver())
 			vaultExp = exp
 		}
 	}
@@ -629,6 +623,40 @@ func (r *Registry) CurrentConfig() store.Config {
 	return r.cfg
 }
 
+// soakWarnAfterResolver returns a closure suitable for
+// vault.Exporter.SetSoakWarnAfterResolver. The closure reads the live
+// config on every call and, on the first malformed value it observes,
+// emits a structured warning so a misconfigured soak window does not
+// silently degrade to the package default. Subsequent calls with the
+// same malformed string stay quiet to avoid log spam at sync cadence;
+// a different malformed value re-arms the warn.
+//
+// mnemo_config validates SoakWarnAfter at write time (see tools.go)
+// so the resolver path is defence-in-depth: users who hand-edit
+// config.json still see the misconfiguration in the daemon log.
+func (r *Registry) soakWarnAfterResolver() func() time.Duration {
+	var (
+		mu         sync.Mutex
+		lastWarned string
+	)
+	return func() time.Duration {
+		raw := r.CurrentConfig().VaultLayout.SoakWarnAfter
+		d, err := r.CurrentConfig().VaultLayout.EffectiveSoakWarnAfter()
+		if err != nil {
+			mu.Lock()
+			fire := raw != lastWarned
+			lastWarned = raw
+			mu.Unlock()
+			if fire {
+				slog.Warn("vault_layout.soak_warn_after malformed; falling back to default",
+					"value", raw, "err", err)
+			}
+			return 0
+		}
+		return d
+	}
+}
+
 // vaultIndexingOptionsFor builds the VaultIndexingOptions struct
 // IngestVaultAnnotations expects, resolving any auto-default scope
 // against the live vault tree (🎯T64.1). Reads the live config under
@@ -807,13 +835,7 @@ func (r *Registry) swapVault(username string, e *userEntry, newPath string) erro
 	exp.SetLayoutResolver(func() string {
 		return r.CurrentConfig().ResolvedVaultLayout(newPath)
 	})
-	exp.SetSoakWarnAfterResolver(func() time.Duration {
-		d, err := r.CurrentConfig().VaultLayout.EffectiveSoakWarnAfter()
-		if err != nil {
-			return 0
-		}
-		return d
-	})
+	exp.SetSoakWarnAfterResolver(r.soakWarnAfterResolver())
 	r.mu.Lock()
 	e.vault = exp
 	vctx := r.startVaultWorkers(username, e)

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -638,11 +638,15 @@ const (
 	VaultLayoutV1   = "v1"
 )
 
-// defaultVaultLayoutSoakWarnAfter is the soak window after which a
+// DefaultVaultLayoutSoakWarnAfter is the soak window after which a
 // vault stuck on layout="both" begins emitting a structured warning on
 // each sync (weekly cadence once tripped). 720h = 30 days. The user
 // can lengthen via VaultLayoutConfig.SoakWarnAfter.
-const defaultVaultLayoutSoakWarnAfter = 720 * time.Hour
+//
+// Exported so the vault package can reference the same value without
+// duplicating the constant (drift would otherwise be silent — neither
+// compilation nor per-package tests would catch it).
+const DefaultVaultLayoutSoakWarnAfter = 720 * time.Hour
 
 // VaultLayoutConfig governs which vault tree(s) the exporter writes.
 // Modelled as a struct (rather than a bare string) so the soak-warn
@@ -661,11 +665,11 @@ type VaultLayoutConfig struct {
 }
 
 // EffectiveSoakWarnAfter parses SoakWarnAfter and returns the duration,
-// or defaultVaultLayoutSoakWarnAfter when unset. A malformed value
+// or DefaultVaultLayoutSoakWarnAfter when unset. A malformed value
 // surfaces as an error so config validation can flag it at write time.
 func (l VaultLayoutConfig) EffectiveSoakWarnAfter() (time.Duration, error) {
 	if l.SoakWarnAfter == "" {
-		return defaultVaultLayoutSoakWarnAfter, nil
+		return DefaultVaultLayoutSoakWarnAfter, nil
 	}
 	d, err := time.ParseDuration(l.SoakWarnAfter)
 	if err != nil {
@@ -695,7 +699,7 @@ func (c Config) ResolvedVaultLayout(resolvedVaultPath string) string {
 	if resolvedVaultPath == "" {
 		return VaultLayoutV2
 	}
-	for _, d := range v1VaultMarkerDirs {
+	for _, d := range V1VaultMarkerDirs {
 		if fi, err := os.Stat(filepath.Join(resolvedVaultPath, d)); err == nil && fi.IsDir() {
 			return VaultLayoutBoth
 		}
@@ -707,11 +711,11 @@ func (c Config) ResolvedVaultLayout(resolvedVaultPath string) string {
 // syntax exclude file at the vault root.
 const defaultVaultIgnoreFile = ".mnemoignore"
 
-// v1VaultMarkerDirs are the root-level subdirectories the v1 vault
+// V1VaultMarkerDirs are the root-level subdirectories the v1 vault
 // layout writes to. The presence of any of these without a sibling
 // `_mnemo/` indicates a pre-Slice 1 vault that should default to
 // "full" indexing scope for continuity.
-var v1VaultMarkerDirs = []string{
+var V1VaultMarkerDirs = []string{
 	"sessions", "decisions", "memories", "skills", "configs",
 	"plans", "targets", "ci", "prs", "repos",
 }
@@ -737,7 +741,7 @@ func (c Config) ResolvedVaultIndexingScope(resolvedVaultPath string) string {
 	if fi, err := os.Stat(filepath.Join(resolvedVaultPath, "_mnemo")); err == nil && fi.IsDir() {
 		return VaultIndexingScopeMnemoOnly
 	}
-	for _, d := range v1VaultMarkerDirs {
+	for _, d := range V1VaultMarkerDirs {
 		if fi, err := os.Stat(filepath.Join(resolvedVaultPath, d)); err == nil && fi.IsDir() {
 			return VaultIndexingScopeFull
 		}

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -84,6 +84,13 @@ type Config struct {
 	// consulted — nested .mnemoignore files are not honoured.
 	VaultIndexingIgnoreFile string `json:"vault_indexing_ignore_file,omitempty"`
 
+	// VaultLayout controls which directory tree(s) the vault exporter
+	// writes (🎯T64.2). The zero value resolves at runtime via
+	// ResolvedVaultLayout against the live vault: a vault with any
+	// root-level v1 marker dir (sessions/, decisions/, ...) defaults to
+	// "both" for migration continuity, anything else defaults to "v2".
+	VaultLayout VaultLayoutConfig `json:"vault_layout,omitempty"`
+
 	// LinkedInstances declares peer mnemo endpoints to federate with
 	// (🎯T15). Each peer is identified by a https URL and a trusted
 	// peer certificate (either a name resolved under ~/.mnemo/peers/
@@ -621,6 +628,80 @@ const (
 	VaultIndexingScopeFull      = "full"
 	VaultIndexingScopeIncludes  = "includes"
 )
+
+// Vault layout constants. v2 writes only to <vault>/_mnemo/; v1 writes
+// only to the root-level v1 dirs (sessions/, decisions/, ...); both
+// writes to both trees during a migration window.
+const (
+	VaultLayoutV2   = "v2"
+	VaultLayoutBoth = "both"
+	VaultLayoutV1   = "v1"
+)
+
+// defaultVaultLayoutSoakWarnAfter is the soak window after which a
+// vault stuck on layout="both" begins emitting a structured warning on
+// each sync (weekly cadence once tripped). 720h = 30 days. The user
+// can lengthen via VaultLayoutConfig.SoakWarnAfter.
+const defaultVaultLayoutSoakWarnAfter = 720 * time.Hour
+
+// VaultLayoutConfig governs which vault tree(s) the exporter writes.
+// Modelled as a struct (rather than a bare string) so the soak-warn
+// window can be tuned alongside the mode without inventing a sibling
+// top-level config key.
+type VaultLayoutConfig struct {
+	// Mode is one of VaultLayoutV2, VaultLayoutBoth, VaultLayoutV1, or
+	// empty. Empty resolves at runtime per ResolvedVaultLayout.
+	Mode string `json:"mode,omitempty"`
+
+	// SoakWarnAfter is a Go time.ParseDuration string controlling when
+	// the daemon begins warning about a vault stuck on Mode == "both".
+	// Empty defaults to 720h (30 days). Only consulted while Mode
+	// resolves to "both"; ignored otherwise.
+	SoakWarnAfter string `json:"soak_warn_after,omitempty"`
+}
+
+// EffectiveSoakWarnAfter parses SoakWarnAfter and returns the duration,
+// or defaultVaultLayoutSoakWarnAfter when unset. A malformed value
+// surfaces as an error so config validation can flag it at write time.
+func (l VaultLayoutConfig) EffectiveSoakWarnAfter() (time.Duration, error) {
+	if l.SoakWarnAfter == "" {
+		return defaultVaultLayoutSoakWarnAfter, nil
+	}
+	d, err := time.ParseDuration(l.SoakWarnAfter)
+	if err != nil {
+		return 0, fmt.Errorf("vault_layout.soak_warn_after: %w", err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("vault_layout.soak_warn_after must be positive, got %v", d)
+	}
+	return d, nil
+}
+
+// ResolvedVaultLayout returns the effective layout mode for the vault
+// at resolvedVaultPath. When VaultLayout.Mode is set explicitly, it
+// wins (after type-check). Otherwise:
+//
+//   - any v1 marker dir present (sessions/, decisions/, ...) → "both"
+//     (migration continuity — keep writing v1 while user opts in to v2)
+//   - otherwise (new or already-v2 vault)                   → "v2"
+//
+// An empty resolvedVaultPath returns "v2" — the call site is
+// responsible for not invoking the exporter when vault is disabled.
+func (c Config) ResolvedVaultLayout(resolvedVaultPath string) string {
+	switch c.VaultLayout.Mode {
+	case VaultLayoutV2, VaultLayoutBoth, VaultLayoutV1:
+		return c.VaultLayout.Mode
+	}
+	if resolvedVaultPath == "" {
+		return VaultLayoutV2
+	}
+	for _, d := range v1VaultMarkerDirs {
+		if fi, err := os.Stat(filepath.Join(resolvedVaultPath, d)); err == nil && fi.IsDir() {
+			return VaultLayoutBoth
+		}
+	}
+	return VaultLayoutV2
+}
 
 // defaultVaultIgnoreFile is the conventional name of the gitignore-
 // syntax exclude file at the vault root.

--- a/internal/store/state.go
+++ b/internal/store/state.go
@@ -1,0 +1,300 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// State is the daemon-managed sidecar that holds runtime-derived state
+// that should not pollute the user-editable ~/.mnemo/config.json but
+// must survive daemon restarts (🎯T64.2).
+//
+// Schema is additive — new fields appear over time, old ones never
+// disappear silently. UnknownKeys preserves any top-level keys the
+// current daemon does not recognise so a newer daemon's additions
+// survive a downgrade-then-upgrade cycle.
+//
+// File location: ~/.mnemo/state.json. Owned exclusively by the daemon;
+// users edit ~/.mnemo/config.json, never this file.
+type State struct {
+	// Version governs schema-shape changes that go beyond
+	// additive-field. Current version: 1.
+	Version int `json:"version"`
+
+	// VaultPath records the path the most recent sync wrote against.
+	// Used by the "vault_path change semantics" rule to detect a path
+	// change and reset the soak-TTL counters.
+	VaultPath string `json:"vault_path,omitempty"`
+
+	// VaultLayoutFirstSeen records the wall-clock time the daemon first
+	// observed each layout mode active for the current vault. Keys are
+	// the layout constants (v1/both/v2); a nil pointer means "not yet
+	// observed". hours_in_<mode> for the recommendation state machine
+	// is derived from the relevant entry.
+	VaultLayoutFirstSeen map[string]*time.Time `json:"vault_layout_first_seen,omitempty"`
+
+	// VaultLayoutLastSoakWarn records the most recent time a
+	// "vault_layout=both past soak window" warning was emitted, so the
+	// daemon can rate-limit the warning to a weekly cadence after the
+	// initial trip. Nil pointer means "never warned".
+	VaultLayoutLastSoakWarn *time.Time `json:"vault_layout_last_soak_warn,omitempty"`
+
+	// IndexingScopeFirstSeen mirrors VaultLayoutFirstSeen for the
+	// indexing-scope axis. Keys: "_mnemo_only", "full", "includes".
+	IndexingScopeFirstSeen map[string]*time.Time `json:"indexing_scope_first_seen,omitempty"`
+
+	// VaultMigrationDocWritten records that mnemo has, at some point
+	// in this vault's history, written _mnemo/MIGRATION.md. The
+	// write-once contract uses this to honour deletion as "I have
+	// read this; move on" — if the file is gone but this flag is
+	// true, the sync path will not recreate it. The user-initiated
+	// WriteMigrationDoc (mnemo_vault_migration_doc write:true) sets
+	// this flag too so subsequent syncs continue to respect it.
+	VaultMigrationDocWritten bool `json:"vault_migration_doc_written,omitempty"`
+
+	// UnknownKeys captures any top-level JSON keys the current daemon
+	// does not recognise. Re-emitted verbatim on write so a future
+	// daemon's additions survive a roundtrip through this binary.
+	UnknownKeys map[string]json.RawMessage `json:"-"`
+}
+
+// CurrentStateVersion is the schema version this binary writes. A
+// state.json with a higher version triggers read-only state mode.
+const CurrentStateVersion = 1
+
+// knownStateKeys is the closed set of top-level JSON keys the current
+// daemon writes. Any incoming key not on this list is captured into
+// State.UnknownKeys and re-emitted unchanged on the next write.
+var knownStateKeys = map[string]struct{}{
+	"version":                      {},
+	"vault_path":                   {},
+	"vault_layout_first_seen":      {},
+	"vault_layout_last_soak_warn":  {},
+	"indexing_scope_first_seen":    {},
+	"vault_migration_doc_written":  {},
+}
+
+// ErrStateVersionAhead signals that the on-disk state.json was written
+// by a newer daemon than this binary. The caller should run in
+// read-only state mode: counters report against recorded data but no
+// new state writes happen for this boot. Restoring this invariant
+// (i.e. discarding fields the older binary cannot represent) requires
+// an explicit user action.
+var ErrStateVersionAhead = errors.New("state.json version is ahead of this daemon")
+
+// stateDirOverride is set by SetStateDirForTesting to redirect
+// state.json reads/writes into a per-test temp directory. The empty
+// string (zero value) means "resolve via os.UserHomeDir as usual".
+var stateDirOverride string
+
+// SetStateDirForTesting redirects state.json read/write into dir
+// (typically a t.TempDir() value). Returns a restore function the
+// caller defers to undo the override. Must not be used concurrently
+// with itself.
+func SetStateDirForTesting(dir string) func() {
+	prev := stateDirOverride
+	stateDirOverride = dir
+	return func() { stateDirOverride = prev }
+}
+
+// StatePath returns the absolute path to ~/.mnemo/state.json (or
+// <override>/state.json when SetStateDirForTesting is active).
+func StatePath() (string, error) {
+	if stateDirOverride != "" {
+		return filepath.Join(stateDirOverride, "state.json"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".mnemo", "state.json"), nil
+}
+
+// LoadState reads ~/.mnemo/state.json. Returns a fresh
+// State{Version: CurrentStateVersion} when the file does not exist
+// (first daemon boot). Returns ErrStateVersionAhead alongside the
+// partially-populated State when the recorded version is higher than
+// CurrentStateVersion so the caller can flip into read-only state mode
+// instead of overwriting unknown fields.
+//
+// Sweeps any leftover .state.json.tmp from a prior crashed write before
+// returning so subsequent atomic writes have a clean tmp slot.
+func LoadState() (State, error) {
+	path, err := StatePath()
+	if err != nil {
+		return State{Version: CurrentStateVersion}, err
+	}
+	return loadStateFrom(path)
+}
+
+func loadStateFrom(path string) (State, error) {
+	// Sweep any stale tempfile from a previous crashed write before
+	// reading the canonical file. The tmp lives next to the target
+	// with a leading dot, matching the in-vault tmp convention.
+	_ = os.Remove(stateTmpPath(path))
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return State{Version: CurrentStateVersion}, nil
+		}
+		return State{Version: CurrentStateVersion}, err
+	}
+
+	// Decode twice: once into the typed State, once into a raw map so
+	// unknown keys are preserved verbatim on the next write.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return State{Version: CurrentStateVersion}, fmt.Errorf("parse state.json: %w", err)
+	}
+	var s State
+	if err := json.Unmarshal(data, &s); err != nil {
+		return State{Version: CurrentStateVersion}, fmt.Errorf("decode state.json: %w", err)
+	}
+
+	// Capture unknown top-level keys for round-trip preservation.
+	for k, v := range raw {
+		if _, known := knownStateKeys[k]; known {
+			continue
+		}
+		if s.UnknownKeys == nil {
+			s.UnknownKeys = make(map[string]json.RawMessage)
+		}
+		s.UnknownKeys[k] = v
+	}
+
+	if s.Version > CurrentStateVersion {
+		return s, ErrStateVersionAhead
+	}
+	if s.Version == 0 {
+		s.Version = CurrentStateVersion
+	}
+	return s, nil
+}
+
+// WriteState persists s to ~/.mnemo/state.json atomically (sibling tmp
+// + fsync + rename). The parent directory is created if missing.
+//
+// Returns ErrStateVersionAhead without touching the file if s.Version
+// is higher than CurrentStateVersion. This keeps the older binary from
+// silently dropping fields it does not understand.
+func WriteState(s State) error {
+	path, err := StatePath()
+	if err != nil {
+		return err
+	}
+	return writeStateTo(path, s)
+}
+
+func writeStateTo(path string, s State) error {
+	if s.Version > CurrentStateVersion {
+		return ErrStateVersionAhead
+	}
+	if s.Version == 0 {
+		s.Version = CurrentStateVersion
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create state dir: %w", err)
+	}
+
+	// Marshal known fields then splice unknown top-level keys back in
+	// so a newer daemon's additions survive a roundtrip through this
+	// binary.
+	body, err := json.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("marshal state: %w", err)
+	}
+	var merged map[string]json.RawMessage
+	if err := json.Unmarshal(body, &merged); err != nil {
+		return fmt.Errorf("re-decode state for merge: %w", err)
+	}
+	for k, v := range s.UnknownKeys {
+		if _, known := knownStateKeys[k]; known {
+			continue
+		}
+		merged[k] = v
+	}
+	data, err := json.MarshalIndent(merged, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal merged state: %w", err)
+	}
+	data = append(data, '\n')
+
+	tmp := stateTmpPath(path)
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("create tmp: %w", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("sync tmp: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("close tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
+// stateTmpPath returns the sibling tempfile path used by the atomic
+// write protocol. Leading dot matches the in-vault tmp convention so
+// PKM tools that skip dotfiles also skip a half-written state file.
+func stateTmpPath(path string) string {
+	dir, base := filepath.Split(path)
+	return filepath.Join(dir, "."+base+".tmp")
+}
+
+// LayoutFirstSeen returns the recorded first-seen time for layout
+// mode, or nil if the mode has not yet been observed under this state.
+func (s State) LayoutFirstSeen(mode string) *time.Time {
+	if s.VaultLayoutFirstSeen == nil {
+		return nil
+	}
+	return s.VaultLayoutFirstSeen[mode]
+}
+
+// RecordLayoutFirstSeen sets the first-seen time for mode to now if it
+// is not already recorded. Returns true when a new entry was written
+// (i.e. the caller should persist the updated state).
+//
+// Existing entries are never overwritten so a daemon restart does not
+// reset the soak-TTL counter.
+func (s *State) RecordLayoutFirstSeen(mode string, now time.Time) bool {
+	if s.VaultLayoutFirstSeen == nil {
+		s.VaultLayoutFirstSeen = make(map[string]*time.Time)
+	}
+	if existing := s.VaultLayoutFirstSeen[mode]; existing != nil {
+		return false
+	}
+	t := now
+	s.VaultLayoutFirstSeen[mode] = &t
+	return true
+}
+
+// ResetLayoutCounters clears all VaultLayoutFirstSeen entries and the
+// last-warn timestamp. Called by the "vault_path change semantics"
+// rule when the configured vault_path no longer matches the recorded
+// State.VaultPath, since soak counters from the previous vault have
+// no meaning against the new one.
+func (s *State) ResetLayoutCounters() {
+	s.VaultLayoutFirstSeen = nil
+	s.VaultLayoutLastSoakWarn = nil
+	s.VaultMigrationDocWritten = false
+}

--- a/internal/store/state_test.go
+++ b/internal/store/state_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLoadState_Missing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	s, err := loadStateFrom(path)
+	if err != nil {
+		t.Fatalf("loadStateFrom missing file: %v", err)
+	}
+	if s.Version != CurrentStateVersion {
+		t.Errorf("missing-file should produce CurrentStateVersion, got %d", s.Version)
+	}
+	if s.VaultLayoutFirstSeen != nil {
+		t.Errorf("VaultLayoutFirstSeen should be nil, got %+v", s.VaultLayoutFirstSeen)
+	}
+}
+
+func TestWriteState_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	now := time.Date(2026, 5, 24, 14, 0, 0, 0, time.UTC)
+	in := State{
+		Version:   1,
+		VaultPath: "/home/u/vault",
+	}
+	if !in.RecordLayoutFirstSeen("both", now) {
+		t.Fatal("RecordLayoutFirstSeen should report true on first record")
+	}
+	if in.RecordLayoutFirstSeen("both", now.Add(time.Hour)) {
+		t.Fatal("RecordLayoutFirstSeen should not overwrite existing entry")
+	}
+
+	if err := writeStateTo(path, in); err != nil {
+		t.Fatalf("writeStateTo: %v", err)
+	}
+
+	out, err := loadStateFrom(path)
+	if err != nil {
+		t.Fatalf("loadStateFrom after write: %v", err)
+	}
+	if out.VaultPath != in.VaultPath {
+		t.Errorf("VaultPath: got %q, want %q", out.VaultPath, in.VaultPath)
+	}
+	if got := out.LayoutFirstSeen("both"); got == nil || !got.Equal(now) {
+		t.Errorf("LayoutFirstSeen(both): got %v, want %v", got, now)
+	}
+}
+
+func TestWriteState_PreservesUnknownKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	// Pretend a future daemon wrote state.json at the current version
+	// with extra top-level keys this daemon does not know about.
+	raw := []byte(`{
+  "version": 1,
+  "vault_path": "/v",
+  "future_key": {"nested": true},
+  "another_extra": "preserved"
+}`)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := loadStateFrom(path)
+	if err != nil {
+		t.Fatalf("loadStateFrom: %v", err)
+	}
+	if _, ok := s.UnknownKeys["future_key"]; !ok {
+		t.Errorf("future_key not captured; got %+v", s.UnknownKeys)
+	}
+
+	// Write back; unknown keys should still be present in the file.
+	if err := writeStateTo(path, s); err != nil {
+		t.Fatalf("writeStateTo: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	var rt map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rt); err != nil {
+		t.Fatalf("re-decode: %v", err)
+	}
+	if _, ok := rt["future_key"]; !ok {
+		t.Errorf("future_key dropped on write; got %s", data)
+	}
+	if _, ok := rt["another_extra"]; !ok {
+		t.Errorf("another_extra dropped on write; got %s", data)
+	}
+}
+
+func TestLoadState_VersionAhead(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	raw := []byte(`{"version": 99}`)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := loadStateFrom(path)
+	if !errors.Is(err, ErrStateVersionAhead) {
+		t.Errorf("expected ErrStateVersionAhead, got %v", err)
+	}
+}
+
+func TestWriteState_RefusesFutureVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	err := writeStateTo(path, State{Version: 99})
+	if !errors.Is(err, ErrStateVersionAhead) {
+		t.Errorf("expected ErrStateVersionAhead, got %v", err)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Errorf("file should not exist after refused write; stat: %v", statErr)
+	}
+}
+
+func TestWriteState_SweepsStaleTmp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	tmp := stateTmpPath(path)
+	if err := os.WriteFile(tmp, []byte("garbage"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// loadStateFrom should sweep the stale tmp before returning.
+	if _, err := loadStateFrom(path); err != nil {
+		t.Fatalf("loadStateFrom: %v", err)
+	}
+	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+		t.Errorf("stale tmp not swept; stat: %v", err)
+	}
+}
+
+func TestResetLayoutCounters(t *testing.T) {
+	now := time.Now().UTC()
+	s := State{Version: 1}
+	s.RecordLayoutFirstSeen("both", now)
+	warn := now.Add(time.Hour)
+	s.VaultLayoutLastSoakWarn = &warn
+
+	s.ResetLayoutCounters()
+	if s.VaultLayoutFirstSeen != nil {
+		t.Errorf("VaultLayoutFirstSeen not cleared: %+v", s.VaultLayoutFirstSeen)
+	}
+	if s.VaultLayoutLastSoakWarn != nil {
+		t.Errorf("VaultLayoutLastSoakWarn not cleared: %v", s.VaultLayoutLastSoakWarn)
+	}
+}

--- a/internal/store/vault_indexing_test.go
+++ b/internal/store/vault_indexing_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestResolvedVaultIndexingScopeExplicit(t *testing.T) {
@@ -140,6 +141,69 @@ func TestResolveVaultIndexingRoots(t *testing.T) {
 				if got[i] != c.want[i] {
 					t.Errorf("roots[%d]: got %q want %q", i, got[i], c.want[i])
 				}
+			}
+		})
+	}
+}
+
+// 🎯T64.2 — vault_layout resolution defaults and explicit override.
+func TestResolvedVaultLayoutExplicit(t *testing.T) {
+	for _, want := range []string{VaultLayoutV2, VaultLayoutBoth, VaultLayoutV1} {
+		t.Run(want, func(t *testing.T) {
+			cfg := Config{VaultLayout: VaultLayoutConfig{Mode: want}}
+			if got := cfg.ResolvedVaultLayout(t.TempDir()); got != want {
+				t.Errorf("explicit layout %q lost: got %q", want, got)
+			}
+		})
+	}
+}
+
+func TestResolvedVaultLayoutDefaultsNewVault(t *testing.T) {
+	cfg := Config{}
+	if got := cfg.ResolvedVaultLayout(t.TempDir()); got != VaultLayoutV2 {
+		t.Errorf("empty vault should default to %q, got %q", VaultLayoutV2, got)
+	}
+}
+
+func TestResolvedVaultLayoutDefaultsV1Vault(t *testing.T) {
+	vault := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(vault, "sessions"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := Config{}
+	if got := cfg.ResolvedVaultLayout(vault); got != VaultLayoutBoth {
+		t.Errorf("v1 vault should default to %q for migration continuity, got %q",
+			VaultLayoutBoth, got)
+	}
+}
+
+func TestVaultLayoutEffectiveSoakWarnAfter(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"default", "", defaultVaultLayoutSoakWarnAfter, false},
+		{"valid", "168h", 168 * time.Hour, false},
+		{"malformed", "thirty days", 0, true},
+		{"negative", "-1h", 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			lc := VaultLayoutConfig{SoakWarnAfter: c.in}
+			got, err := lc.EffectiveSoakWarnAfter()
+			if c.wantErr {
+				if err == nil {
+					t.Errorf("expected error for %q, got %v", c.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("got %v want %v", got, c.want)
 			}
 		})
 	}

--- a/internal/store/vault_indexing_test.go
+++ b/internal/store/vault_indexing_test.go
@@ -184,7 +184,7 @@ func TestVaultLayoutEffectiveSoakWarnAfter(t *testing.T) {
 		want    time.Duration
 		wantErr bool
 	}{
-		{"default", "", defaultVaultLayoutSoakWarnAfter, false},
+		{"default", "", DefaultVaultLayoutSoakWarnAfter, false},
 		{"valid", "168h", 168 * time.Hour, false},
 		{"malformed", "thirty days", 0, true},
 		{"negative", "-1h", 0, true},

--- a/internal/tools/config_tool_test.go
+++ b/internal/tools/config_tool_test.go
@@ -152,3 +152,35 @@ func TestConfigToolNoControllerAvailable(t *testing.T) {
 		t.Errorf("expected error when controller not wired")
 	}
 }
+
+// TestConfigToolWriteRejectsMalformedSoakWarnAfter ensures the
+// mnemo_config write path surfaces a malformed vault_layout
+// configuration synchronously instead of letting it fall through to
+// the resolver, where it would have silently degraded to the package
+// default. The user sees the error at write time, not as a vanished
+// override on next sync.
+func TestConfigToolWriteRejectsMalformedSoakWarnAfter(t *testing.T) {
+	ctl := &fakeCtl{cur: store.Config{}}
+	ch := &callHandler{}
+	out, isErr, err := ch.config(map[string]any{
+		"op": "write",
+		"patch": map[string]any{
+			"vault_layout": map[string]any{
+				"mode":            "both",
+				"soak_warn_after": "thirty days",
+			},
+		},
+	}, ctl)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !isErr {
+		t.Errorf("expected tool-level error for malformed soak_warn_after, got: %s", out)
+	}
+	if !strings.Contains(out, "soak_warn_after") {
+		t.Errorf("error should mention soak_warn_after, got: %s", out)
+	}
+	if ctl.last.VaultLayout.SoakWarnAfter != "" {
+		t.Errorf("controller should not have received the bad config; got %q", ctl.last.VaultLayout.SoakWarnAfter)
+	}
+}

--- a/internal/tools/main_test.go
+++ b/internal/tools/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marcelocantos/mnemo/internal/store"
+)
+
+// TestMain isolates state.json (🎯T64.2) into a per-process temp
+// directory so tests exercising mnemo_vault_status do not read or
+// write the daemon user's real ~/.mnemo/state.json.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "mnemo-tools-state-")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	sub := filepath.Join(dir, ".mnemo")
+	_ = os.MkdirAll(sub, 0o755)
+	restore := store.SetStateDirForTesting(sub)
+	defer restore()
+
+	os.Exit(m.Run())
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -2465,10 +2465,7 @@ func vaultLayoutRecommendation(layout, vaultPath string, hoursInBoth int64, soak
 // Used by the recommendation state machine and by the migration-doc
 // snapshotter.
 func hasV1MarkerDirs(vaultPath string) bool {
-	for _, d := range []string{
-		"sessions", "decisions", "memories", "skills", "configs",
-		"plans", "targets", "ci", "prs", "repos",
-	} {
+	for _, d := range store.V1VaultMarkerDirs {
 		if fi, err := os.Stat(filepath.Join(vaultPath, d)); err == nil && fi.IsDir() {
 			return true
 		}
@@ -2518,6 +2515,9 @@ func (h *callHandler) config(args map[string]any, ctl ConfigController) (string,
 		current := ctl.Get()
 		merged, err := mergeConfigPatch(current, patch)
 		if err != nil {
+			return fmt.Sprintf("patch invalid: %v", err), true, nil
+		}
+		if _, err := merged.VaultLayout.EffectiveSoakWarnAfter(); err != nil {
 			return fmt.Sprintf("patch invalid: %v", err), true, nil
 		}
 		report, err := ctl.Put(merged)

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -32,6 +32,8 @@ import (
 type VaultSyncer interface {
 	Sync(ctx context.Context) error
 	Path() string
+	MigrationDocSnapshot() string
+	WriteMigrationDoc() (string, error)
 }
 
 // CompactorHealthReporter is satisfied by *compact.Watcher.
@@ -600,7 +602,19 @@ Human content added below the <!-- mnemo:generated --> fence in any vault note i
 Vault must be configured via vault_path in ~/.mnemo/config.json.`),
 		),
 		mcp.NewTool("mnemo_vault_status",
-			mcp.WithDescription("Report vault configuration: whether vault is enabled, the vault root path, the active indexing scope (vault_indexing_scope) with its includes and .mnemoignore file state, and a count of notes on disk by section."),
+			mcp.WithDescription("Report vault configuration: whether vault is enabled, the vault root path, the active indexing scope (vault_indexing_scope) with its includes and .mnemoignore file state, the resolved vault_layout (v1/both/v2) with soak counter and migration recommendation, and a count of notes on disk by section."),
+		),
+		mcp.NewTool("mnemo_vault_migration_doc",
+			mcp.WithDescription(`Return or rewrite the v1→v2 layout MIGRATION.md snapshot.
+
+Modes:
+  - write=false (default): return the current state-of-vault snapshot as text without touching the filesystem. Use this to inspect what would be written without persisting.
+  - write=true: idempotently render the snapshot to <vault>/_mnemo/MIGRATION.md, overwriting any existing file. Use this to restore the doc after deleting it, or to refresh it after the v1 layout state changes.
+
+MIGRATION.md is normally write-once: mnemo creates it the first sync that observes a v1 layout and never regenerates it. Deleting it tells mnemo "I have read this; move on." This tool is the user-initiated escape hatch when you want the doc back.
+
+Requires vault_path to be configured.`),
+			mcp.WithBoolean("write", mcp.Description("If true, persist the snapshot to <vault>/_mnemo/MIGRATION.md. Default: false (snapshot only).")),
 		),
 		mcp.NewTool("mnemo_compactor_status",
 			mcp.WithDescription(`Report the live state of mnemo's background session compactor (🎯T67). Returns:
@@ -749,6 +763,8 @@ func (h *Handler) Call(ctx context.Context, cc CallContext, name string, args ma
 		return ch.vaultStatus(h.cfgCtl)
 	case "mnemo_compactor_status":
 		return ch.compactorStatus(h.resolveCompactor)
+	case "mnemo_vault_migration_doc":
+		return ch.vaultMigrationDoc(args)
 	case "mnemo_config":
 		return ch.config(args, h.cfgCtl)
 	default:
@@ -2277,6 +2293,30 @@ func (h *callHandler) vaultStatus(ctl ConfigController) (string, bool, error) {
 	}
 	fmt.Fprintf(&b, "  ignore_file: %s (%s)\n\n", ignoreFile, ignoreState)
 
+	// Vault layout (🎯T64.2). Surfaces the resolved mode, soak counter
+	// (days_in_both), and recommendation per the design's state
+	// machine so the user can audit whether a "both" vault is still
+	// within its migration window.
+	layout := cfg.ResolvedVaultLayout(vaultPath)
+	b.WriteString("Layout:\n")
+	fmt.Fprintf(&b, "  mode:        %s", layout)
+	if cfg.VaultLayout.Mode == "" {
+		b.WriteString("  (auto-default)")
+	}
+	b.WriteString("\n")
+
+	state, _ := store.LoadState()
+	soakAfter, _ := cfg.VaultLayout.EffectiveSoakWarnAfter()
+	hoursInBoth, daysInBoth := computeHoursInBoth(state, layout)
+	if layout == store.VaultLayoutBoth {
+		fmt.Fprintf(&b, "  days_in_both: %d (soak_warn_after: %s)\n", daysInBoth, soakAfter)
+	}
+	rec := vaultLayoutRecommendation(layout, vaultPath, hoursInBoth, soakAfter)
+	if rec != "" {
+		fmt.Fprintf(&b, "  recommendation: %s\n", rec)
+	}
+	b.WriteString("\n")
+
 	b.WriteString("Notes on disk:\n")
 	total := 0
 	for _, sec := range sections {
@@ -2355,6 +2395,85 @@ func (h *callHandler) compactorStatus(resolve func(username string) CompactorHea
 	}
 
 	return b.String(), false, nil
+}
+
+// vaultMigrationDoc implements mnemo_vault_migration_doc. The default
+// (write: false) returns the current state-of-vault snapshot without
+// touching the filesystem; write: true overwrites _mnemo/MIGRATION.md
+// with the same content, returning the path written to.
+func (h *callHandler) vaultMigrationDoc(args map[string]any) (string, bool, error) {
+	if h.vault == nil {
+		return vaultNotConfigured, false, nil
+	}
+	write, _ := args["write"].(bool)
+	if !write {
+		return h.vault.MigrationDocSnapshot(), false, nil
+	}
+	path, err := h.vault.WriteMigrationDoc()
+	if err != nil {
+		return fmt.Sprintf("write migration doc failed: %v", err), true, nil
+	}
+	return fmt.Sprintf("wrote %s", path), false, nil
+}
+
+// computeHoursInBoth returns (hours, days) elapsed since the daemon
+// first observed layout="both" for the current vault, or (0, 0) when
+// the current resolved layout is not "both" or no first-seen entry
+// has been recorded yet.
+func computeHoursInBoth(state store.State, layout string) (hours, days int64) {
+	if layout != store.VaultLayoutBoth {
+		return 0, 0
+	}
+	t := state.LayoutFirstSeen(store.VaultLayoutBoth)
+	if t == nil {
+		return 0, 0
+	}
+	delta := time.Since(*t)
+	if delta < 0 {
+		return 0, 0
+	}
+	h := int64(delta / time.Hour)
+	d := int64((delta + 12*time.Hour) / (24 * time.Hour))
+	return h, d
+}
+
+// vaultLayoutRecommendation implements the state machine from
+// docs/design/vault-library-wing.md. Pure function of observable
+// state, so the recommendation always matches what the user sees.
+//
+// Returns "" (empty) when no migration action is owed.
+func vaultLayoutRecommendation(layout, vaultPath string, hoursInBoth int64, soakAfter time.Duration) string {
+	soakAfterHours := int64(soakAfter / time.Hour)
+	switch layout {
+	case store.VaultLayoutBoth:
+		if hoursInBoth >= soakAfterHours {
+			return "opt into v2"
+		}
+		return "still within soak"
+	case store.VaultLayoutV2:
+		if hasV1MarkerDirs(vaultPath) {
+			return "run gc_legacy"
+		}
+		return ""
+	default:
+		return ""
+	}
+}
+
+// hasV1MarkerDirs reports whether any of the v1 root-level marker
+// directories (sessions/, decisions/, ...) exist under vaultPath.
+// Used by the recommendation state machine and by the migration-doc
+// snapshotter.
+func hasV1MarkerDirs(vaultPath string) bool {
+	for _, d := range []string{
+		"sessions", "decisions", "memories", "skills", "configs",
+		"plans", "targets", "ci", "prs", "repos",
+	} {
+		if fi, err := os.Stat(filepath.Join(vaultPath, d)); err == nil && fi.IsDir() {
+			return true
+		}
+	}
+	return false
 }
 
 // countMDFiles counts *.md files recursively under dir.
@@ -2440,6 +2559,7 @@ var knownConfigKeys = map[string]struct{}{
 	"vault_indexing_scope":       {},
 	"vault_indexing_includes":    {},
 	"vault_indexing_ignore_file": {},
+	"vault_layout":               {},
 	"linked_instances":           {},
 }
 

--- a/internal/vault/main_test.go
+++ b/internal/vault/main_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package vault
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marcelocantos/mnemo/internal/store"
+)
+
+// TestMain isolates state.json (🎯T64.2) into a per-process temp
+// directory so the test suite never reads or writes the daemon user's
+// real ~/.mnemo/state.json. Vault Sync calls maintainStateAndWarn,
+// which would otherwise touch the user's home.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "mnemo-vault-state-")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	// Mirror the daemon's layout: state.json lives under .mnemo/
+	// relative to the override root.
+	sub := filepath.Join(dir, ".mnemo")
+	_ = os.MkdirAll(sub, 0o755)
+	restore := store.SetStateDirForTesting(sub)
+	defer restore()
+
+	os.Exit(m.Run())
+}

--- a/internal/vault/namespace.go
+++ b/internal/vault/namespace.go
@@ -1,0 +1,273 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package vault
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/marcelocantos/mnemo/internal/store"
+)
+
+// mnemoNamespaceDir is the v2 layout's reserved subdirectory under the
+// vault root (🎯T64.2). Every mnemo-generated abstraction lives under
+// here; user notes live alongside it untouched.
+const mnemoNamespaceDir = "_mnemo"
+
+// migrationDocName is the write-once file documenting a v1→v2
+// migration. Created the first sync that observes any v1 marker dir,
+// then never regenerated unless the user opts back in via the
+// mnemo_vault_migration_doc MCP tool.
+const migrationDocName = "MIGRATION.md"
+
+// syncMnemoNamespace writes <vault>/_mnemo/{index.md,README.md} and,
+// on first v1-detection, the write-once MIGRATION.md.
+//
+// Layout-gating: caller invokes only when the resolved layout is "v2"
+// or "both". v1 vaults skip this entirely (the _mnemo/ wing does not
+// exist for them).
+//
+// All writes use writeNote, so the standard fence contract applies:
+// human edits below the <!-- mnemo:generated --> fence survive
+// re-syncs. The single exception is MIGRATION.md, which is written
+// without a fence and never touched again.
+func (e *Exporter) syncMnemoNamespace() error {
+	wingDir := filepath.Join(e.path, mnemoNamespaceDir)
+	if err := os.MkdirAll(wingDir, 0o755); err != nil {
+		return fmt.Errorf("vault: mkdir %s: %w", wingDir, err)
+	}
+
+	if err := writeNote(filepath.Join(wingDir, "index.md"), renderMnemoIndex(), ""); err != nil {
+		return fmt.Errorf("vault: write _mnemo/index.md: %w", err)
+	}
+	if err := writeNote(filepath.Join(wingDir, "README.md"), renderMnemoREADME(), ""); err != nil {
+		return fmt.Errorf("vault: write _mnemo/README.md: %w", err)
+	}
+
+	// MIGRATION.md is write-once. Only create it when v1 dirs are
+	// present AND state.json records no prior write for this vault. A
+	// user who deletes the file is signalling "I have read this; move
+	// on" — state.VaultMigrationDocWritten stays true and we honour
+	// that by not recreating it. Reading and writing state here is
+	// best-effort: failures log and proceed so a state.json problem
+	// never blocks the rest of the sync.
+	v1Dirs := detectV1Dirs(e.path)
+	if len(v1Dirs) > 0 {
+		state, err := store.LoadState()
+		if err != nil {
+			return fmt.Errorf("vault: load state for migration-doc gate: %w", err)
+		}
+		if !state.VaultMigrationDocWritten {
+			migPath := filepath.Join(wingDir, migrationDocName)
+			content := renderMigrationDoc(e.path, v1Dirs)
+			if err := os.WriteFile(migPath, []byte(content), 0o644); err != nil {
+				return fmt.Errorf("vault: write _mnemo/MIGRATION.md: %w", err)
+			}
+			state.VaultMigrationDocWritten = true
+			if err := store.WriteState(state); err != nil {
+				return fmt.Errorf("vault: persist migration-doc flag: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// detectV1Dirs returns the subset of v1 marker dirs that exist under
+// vaultPath. Used by the namespace writer (for MIGRATION.md gating)
+// and by the migration-doc tool (to summarise what would be migrated).
+//
+// The list mirrors store.v1VaultMarkerDirs but is duplicated here to
+// avoid coupling the vault package to that unexported symbol. Drift
+// risk is low: the v1 layout is frozen.
+func detectV1Dirs(vaultPath string) []string {
+	candidates := []string{
+		"sessions", "decisions", "memories", "skills", "configs",
+		"plans", "targets", "ci", "prs", "repos",
+	}
+	var present []string
+	for _, d := range candidates {
+		if fi, err := os.Stat(filepath.Join(vaultPath, d)); err == nil && fi.IsDir() {
+			present = append(present, d)
+		}
+	}
+	return present
+}
+
+// renderMnemoIndex returns the content of <vault>/_mnemo/index.md —
+// the entry point for the mnemo-generated wing of the vault.
+func renderMnemoIndex() string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString("tags:\n")
+	b.WriteString("  - mnemo\n")
+	b.WriteString("  - mnemo/index\n")
+	b.WriteString("---\n\n")
+	b.WriteString("# mnemo library wing\n\n")
+	b.WriteString("Generated knowledge — themes, patterns, cross-repo views, ")
+	b.WriteString("lessons, filtered decisions, and indexed memories — ")
+	b.WriteString("produced by [mnemo](https://github.com/marcelocantos/mnemo).\n\n")
+
+	b.WriteString("## Collections\n\n")
+	b.WriteString("- `themes/` — cross-session clusters of related work\n")
+	b.WriteString("- `patterns/` — recurring workflow patterns\n")
+	b.WriteString("- `cross-repo/` — themes spanning multiple repositories\n")
+	b.WriteString("- `lessons/` — distilled feedback and confirmed decisions\n")
+	b.WriteString("- `decisions/` — high-signal decisions filtered from sessions\n")
+	b.WriteString("- `memories/` — auto-memory files indexed across projects\n\n")
+
+	b.WriteString("## Conventions\n\n")
+	b.WriteString("Every file under `_mnemo/` carries the `mnemo` tag plus a ")
+	b.WriteString("`mnemo/<type>` tag. Filter your graph or search by ")
+	b.WriteString("`-tag:mnemo` to exclude the wing entirely; query ")
+	b.WriteString("`FROM \"_mnemo\"` to scope to it.\n\n")
+	b.WriteString("Content above the `<!-- mnemo:generated -->` fence is owned ")
+	b.WriteString("by mnemo and regenerated on each sync. Annotations below ")
+	b.WriteString("the fence are yours and are preserved across re-syncs.\n")
+
+	return b.String()
+}
+
+// renderMnemoREADME returns the content of <vault>/_mnemo/README.md —
+// orientation for a user who opens the directory cold.
+func renderMnemoREADME() string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString("tags:\n")
+	b.WriteString("  - mnemo\n")
+	b.WriteString("  - mnemo/readme\n")
+	b.WriteString("---\n\n")
+	b.WriteString("# _mnemo/ — generated knowledge wing\n\n")
+	b.WriteString("This directory is the mnemo daemon's writable workspace inside ")
+	b.WriteString("your vault. Everything you see here was written by ")
+	b.WriteString("[mnemo](https://github.com/marcelocantos/mnemo) from indexed ")
+	b.WriteString("session transcripts, memories, and decisions.\n\n")
+
+	b.WriteString("## Two contracts to know about\n\n")
+	b.WriteString("1. **Fence contract.** Every file (except `MIGRATION.md`) ")
+	b.WriteString("uses an `<!-- mnemo:generated -->` HTML comment to ")
+	b.WriteString("separate generated content above from your annotations ")
+	b.WriteString("below. mnemo rewrites everything above the fence on ")
+	b.WriteString("every sync; everything below is yours and is preserved.\n\n")
+	b.WriteString("2. **`MIGRATION.md` write-once.** When mnemo first detects ")
+	b.WriteString("that your vault was populated by the v1 layout (root-level ")
+	b.WriteString("`sessions/`, `decisions/`, ...), it writes this file ")
+	b.WriteString("**once** to explain what changed. mnemo does not ")
+	b.WriteString("regenerate it on subsequent syncs. If you delete it, ")
+	b.WriteString("mnemo takes that as \"I have read this; move on\" and ")
+	b.WriteString("will not recreate it. To get the doc back, run ")
+	b.WriteString("`mnemo_vault_migration_doc(write: true)` from any ")
+	b.WriteString("MCP-aware client.\n\n")
+
+	b.WriteString("## Index\n\n")
+	b.WriteString("See [[_mnemo/index|index]] for the collections.\n\n")
+
+	b.WriteString("## Safe to touch?\n\n")
+	b.WriteString("Below-fence content: yes, freely. Mnemo never touches it.\n")
+	b.WriteString("Above-fence content: edits will be overwritten on the next ")
+	b.WriteString("sync — copy anything worth keeping below the fence first.\n")
+	b.WriteString("Whole files: deleting them is fine; mnemo will recreate ")
+	b.WriteString("the generated ones on the next sync (except `MIGRATION.md` ")
+	b.WriteString("per the contract above).\n")
+	return b.String()
+}
+
+// renderMigrationDoc produces the body of MIGRATION.md given the
+// vault path and the list of detected v1 dirs.
+//
+// The doc is intentionally narrow: it explains the layout change and
+// points the user at the gc_legacy tool (slice 9). It does not claim
+// what has migrated where, since the per-collection migrations land
+// across subsequent slices. The doc is the "read me first" pointer,
+// not a manifest.
+func renderMigrationDoc(vaultPath string, v1Dirs []string) string {
+	sort.Strings(v1Dirs)
+	var b strings.Builder
+	b.WriteString("# mnemo vault — v1 → v2 layout migration\n\n")
+	b.WriteString("This vault was populated under mnemo's v1 layout, which ")
+	b.WriteString("wrote generated notes to root-level directories alongside ")
+	b.WriteString("your own files. As of mnemo v0.43+, generated content ")
+	b.WriteString("lives under `_mnemo/` so it never collides with your ")
+	b.WriteString("own structure.\n\n")
+
+	b.WriteString("## What mnemo saw\n\n")
+	b.WriteString("The following root-level v1 directories are present in ")
+	b.WriteString("this vault:\n\n")
+	for _, d := range v1Dirs {
+		fmt.Fprintf(&b, "- `%s/`\n", d)
+	}
+	b.WriteString("\n")
+
+	b.WriteString("## What happens next\n\n")
+	b.WriteString("- `vault_layout` defaults to `\"both\"` on a v1-populated ")
+	b.WriteString("vault. mnemo writes to both root-level dirs and `_mnemo/` ")
+	b.WriteString("so nothing you currently rely on disappears.\n")
+	b.WriteString("- After a soak window (30 days by default), mnemo emits a ")
+	b.WriteString("weekly warning suggesting you opt into pure v2.\n")
+	b.WriteString("- `mnemo_vault_gc_legacy` (forthcoming) is the user-")
+	b.WriteString("initiated path that removes the v1 root-level dirs once ")
+	b.WriteString("you are satisfied with the new layout.\n\n")
+
+	b.WriteString("## Opting in early\n\n")
+	b.WriteString("Set `vault_layout.mode = \"v2\"` in `~/.mnemo/config.json` ")
+	b.WriteString("(or via `mnemo_config`). New syncs will stop writing v1 ")
+	b.WriteString("paths immediately; existing v1 files remain on disk until ")
+	b.WriteString("you run `gc_legacy`.\n\n")
+
+	b.WriteString("## This file\n\n")
+	b.WriteString("`MIGRATION.md` is **write-once**. mnemo will not ")
+	b.WriteString("regenerate it. If you delete it, mnemo will not recreate ")
+	b.WriteString("it. To get a fresh snapshot, run ")
+	b.WriteString("`mnemo_vault_migration_doc(write: true)`.\n")
+	return b.String()
+}
+
+// MigrationDocSnapshot returns the current MIGRATION.md content
+// without writing anything. Used by the mnemo_vault_migration_doc MCP
+// tool's `write: false` mode.
+func (e *Exporter) MigrationDocSnapshot() string {
+	return renderMigrationDoc(e.path, detectV1Dirs(e.path))
+}
+
+// WriteMigrationDoc renders and writes MIGRATION.md to the vault's
+// _mnemo/ directory unconditionally (overwriting any existing file).
+// Used by mnemo_vault_migration_doc(write: true) so a user who deleted
+// the file can get a fresh snapshot on demand.
+//
+// The directory is created if missing. Returns the path written to so
+// the caller can include it in the tool response.
+func (e *Exporter) WriteMigrationDoc() (string, error) {
+	wingDir := filepath.Join(e.path, mnemoNamespaceDir)
+	if err := os.MkdirAll(wingDir, 0o755); err != nil {
+		return "", fmt.Errorf("vault: mkdir %s: %w", wingDir, err)
+	}
+	path := filepath.Join(wingDir, migrationDocName)
+	content := renderMigrationDoc(e.path, detectV1Dirs(e.path))
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return "", fmt.Errorf("vault: write _mnemo/MIGRATION.md: %w", err)
+	}
+	// Also pin the write-once flag so the periodic sync path keeps
+	// honouring deletion as "move on" rather than recreating.
+	state, err := store.LoadState()
+	if err == nil {
+		state.VaultMigrationDocWritten = true
+		_ = store.WriteState(state)
+	}
+	return path, nil
+}
+
+// resolveLayoutHooked is a package-level seam used by the exporter's
+// Sync to look up the active layout. Real callers set this from the
+// registry (which reads the live config); tests can override.
+//
+// store import is intentional here even though we only need string
+// constants: keeping them in one place avoids drift if the design
+// adds a fourth layout mode.
+var (
+	_ = store.VaultLayoutV2
+	_ = store.VaultLayoutBoth
+	_ = store.VaultLayoutV1
+)

--- a/internal/vault/namespace.go
+++ b/internal/vault/namespace.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -49,27 +50,43 @@ func (e *Exporter) syncMnemoNamespace() error {
 	}
 
 	// MIGRATION.md is write-once. Only create it when v1 dirs are
-	// present AND state.json records no prior write for this vault. A
-	// user who deletes the file is signalling "I have read this; move
-	// on" — state.VaultMigrationDocWritten stays true and we honour
-	// that by not recreating it. Reading and writing state here is
-	// best-effort: failures log and proceed so a state.json problem
-	// never blocks the rest of the sync.
+	// present AND neither the on-disk file nor state.json records a
+	// prior write. A user who deletes the file is signalling "I have
+	// read this; move on" — we honour that by not recreating it. Two
+	// sources of truth gate the write so the contract survives a
+	// state.json that is unhealthy precisely when the contract matters
+	// most (disk full, permission failure on the state write).
+	// Reading and writing state here is best-effort: failures log and
+	// proceed so a state.json problem never blocks the rest of the
+	// sync.
 	v1Dirs := detectV1Dirs(e.path)
 	if len(v1Dirs) > 0 {
 		state, err := store.LoadState()
 		if err != nil {
-			return fmt.Errorf("vault: load state for migration-doc gate: %w", err)
+			slog.Warn("vault: load state for migration-doc gate failed; skipping MIGRATION.md", "err", err)
+			return nil
+		}
+		migPath := filepath.Join(wingDir, migrationDocName)
+		if _, statErr := os.Stat(migPath); statErr == nil {
+			// File already on disk — honour as already-written. Pin the
+			// flag if state.json missed it so future syncs (and the
+			// soak-warn path) see a consistent view.
+			if !state.VaultMigrationDocWritten {
+				state.VaultMigrationDocWritten = true
+				if err := store.WriteState(state); err != nil {
+					slog.Warn("vault: pin migration-doc flag failed", "err", err)
+				}
+			}
+			return nil
 		}
 		if !state.VaultMigrationDocWritten {
-			migPath := filepath.Join(wingDir, migrationDocName)
 			content := renderMigrationDoc(e.path, v1Dirs)
 			if err := os.WriteFile(migPath, []byte(content), 0o644); err != nil {
 				return fmt.Errorf("vault: write _mnemo/MIGRATION.md: %w", err)
 			}
 			state.VaultMigrationDocWritten = true
 			if err := store.WriteState(state); err != nil {
-				return fmt.Errorf("vault: persist migration-doc flag: %w", err)
+				slog.Warn("vault: persist migration-doc flag failed; file written", "err", err)
 			}
 		}
 	}
@@ -79,17 +96,9 @@ func (e *Exporter) syncMnemoNamespace() error {
 // detectV1Dirs returns the subset of v1 marker dirs that exist under
 // vaultPath. Used by the namespace writer (for MIGRATION.md gating)
 // and by the migration-doc tool (to summarise what would be migrated).
-//
-// The list mirrors store.v1VaultMarkerDirs but is duplicated here to
-// avoid coupling the vault package to that unexported symbol. Drift
-// risk is low: the v1 layout is frozen.
 func detectV1Dirs(vaultPath string) []string {
-	candidates := []string{
-		"sessions", "decisions", "memories", "skills", "configs",
-		"plans", "targets", "ci", "prs", "repos",
-	}
 	var present []string
-	for _, d := range candidates {
+	for _, d := range store.V1VaultMarkerDirs {
 		if fi, err := os.Stat(filepath.Join(vaultPath, d)); err == nil && fi.IsDir() {
 			present = append(present, d)
 		}
@@ -258,16 +267,3 @@ func (e *Exporter) WriteMigrationDoc() (string, error) {
 	}
 	return path, nil
 }
-
-// resolveLayoutHooked is a package-level seam used by the exporter's
-// Sync to look up the active layout. Real callers set this from the
-// registry (which reads the live config); tests can override.
-//
-// store import is intentional here even though we only need string
-// constants: keeping them in one place avoids drift if the design
-// adds a fourth layout mode.
-var (
-	_ = store.VaultLayoutV2
-	_ = store.VaultLayoutBoth
-	_ = store.VaultLayoutV1
-)

--- a/internal/vault/namespace_test.go
+++ b/internal/vault/namespace_test.go
@@ -256,6 +256,117 @@ func TestVaultPathChangeResetsCounters(t *testing.T) {
 	}
 }
 
+// TestNoOpSyncDoesNotRewriteState verifies that a sync against a
+// vault whose state is already current does not rewrite state.json.
+// Regression for the maintainStateAndWarn bug where the `changed`
+// flag was unconditionally true after the VaultPath assignment,
+// triggering an atomic state-file write on every sync.
+func TestNoOpSyncDoesNotRewriteState(t *testing.T) {
+	dir, _ := os.MkdirTemp("", "mnemo-noop-state-")
+	defer os.RemoveAll(dir)
+	restore := store.SetStateDirForTesting(dir)
+	defer restore()
+
+	_, exp := newVaultForTest(t)
+	// v2 layout: no root-level v1 dirs get written, no MIGRATION.md
+	// gating runs. The only state.json writer in this path is
+	// maintainStateAndWarn, which is exactly what the regression
+	// targets.
+	exp.SetLayoutResolver(func() string { return store.VaultLayoutV2 })
+
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync 1: %v", err)
+	}
+	statePath := filepath.Join(dir, "state.json")
+
+	// Backdate the file so any rewrite is detectable by mtime.
+	past := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(statePath, past, past); err != nil {
+		t.Fatal(err)
+	}
+	stat1, err := os.Stat(statePath)
+	if err != nil {
+		t.Fatalf("stat state.json: %v", err)
+	}
+
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync 2: %v", err)
+	}
+	stat2, err := os.Stat(statePath)
+	if err != nil {
+		t.Fatalf("stat state.json after second sync: %v", err)
+	}
+	if !stat1.ModTime().Equal(stat2.ModTime()) {
+		t.Errorf("state.json rewritten on no-op sync; mtime moved %v → %v",
+			stat1.ModTime(), stat2.ModTime())
+	}
+}
+
+// TestMigrationDocStateClearedFileExists verifies that an existing
+// MIGRATION.md on disk is honoured as already-written even when
+// state.json was cleared (e.g. wiped manually, or a prior state-write
+// failed). The on-disk file is the load-bearing source of truth for
+// the write-once contract; state.json is a hint.
+func TestMigrationDocStateClearedFileExists(t *testing.T) {
+	dir, _ := os.MkdirTemp("", "mnemo-migclear-state-")
+	defer os.RemoveAll(dir)
+	restore := store.SetStateDirForTesting(dir)
+	defer restore()
+
+	vaultDir, exp := newVaultForTest(t)
+	exp.SetLayoutResolver(func() string { return store.VaultLayoutBoth })
+
+	if err := os.MkdirAll(filepath.Join(vaultDir, "sessions"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Manually plant a MIGRATION.md with a sentinel payload to ensure
+	// the syncer does not overwrite it.
+	wingDir := filepath.Join(vaultDir, mnemoNamespaceDir)
+	if err := os.MkdirAll(wingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	migPath := filepath.Join(wingDir, migrationDocName)
+	sentinel := []byte("USER-EDITED MIGRATION CONTENT\n")
+	if err := os.WriteFile(migPath, sentinel, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Leave state.json empty: VaultMigrationDocWritten is false.
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	got, err := os.ReadFile(migPath)
+	if err != nil {
+		t.Fatalf("MIGRATION.md missing: %v", err)
+	}
+	if string(got) != string(sentinel) {
+		t.Errorf("MIGRATION.md clobbered; got %q, want %q", got, sentinel)
+	}
+
+	// Flag should have been back-filled from the on-disk file so the
+	// next sync sees a consistent view.
+	s, _ := store.LoadState()
+	if !s.VaultMigrationDocWritten {
+		t.Error("VaultMigrationDocWritten was not pinned after on-disk detection")
+	}
+}
+
+// TestSoakWarnAfterDefaultFromStore pins this package's fallback to
+// the exported store constant so the two cannot silently drift. With
+// the constant inlined, a change in store would not break this test;
+// referencing store.DefaultVaultLayoutSoakWarnAfter directly makes a
+// future re-introduction of a local copy fail at compile time.
+func TestSoakWarnAfterDefaultFromStore(t *testing.T) {
+	_, exp := newVaultForTest(t)
+	got := exp.soakWarnAfter()
+	if got != store.DefaultVaultLayoutSoakWarnAfter {
+		t.Errorf("soakWarnAfter default = %v, want store.DefaultVaultLayoutSoakWarnAfter = %v",
+			got, store.DefaultVaultLayoutSoakWarnAfter)
+	}
+}
+
 // newVaultForTest builds an Exporter against a fresh temp store and
 // vault dir. No layout resolver is set — callers configure their own.
 func newVaultForTest(t *testing.T) (string, *Exporter) {

--- a/internal/vault/namespace_test.go
+++ b/internal/vault/namespace_test.go
@@ -1,0 +1,280 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package vault
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marcelocantos/mnemo/internal/store"
+	"github.com/marcelocantos/mnemo/internal/storetest"
+)
+
+// TestSyncWritesMnemoNamespace verifies that a fresh sync creates
+// <vault>/_mnemo/index.md and README.md with the standard fence
+// contract (🎯T64.2 acceptance: "_mnemo/index.md and _mnemo/README.md
+// exist with the standard fence contract").
+func TestSyncWritesMnemoNamespace(t *testing.T) {
+	vaultDir, exp := newVaultForTest(t)
+	exp.SetLayoutResolver(func() string { return store.VaultLayoutV2 })
+
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	for _, name := range []string{"index.md", "README.md"} {
+		path := filepath.Join(vaultDir, mnemoNamespaceDir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("%s missing: %v", name, err)
+		}
+		if !strings.Contains(string(data), generatedFence) {
+			t.Errorf("%s lacks generated fence", name)
+		}
+	}
+}
+
+// TestMigrationDocWriteOnce verifies the MIGRATION.md write-once
+// contract: created on v1-detection, never regenerated even after
+// deletion (🎯T64.2 acceptance: "MIGRATION.md is written once...
+// deletion is respected").
+func TestMigrationDocWriteOnce(t *testing.T) {
+	vaultDir, exp := newVaultForTest(t)
+	exp.SetLayoutResolver(func() string { return store.VaultLayoutBoth })
+
+	// Simulate a v1-populated vault by creating one of the v1 marker
+	// dirs before the first sync.
+	if err := os.MkdirAll(filepath.Join(vaultDir, "sessions"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync 1: %v", err)
+	}
+	migPath := filepath.Join(vaultDir, mnemoNamespaceDir, migrationDocName)
+	first, err := os.ReadFile(migPath)
+	if err != nil {
+		t.Fatalf("MIGRATION.md missing after first sync: %v", err)
+	}
+	if !strings.Contains(string(first), "v1 → v2 layout migration") {
+		t.Errorf("MIGRATION.md body unexpected: %q", first)
+	}
+
+	// Bump mtime then sync again; the doc must not be re-rendered.
+	if err := os.Chtimes(migPath, time.Now().Add(-time.Hour), time.Now().Add(-time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	stat1, _ := os.Stat(migPath)
+
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync 2: %v", err)
+	}
+	stat2, _ := os.Stat(migPath)
+	if !stat1.ModTime().Equal(stat2.ModTime()) {
+		t.Errorf("MIGRATION.md re-written on second sync; mtime moved %v → %v",
+			stat1.ModTime(), stat2.ModTime())
+	}
+
+	// Delete and resync — must not be recreated.
+	if err := os.Remove(migPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync 3: %v", err)
+	}
+	if _, err := os.Stat(migPath); !os.IsNotExist(err) {
+		t.Errorf("MIGRATION.md recreated after deletion; stat: %v", err)
+	}
+}
+
+// TestMigrationDocOnDemand verifies that WriteMigrationDoc
+// (mnemo_vault_migration_doc write: true) recreates the file after
+// deletion — the user-initiated escape hatch.
+func TestMigrationDocOnDemand(t *testing.T) {
+	vaultDir, exp := newVaultForTest(t)
+	exp.SetLayoutResolver(func() string { return store.VaultLayoutBoth })
+
+	if err := os.MkdirAll(filepath.Join(vaultDir, "decisions"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	migPath := filepath.Join(vaultDir, mnemoNamespaceDir, migrationDocName)
+	if err := os.Remove(migPath); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := exp.WriteMigrationDoc()
+	if err != nil {
+		t.Fatalf("WriteMigrationDoc: %v", err)
+	}
+	if got != migPath {
+		t.Errorf("returned path %q, want %q", got, migPath)
+	}
+	if _, err := os.Stat(migPath); err != nil {
+		t.Errorf("MIGRATION.md not present after WriteMigrationDoc: %v", err)
+	}
+
+	snap := exp.MigrationDocSnapshot()
+	if !strings.Contains(snap, "decisions") {
+		t.Errorf("snapshot missing detected v1 dir: %q", snap)
+	}
+}
+
+// TestLayoutGating verifies the v2/both/v1 layout gates the right
+// writers (🎯T64.2 + design's "what each mode writes" rule).
+func TestLayoutGating(t *testing.T) {
+	cases := []struct {
+		layout      string
+		wantMnemo   bool
+		wantV1Root  bool // sessions/ or repos/ should exist
+		wantV1Index bool // root index.md
+	}{
+		{store.VaultLayoutV2, true, false, false},
+		{store.VaultLayoutBoth, true, true, true},
+		{store.VaultLayoutV1, false, true, true},
+	}
+	for _, c := range cases {
+		t.Run(c.layout, func(t *testing.T) {
+			vaultDir, exp := newVaultForTest(t)
+			exp.SetLayoutResolver(func() string { return c.layout })
+
+			if err := exp.Sync(context.Background()); err != nil {
+				t.Fatalf("Sync: %v", err)
+			}
+			_, errMnemo := os.Stat(filepath.Join(vaultDir, mnemoNamespaceDir, "index.md"))
+			gotMnemo := errMnemo == nil
+			if gotMnemo != c.wantMnemo {
+				t.Errorf("_mnemo/index.md present=%v, want %v (err: %v)", gotMnemo, c.wantMnemo, errMnemo)
+			}
+
+			_, errIdx := os.Stat(filepath.Join(vaultDir, "index.md"))
+			gotV1Index := errIdx == nil
+			if gotV1Index != c.wantV1Index {
+				t.Errorf("root index.md present=%v, want %v", gotV1Index, c.wantV1Index)
+			}
+		})
+	}
+}
+
+// TestSoakWarningEmitsThenRateLimits verifies the soak-window
+// warning fires once after the threshold and then respects the
+// weekly cadence (🎯T64.2 acceptance: "emits a weekly structured
+// warning; the layout never auto-narrows").
+func TestSoakWarningEmitsThenRateLimits(t *testing.T) {
+	// Use a tight soak window so the test does not depend on the
+	// 720h default. State is isolated by TestMain.
+	dir, _ := os.MkdirTemp("", "mnemo-soak-state-")
+	defer os.RemoveAll(dir)
+	restore := store.SetStateDirForTesting(dir)
+	defer restore()
+
+	vaultDir, exp := newVaultForTest(t)
+	exp.SetLayoutResolver(func() string { return store.VaultLayoutBoth })
+	// 1ns soak window → already tripped from first observation.
+	exp.SetSoakWarnAfterResolver(func() time.Duration { return time.Nanosecond })
+
+	// Seed state with vault_path and a first-seen time so the
+	// computed hours_in_both is non-zero.
+	seed := store.State{
+		Version:   1,
+		VaultPath: vaultDir,
+		VaultLayoutFirstSeen: map[string]*time.Time{
+			store.VaultLayoutBoth: ptrTime(time.Now().Add(-time.Hour).UTC()),
+		},
+	}
+	if err := store.WriteState(seed); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	// First sync — warning should fire, last-warn timestamp recorded.
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync 1: %v", err)
+	}
+	s1, _ := store.LoadState()
+	if s1.VaultLayoutLastSoakWarn == nil {
+		t.Fatal("expected VaultLayoutLastSoakWarn set after threshold-tripped sync")
+	}
+
+	// Second sync immediately after — last-warn timestamp must not
+	// advance (weekly cadence not yet elapsed).
+	firstWarn := *s1.VaultLayoutLastSoakWarn
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync 2: %v", err)
+	}
+	s2, _ := store.LoadState()
+	if s2.VaultLayoutLastSoakWarn == nil || !s2.VaultLayoutLastSoakWarn.Equal(firstWarn) {
+		t.Errorf("warn timestamp advanced within cadence; before=%v after=%v",
+			firstWarn, s2.VaultLayoutLastSoakWarn)
+	}
+}
+
+// TestVaultPathChangeResetsCounters verifies the "vault_path change
+// semantics" rule: when state.json records a different vault path
+// from the active one, the soak counters are reset.
+func TestVaultPathChangeResetsCounters(t *testing.T) {
+	dir, _ := os.MkdirTemp("", "mnemo-reset-state-")
+	defer os.RemoveAll(dir)
+	restore := store.SetStateDirForTesting(dir)
+	defer restore()
+
+	// Pre-seed state.json with a different vault path and a recorded
+	// first-seen time.
+	oldFirstSeen := time.Now().Add(-24 * time.Hour).UTC()
+	seed := store.State{
+		Version:   1,
+		VaultPath: "/some/other/vault",
+		VaultLayoutFirstSeen: map[string]*time.Time{
+			store.VaultLayoutBoth: ptrTime(oldFirstSeen),
+		},
+	}
+	if err := store.WriteState(seed); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	vaultDir, exp := newVaultForTest(t)
+	exp.SetLayoutResolver(func() string { return store.VaultLayoutBoth })
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	s, _ := store.LoadState()
+	if s.VaultPath != vaultDir {
+		t.Errorf("VaultPath: got %q, want %q", s.VaultPath, vaultDir)
+	}
+	got := s.LayoutFirstSeen(store.VaultLayoutBoth)
+	if got == nil {
+		t.Fatal("first-seen entry should have been re-recorded for new vault")
+	}
+	if got.Equal(oldFirstSeen) {
+		t.Errorf("first-seen entry was not reset; still %v from previous vault", oldFirstSeen)
+	}
+}
+
+// newVaultForTest builds an Exporter against a fresh temp store and
+// vault dir. No layout resolver is set — callers configure their own.
+func newVaultForTest(t *testing.T) (string, *Exporter) {
+	t.Helper()
+	projDir := t.TempDir()
+	storetest.WriteJSONL(t, projDir, "-Users-x-dev-app", "sess-ns-01", []map[string]any{
+		storetest.MetaMsg("user", "hi", "2026-05-10T10:00:00Z", "/Users/x/dev/app", "main"),
+		storetest.Msg("assistant", "hi back", "2026-05-10T10:00:01Z"),
+	})
+	s := storetest.NewStore(t, projDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+	vaultDir := t.TempDir()
+	exp, err := New(s, vaultDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return vaultDir, exp
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -107,7 +107,7 @@ type Exporter struct {
 	resolveLayout func() string
 
 	// resolveSoakWarnAfter returns the configured "both"-layout soak
-	// window. Nil → defaultVaultSoakWarnAfter (720h / 30 days).
+	// window. Nil → store.DefaultVaultLayoutSoakWarnAfter (720h / 30 days).
 	resolveSoakWarnAfter func() time.Duration
 }
 
@@ -174,16 +174,15 @@ func (e *Exporter) maintainStateAndWarn(layout string) {
 		return
 	}
 
+	pathReset := false
 	if state.VaultPath != e.path {
 		state.ResetLayoutCounters()
 		state.VaultPath = e.path
+		pathReset = true
 	}
 
 	now := time.Now().UTC()
-	changed := state.RecordLayoutFirstSeen(layout, now)
-	// Bookkeeping field updates we want to persist whether or not the
-	// first-seen entry was new — VaultPath above may have been reset.
-	changed = changed || state.VaultPath == e.path
+	changed := state.RecordLayoutFirstSeen(layout, now) || pathReset
 
 	if layout == store.VaultLayoutBoth {
 		t := state.LayoutFirstSeen(store.VaultLayoutBoth)
@@ -220,19 +219,14 @@ func (e *Exporter) maintainStateAndWarn(layout string) {
 // a full Config.
 func (e *Exporter) soakWarnAfter() time.Duration {
 	if e.resolveSoakWarnAfter == nil {
-		return defaultVaultSoakWarnAfter
+		return store.DefaultVaultLayoutSoakWarnAfter
 	}
 	d := e.resolveSoakWarnAfter()
 	if d <= 0 {
-		return defaultVaultSoakWarnAfter
+		return store.DefaultVaultLayoutSoakWarnAfter
 	}
 	return d
 }
-
-// defaultVaultSoakWarnAfter mirrors store.defaultVaultLayoutSoakWarnAfter
-// (kept duplicated rather than exported to avoid widening the store
-// API for one constant; tests pin both values).
-const defaultVaultSoakWarnAfter = 720 * time.Hour
 
 // activeLayout returns the resolved layout mode for this sync, or
 // VaultLayoutBoth when no resolver is configured (safe default).

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -98,6 +98,17 @@ type Exporter struct {
 	path    string
 	syncMu  sync.Mutex
 	syncing bool
+
+	// resolveLayout returns the active vault layout mode (v1/both/v2)
+	// at sync time. Nil → resolved as VaultLayoutBoth (the safest
+	// default — preserves existing v1 writers while populating the
+	// new _mnemo/ wing). SetLayoutResolver swaps in a live resolver
+	// from the registry, which reads the daemon's current config.
+	resolveLayout func() string
+
+	// resolveSoakWarnAfter returns the configured "both"-layout soak
+	// window. Nil → defaultVaultSoakWarnAfter (720h / 30 days).
+	resolveSoakWarnAfter func() time.Duration
 }
 
 // New creates a new Exporter rooted at path. The directory is created if
@@ -112,6 +123,131 @@ func New(backend store.Backend, path string) (*Exporter, error) {
 
 // Path returns the vault root directory.
 func (e *Exporter) Path() string { return e.path }
+
+// SetLayoutResolver swaps in a function the exporter calls at sync
+// time to learn the active vault_layout mode. The registry passes a
+// closure over its live Config so a hot-reload change to vault_layout
+// takes effect on the next sync without rebuilding the exporter.
+//
+// A nil resolver (the default) is treated as VaultLayoutBoth — the
+// conservative choice that keeps the v1 path active until layout is
+// explicitly set.
+func (e *Exporter) SetLayoutResolver(fn func() string) {
+	e.resolveLayout = fn
+}
+
+// SetSoakWarnAfterResolver swaps in a function the exporter calls at
+// sync time to learn the soak window for the "both" warning. Nil
+// leaves the default (720h) in effect.
+func (e *Exporter) SetSoakWarnAfterResolver(fn func() time.Duration) {
+	e.resolveSoakWarnAfter = fn
+}
+
+// soakWarnCadence is how often the daemon re-emits the
+// "vault_layout=both past soak window" warning once the initial trip
+// has fired. Weekly cadence per the design.
+const soakWarnCadence = 7 * 24 * time.Hour
+
+// maintainStateAndWarn updates ~/.mnemo/state.json for the active
+// layout and emits the soak-window warning when due. Designed as a
+// best-effort sidecar: any error is logged and execution continues so
+// state-file trouble never blocks a vault sync.
+//
+// Rules:
+//   - If state.VaultPath differs from this exporter's path, reset the
+//     layout counters (the recorded soak time belonged to the previous
+//     vault and has no meaning against the new one) and re-record
+//     state.VaultPath.
+//   - Record first-seen for the active layout if not already present.
+//   - When layout == "both" and hours_in_both >= soak window, emit a
+//     structured warning if no prior warning has fired or the last one
+//     was >= soakWarnCadence ago. Persist the warn timestamp.
+//
+// Soak window: pulled from the same Config the layout resolver reads.
+// We approximate by loading state regardless of resolver and reusing
+// the default soak constant when no Config is available — the
+// resolver path always provides one in practice.
+func (e *Exporter) maintainStateAndWarn(layout string) {
+	state, err := store.LoadState()
+	if err != nil {
+		slog.Warn("vault: load state.json failed", "err", err)
+		return
+	}
+
+	if state.VaultPath != e.path {
+		state.ResetLayoutCounters()
+		state.VaultPath = e.path
+	}
+
+	now := time.Now().UTC()
+	changed := state.RecordLayoutFirstSeen(layout, now)
+	// Bookkeeping field updates we want to persist whether or not the
+	// first-seen entry was new — VaultPath above may have been reset.
+	changed = changed || state.VaultPath == e.path
+
+	if layout == store.VaultLayoutBoth {
+		t := state.LayoutFirstSeen(store.VaultLayoutBoth)
+		if t != nil {
+			hoursInBoth := time.Since(*t) / time.Hour
+			soakAfter := e.soakWarnAfter()
+			if hoursInBoth >= soakAfter/time.Hour {
+				if state.VaultLayoutLastSoakWarn == nil ||
+					now.Sub(*state.VaultLayoutLastSoakWarn) >= soakWarnCadence {
+					days := int64((time.Since(*t) + 12*time.Hour) / (24 * time.Hour))
+					slog.Warn(`vault_layout="both" past soak window — opt into "v2" or run mnemo_vault_gc_legacy to finish migrating`,
+						"days_in_both", days,
+						"soak_warn_after", soakAfter,
+						"vault_path", e.path)
+					nowCopy := now
+					state.VaultLayoutLastSoakWarn = &nowCopy
+					changed = true
+				}
+			}
+		}
+	}
+
+	if !changed {
+		return
+	}
+	if err := store.WriteState(state); err != nil {
+		slog.Warn("vault: write state.json failed", "err", err)
+	}
+}
+
+// soakWarnAfter returns the configured soak window. Resolved through
+// a closure the registry installs (resolveSoakWarnAfter); nil falls
+// back to the package default so the package remains testable without
+// a full Config.
+func (e *Exporter) soakWarnAfter() time.Duration {
+	if e.resolveSoakWarnAfter == nil {
+		return defaultVaultSoakWarnAfter
+	}
+	d := e.resolveSoakWarnAfter()
+	if d <= 0 {
+		return defaultVaultSoakWarnAfter
+	}
+	return d
+}
+
+// defaultVaultSoakWarnAfter mirrors store.defaultVaultLayoutSoakWarnAfter
+// (kept duplicated rather than exported to avoid widening the store
+// API for one constant; tests pin both values).
+const defaultVaultSoakWarnAfter = 720 * time.Hour
+
+// activeLayout returns the resolved layout mode for this sync, or
+// VaultLayoutBoth when no resolver is configured (safe default).
+func (e *Exporter) activeLayout() string {
+	if e.resolveLayout == nil {
+		return store.VaultLayoutBoth
+	}
+	mode := e.resolveLayout()
+	switch mode {
+	case store.VaultLayoutV2, store.VaultLayoutBoth, store.VaultLayoutV1:
+		return mode
+	default:
+		return store.VaultLayoutBoth
+	}
+}
 
 // Sync performs a full vault synchronisation: sessions, decisions, memories,
 // plans, targets, CI runs, PRs, per-repo indices, and the root index.
@@ -139,34 +275,51 @@ func (e *Exporter) Sync(ctx context.Context) error {
 		e.syncMu.Unlock()
 	}()
 
-	slog.Info("vault: sync starting", "path", e.path)
+	layout := e.activeLayout()
+	slog.Info("vault: sync starting", "path", e.path, "layout", layout)
 	start := time.Now()
 
-	// Sessions must be synced first: the path map they produce is needed
-	// by decisions (for back-links) and repo indices (for forward-links).
-	sessionPaths, err := e.syncSessions(ctx)
+	// State.json bookkeeping (🎯T64.2): record first-seen for the
+	// active layout so the soak-TTL counter can age, and emit the
+	// weekly warning when "both" sits past the soak window. Failures
+	// here are non-fatal: they log and proceed so a state.json
+	// problem does not block the actual vault write.
+	e.maintainStateAndWarn(layout)
+
 	var firstErr error
 	setErr := func(e error) {
 		if e != nil && firstErr == nil {
 			firstErr = e
 		}
 	}
-	setErr(err)
-	setErr(e.syncDecisions(ctx, sessionPaths))
-	setErr(e.syncMemories(ctx))
-	setErr(e.syncPlans(ctx))
-	setErr(e.syncTargets(ctx))
-	setErr(e.syncCI(ctx))
-	setErr(e.syncPRs(ctx))
-	setErr(e.syncSkills(ctx))
-	setErr(e.syncConfigs(ctx))
-	// Repo indices and root index are written last so they reflect the
-	// session paths already materialised above. Fetch repos once and
-	// pass to both so we avoid two identical ListRepos queries.
-	repos, err := e.backend.ListRepos("")
-	setErr(err)
-	setErr(e.syncRepoIndices(ctx, repos, sessionPaths))
-	setErr(e.syncRootIndex(repos))
+
+	// _mnemo/ namespace (🎯T64.2). Written under v2 and both; skipped
+	// under pure v1 (the wing does not exist in that layout). Runs
+	// first so the wing exists before any subsequent slice tries to
+	// write _mnemo/<collection>/ pages.
+	if layout != store.VaultLayoutV1 {
+		setErr(e.syncMnemoNamespace())
+	}
+
+	// v1 root-level writers (sessions/, decisions/, ...). Skipped
+	// under pure v2; run under v1 and both. Sessions go first because
+	// the path map is needed by decisions and repo indices.
+	if layout != store.VaultLayoutV2 {
+		sessionPaths, err := e.syncSessions(ctx)
+		setErr(err)
+		setErr(e.syncDecisions(ctx, sessionPaths))
+		setErr(e.syncMemories(ctx))
+		setErr(e.syncPlans(ctx))
+		setErr(e.syncTargets(ctx))
+		setErr(e.syncCI(ctx))
+		setErr(e.syncPRs(ctx))
+		setErr(e.syncSkills(ctx))
+		setErr(e.syncConfigs(ctx))
+		repos, err := e.backend.ListRepos("")
+		setErr(err)
+		setErr(e.syncRepoIndices(ctx, repos, sessionPaths))
+		setErr(e.syncRootIndex(repos))
+	}
 
 	slog.Info("vault: sync complete",
 		"elapsed", time.Since(start).Round(time.Millisecond),


### PR DESCRIPTION
## Summary
- Adds `vault_layout` config (`v2` / `both` / `v1`) with auto-default (v2 for new vaults, both for v1-populated for migration continuity) and a configurable soak window (`soak_warn_after`, default 720h).
- Carves out the `_mnemo/` namespace under the vault root: writes `index.md` + `README.md` under the standard fence contract, plus the write-once `MIGRATION.md` on first v1-detection.
- New `~/.mnemo/state.json` sidecar tracks layout first-seen timestamps, last soak-warn time, and the migration-doc write-once flag. Atomic writes, version-aware, preserves unknown keys for downgrade-compat.
- Gates `Exporter.Sync` writers per layout — v2 skips the v1 root-level dirs, v1 skips `_mnemo/`, both writes both.
- `mnemo_vault_status` now surfaces resolved layout, `days_in_both`, and the design's recommendation state machine.
- Emits the design's structured soak warning on first trip past the window and then on a weekly cadence; layout never auto-narrows.
- New `mnemo_vault_migration_doc(write: bool)` MCP tool: snapshot-only by default, idempotent regen of `_mnemo/MIGRATION.md` on `write: true` (covers the documented "deleted, want it back" escape hatch).
- `vault_path` change resets layout counters + the migration-doc flag so the previous vault's soak state doesn't bleed into a new one.

Flips 🎯T64.2 → achieved in `bullseye.yaml`. The MVP v2 boundary now moves to T64.3 (move decisions + memories under `_mnemo/`) → T64.4 (drop raw-signal writers).

## Test plan
- [x] `go build -tags "sqlite_fts5" -o bin/mnemo .`
- [x] `go vet ./...`
- [x] `go test -tags "sqlite_fts5" ./internal/store/...` — passes (pre-existing `TestQuery` sqldeep parse failure on master is unrelated to this PR)
- [x] `go test -tags "sqlite_fts5" ./internal/vault/...`
- [x] `go test -tags "sqlite_fts5" ./internal/tools/...`
- [x] `go test -tags "sqlite_fts5" ./internal/registry/...`
- [x] State round-trip, version-ahead refusal, unknown-key preservation
- [x] Layout resolution: explicit modes + new-vault default + v1-vault default
- [x] `_mnemo/index.md` / `README.md` written with fence
- [x] `MIGRATION.md` write-once across sync, deletion, and resync; on-demand regen via `WriteMigrationDoc`
- [x] Layout-mode gating for v2 / both / v1
- [x] Soak warning fires on first threshold trip then respects the weekly cadence
- [x] `vault_path` change resets counters
- [x] Manual `mnemo_vault_status` + `mnemo_vault_migration_doc(write: false)` sanity check against a real vault before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)