### PR TITLE
Release v0.44.0 (🎯T67 compactor hardening)

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1937,6 +1937,63 @@ targets:
     - T49
     origin: '2026-05-23 design discussion (this session); supersedes the abandoned mid-flight T64 from 2026-05-21 which lost its slot to PR #95''s vault-library-wing parent'
     discovered: 2026-05-23
+  T66:
+    name: mnemo_query's documented schema is the only schema agents reach for; sqlite_master/PRAGMA introspection is structurally discouraged
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - 'mnemo_query''s tool description opens with an explicit exhaustiveness directive: tables/columns listed are the complete public schema for agent queries, sqlite_master/sqlite_schema/PRAGMA table_info are named as anti-patterns, and the agent is told to report a missing-table case as a documentation bug rather than introspect.'
+    - mnemo_query refuses queries that reference sqlite_master, sqlite_schema, or PRAGMA-table-introspection statements; the rejection error points back to the documented schema with the same wording as the tool description, so an agent that didn't read the description learns the rule from the error.
+    - The schema listed in mnemo_query's description is generated at startup from PRAGMA table_info (or equivalent runtime introspection) rather than maintained by hand. Drift between the description and the actual database becomes impossible.
+    - agents-guide.md and the mnemo_query tool description no longer disagree on which tables exist. Either one source is authoritative and the other links to it, or both derive from the same runtime-generated list.
+    - An agent (Claude Sonnet 4.6+ / Opus 4.7+) given an unfamiliar query task against mnemo never reaches for sqlite_master in a fresh-context evaluation run — verified with a representative prompt batch (e.g., 'list all tables', 'find tables related to compactions', 'what columns does messages have').
+    context: |-
+      Recurring observation across multiple Claude sessions: agents asked to query mnemo's DB reach for `SELECT name FROM sqlite_master ...` even though the `mnemo_query` tool description fully enumerates the schema. Two compounding causes: (a) the description never says "this list is exhaustive" so agents read it as a selection rather than a contract, and (b) the description and agents-guide.md have drifted — each looks incomplete next to the other, which itself cues an agent to introspect "to see what else is there". Fixing both the directive wording and the drift removes the cue; a runtime rejection of sqlite_master queries provides a defence-in-depth that teaches the rule via the error message for agents that skipped the description.
+
+      Also exposed an unrelated documentation gap: tables like `compactions`, `targets`, `plans`, `session_chains`, `notes` (post-T65) are missing from one or both of the two documentation sources.
+
+      Discovered 2026-05-26 during compactor-status diagnosis: the parent session attempted `SELECT name FROM sqlite_master ...` after a prior session had made the same mistake.
+    origin: manual
+    discovered: 2026-05-26
+  T67:
+    name: Compactor watcher converges promptly under normal load, never goes silent for hours, and self-reports its health
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - 'SelectCompactionCandidates picks sessions using TWO triggers OR-ed together: (a) >= N substantive messages SINCE the latest compaction''s entry_id_to (or since first_msg when no prior compaction exists), OR (b) >= 1 such message AND >= t minutes elapsed since session.last_msg. N and t are configurable on WatcherConfig with sensible defaults (e.g., N=50, t=15min). This matches T59''s original design (bullseye.yaml:1596 specified ''since most recent compaction''; the implementation drifted to lifetime substantive_msgs) AND captures small sessions that never reach N but go quiet — currently those never get compacted at all.'
+    - SelectCompactionCandidates excludes sessions whose cumulative compaction tokens already meet or exceed Compactor.maxRatio of the session's tokens. The budget check, currently post-selection, is also a candidate-set filter so wasted ticks on budget-exhausted sessions go to zero in steady state.
+    - outcomeBudgetExceeded logs at DEBUG, not INFO. The default daemon log no longer accumulates thousands of budget_exceeded INFO lines per day.
+    - pollCIForRepo does NOT hold store.rwmu.Lock across any gh subprocess invocation or log fetch. Either the subprocess calls happen before the lock is taken, or the upsert+log-fetch loop drops and re-acquires the lock per row. Compactor RLock acquisition latency under steady CI-poll load stays bounded (a few seconds at worst).
+    - The Watcher applies a per-tick timeout (e.g. 5 minutes) so a single stuck tick — claudia subprocess hang, lock contention, runaway query — cannot silence the entire watcher loop. A timed-out tick is logged at WARN with the candidate's session_id and elapsed time.
+    - The daemon exposes a goroutine dump on demand — pprof endpoint, a SIGUSR1 handler that writes a runtime stack dump to a known path, or a mnemo_self / new MCP tool that surfaces watcher progress (last_scan_at, last_tick_at, in_flight_session). Future silences can be diagnosed without restarting the daemon.
+    - Compactor exposes lifecycle metrics queryable via mnemo (e.g. last successful compaction timestamp, candidates returned by last scan, count of budget_exceeded vs compacted in last N ticks). A mnemo_status or dedicated tool surfaces them so 'is the compactor working?' is answerable without grepping /opt/homebrew/var/log/mnemo.log.
+    context: |-
+      Diagnosed 2026-05-26 during a 'is the compactor working?' investigation.
+
+      Observations:
+      - 35 successful compactions over 2 days, vs 9,376 budget_exceeded ticks — the wasted-tick ratio is ~270:1.
+      - Today's tick log: compactor ran every ~60s from 07:00–07:34 Sydney, then intervals grew (37min, 47min, 2h, 5h+), then went silent at 11:05. Daemon otherwise alive (CI poller, backup, connection sweeper still firing) and no claudia subprocess present. Strongly suggests the watcher goroutine is blocked on a sync primitive, most likely rwmu.RLock contention.
+
+      Root causes (in priority order):
+
+      1. **Trigger drift from T59 design + missing OR-clause.** T59's context (bullseye.yaml:1596) specified "more than N substantive messages SINCE THE MOST RECENT COMPACTION for that session (or since first_msg if none)". Implementation uses ss.substantive_msgs (lifetime total) — so once a session has ever crossed 50, it stays a candidate forever, leading to the wasted-tick storm. Additionally, the original design only fires on the message-count trigger; short sessions (< N substantive) never compact at all, even after going dormant. The right shape is OR-ed:
+         - >= N substantive messages SINCE last compaction's entry_id_to, OR
+         - >= 1 such message AND >= t minutes idle since last_msg
+         The second clause captures small but settled sessions. Not found in the written design or session transcripts — either lost from a verbal discussion or just intuitive design that was never codified. Both halves go in.
+
+      2. **rwmu.Lock-during-gh-subprocess.** pollCIForRepo (store.go:2499) takes s.rwmu.Lock() and then shells out to `gh run view --log` for every failed run before releasing. With 3190 'CI poll failed' messages today (~11 per 5-min cycle) the write lock is held across many slow subprocess calls per poll. The compactor's checkBudget path takes RLock, blocks behind that. Load-bearing cause of today's silence.
+
+      3. **No per-tick timeout in Watcher.** A single stuck tick blocks the whole watcher loop indefinitely.
+
+      4. **Observability gap.** There is no in-product way to ask the daemon 'is the compactor running, when did it last tick, what was the outcome'. Diagnosis required reading /opt/homebrew/var/log/mnemo.log and pid inspection.
+
+      Currently, session 73837c9a (this conversation, 441 substantive msgs, never compacted) is a fresh candidate but no scan has acknowledged it for 5+ hours.
+
+      Fix scope: the trigger redesign + rwmu-during-gh issue are the load-bearing root causes; everything else is supporting hardening.
+    origin: manual
+    discovered: 2026-05-26
   T7:
     name: Agent-defined query templates
     status: achieved

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1958,7 +1958,7 @@ targets:
     discovered: 2026-05-26
   T67:
     name: Compactor watcher converges promptly under normal load, never goes silent for hours, and self-reports its health
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -1994,6 +1994,7 @@ targets:
       Fix scope: the trigger redesign + rwmu-during-gh issue are the load-bearing root causes; everything else is supporting hardening.
     origin: manual
     discovered: 2026-05-26
+    achieved: 2026-05-26
   T7:
     name: Agent-defined query templates
     status: achieved

--- a/internal/compact/compact.go
+++ b/internal/compact/compact.go
@@ -164,6 +164,13 @@ func New(s storeBackend, caller LLMCaller, cfg Config) *Compactor {
 	return c
 }
 
+// MaxTokenRatio reports the configured cumulative-summariser-cost
+// budget cap as a ratio of the tracked session's own token cost.
+// The Watcher reads it to pre-filter budget-exhausted sessions at
+// the candidate-selection level (🎯T67), so checkBudget no longer
+// has to be load-bearing for the budget_exceeded outcome.
+func (c *Compactor) MaxTokenRatio() float64 { return c.maxRatio }
+
 // ErrNothingToCompact indicates the session has no messages past the
 // most recent compaction. Not a real error — callers poll on this.
 var ErrNothingToCompact = errors.New("compact: nothing new to compact")

--- a/internal/compact/watcher.go
+++ b/internal/compact/watcher.go
@@ -17,22 +17,46 @@ import (
 	"github.com/marcelocantos/mnemo/internal/targets"
 )
 
-// WatcherConfig tunes the activity-driven Watcher (🎯T59). Zero
-// values mean "use defaults".
+// WatcherConfig tunes the activity-driven Watcher (🎯T59, expanded
+// 🎯T67). Zero values mean "use defaults".
 type WatcherConfig struct {
 	// ScanInterval is how often the watcher scans session_summary
 	// for compaction candidates. Default: 1 minute.
 	ScanInterval time.Duration
 
-	// MinMessages is the minimum substantive_msgs for a session to
-	// be considered. Sessions below this never get a tick.
-	// Default: 50.
-	MinMessages int
+	// MinDeltaMessages is trigger A's threshold: a session qualifies
+	// if it has accumulated this many substantive messages since its
+	// latest compaction's entry_id_to (or since first_msg if no
+	// prior compaction exists). Pre-T67 this was measured against
+	// the session's lifetime substantive_msgs counter — the
+	// implementation drift that left already-compacted sessions
+	// stuck in the candidate set forever. Default: 50.
+	MinDeltaMessages int
+
+	// IdleTimeout is trigger B's idle threshold: a session with at
+	// least one new substantive message AND last_msg older than
+	// (now - IdleTimeout) qualifies. Captures small/one-shot
+	// sessions that never reach MinDeltaMessages but go quiet long
+	// enough to be worth summarising for restore. Default: 15
+	// minutes.
+	IdleTimeout time.Duration
 
 	// RecencyWindow caps how stale a session's last_msg may be and
-	// still be considered. Sessions whose latest message is older
-	// than (now - RecencyWindow) are skipped. Default: 4 hours.
+	// still be considered at all. Sessions whose latest message is
+	// older than (now - RecencyWindow) are dropped, regardless of
+	// trigger. Default: 24 hours — wide enough that an "idle for a
+	// few hours" session still gets compacted via trigger B, but
+	// narrow enough that long-dead sessions don't keep flowing
+	// through the SQL.
 	RecencyWindow time.Duration
+
+	// TickTimeout caps wall-clock time for a single compactor.Compact
+	// call. A stuck claudia subprocess, runaway query, or lock
+	// contention that exceeds the timeout cancels the tick and the
+	// watcher proceeds to the next candidate. Without this, a single
+	// pathological tick wedges the entire scan loop indefinitely.
+	// Default: 5 minutes.
+	TickTimeout time.Duration
 
 	// MaxCandidates caps the number of sessions returned by one
 	// scan, sorted most-recently-active first. Default: 100.
@@ -46,18 +70,32 @@ func (c *WatcherConfig) scanInterval() time.Duration {
 	return time.Minute
 }
 
-func (c *WatcherConfig) minMessages() int {
-	if c.MinMessages > 0 {
-		return c.MinMessages
+func (c *WatcherConfig) minDeltaMessages() int {
+	if c.MinDeltaMessages > 0 {
+		return c.MinDeltaMessages
 	}
 	return 50
+}
+
+func (c *WatcherConfig) idleTimeout() time.Duration {
+	if c.IdleTimeout > 0 {
+		return c.IdleTimeout
+	}
+	return 15 * time.Minute
 }
 
 func (c *WatcherConfig) recencyWindow() time.Duration {
 	if c.RecencyWindow > 0 {
 		return c.RecencyWindow
 	}
-	return 4 * time.Hour
+	return 24 * time.Hour
+}
+
+func (c *WatcherConfig) tickTimeout() time.Duration {
+	if c.TickTimeout > 0 {
+		return c.TickTimeout
+	}
+	return 5 * time.Minute
 }
 
 func (c *WatcherConfig) maxCandidates() int {
@@ -68,17 +106,27 @@ func (c *WatcherConfig) maxCandidates() int {
 }
 
 // storeSource is the narrow slice of the store the Watcher needs.
-// Under the activity-driven model (🎯T59), candidate selection
-// scans session_summary directly; daemon_connections is consulted
-// only for best-effort connection_id attribution and is exposed
-// via the CompactionCandidate already filled by the store.
+// Under the activity-driven model (🎯T59) — and the dual-trigger
+// candidate filter added in 🎯T67 — selection scans session_summary
+// directly with a delta-message and idle-time computation;
+// daemon_connections is consulted only for best-effort connection_id
+// attribution and is exposed via the CompactionCandidate already
+// filled by the store.
 type storeSource interface {
-	// SelectCompactionCandidates returns sessions worth a tick:
-	// substantive_msgs ≥ minMsgs AND last_msg > recencyCutoff,
-	// capped at limit rows, most-recently-active first. Each
-	// candidate carries the session's CWD and best-effort
-	// ConnectionID (empty if no binding exists).
-	SelectCompactionCandidates(minMsgs int, recencyCutoff time.Time, limit int) ([]store.CompactionCandidate, error)
+	// SelectCompactionCandidates returns sessions worth a tick under
+	// the 🎯T67 dual-trigger model. See store.SelectCompactionCandidates
+	// for the full semantics; in summary, a session qualifies when
+	// last_msg is within recencyCutoff AND it has new substantive
+	// messages since the latest compaction AND either delta >=
+	// minDeltaMsgs OR last_msg <= idleCutoff. maxBudgetRatio
+	// pre-filters budget-exhausted sessions.
+	SelectCompactionCandidates(
+		minDeltaMsgs int,
+		idleCutoff time.Time,
+		recencyCutoff time.Time,
+		maxBudgetRatio float64,
+		limit int,
+	) ([]store.CompactionCandidate, error)
 	// SessionCWD returns the cwd recorded for a session, used by
 	// loadTargetContext to find a bullseye.yaml alongside the
 	// session's working tree. Empty if unknown.
@@ -104,8 +152,13 @@ type Watcher struct {
 	cfg        WatcherConfig
 	excludeCWD string
 
-	mu    sync.Mutex
-	lastN int // candidates returned by the last scan (for tests)
+	mu              sync.Mutex
+	lastN           int       // candidates returned by the last scan
+	lastScanAt      time.Time // wall clock of the last scan return
+	lastTickAt      time.Time // wall clock of the last tick completion
+	lastTickOutcome tickOutcome
+	inFlightSession string // session_id currently being ticked (or "")
+	counts          map[tickOutcome]int64
 }
 
 // NewWatcher builds an activity-driven watcher. excludeCWD is the
@@ -119,6 +172,51 @@ func NewWatcher(src storeSource, c *Compactor, cfg WatcherConfig, excludeCWD str
 		compactor:  c,
 		cfg:        cfg,
 		excludeCWD: excludeCWD,
+		counts:     map[tickOutcome]int64{},
+	}
+}
+
+// HealthSnapshot is the externally-visible state of the watcher,
+// surfaced by the mnemo_compactor_status MCP tool. Lets agents (and
+// humans) answer "is the compactor working, what was its last
+// outcome, what is it doing right now?" without grepping the daemon
+// log.
+type HealthSnapshot struct {
+	LastScanAt       time.Time
+	LastScanCount    int
+	LastTickAt       time.Time
+	LastTickOutcome  string
+	InFlightSession  string
+	Counts           map[string]int64
+	ScanInterval     time.Duration
+	IdleTimeout      time.Duration
+	RecencyWindow    time.Duration
+	TickTimeout      time.Duration
+	MinDeltaMessages int
+	MaxTokenRatio    float64
+}
+
+// Health returns a snapshot of the watcher's runtime state.
+func (w *Watcher) Health() HealthSnapshot {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	counts := make(map[string]int64, len(w.counts))
+	for k, v := range w.counts {
+		counts[string(k)] = v
+	}
+	return HealthSnapshot{
+		LastScanAt:       w.lastScanAt,
+		LastScanCount:    w.lastN,
+		LastTickAt:       w.lastTickAt,
+		LastTickOutcome:  string(w.lastTickOutcome),
+		InFlightSession:  w.inFlightSession,
+		Counts:           counts,
+		ScanInterval:     w.cfg.scanInterval(),
+		IdleTimeout:      w.cfg.idleTimeout(),
+		RecencyWindow:    w.cfg.recencyWindow(),
+		TickTimeout:      w.cfg.tickTimeout(),
+		MinDeltaMessages: w.cfg.minDeltaMessages(),
+		MaxTokenRatio:    w.compactor.MaxTokenRatio(),
 	}
 }
 
@@ -149,15 +247,22 @@ func (w *Watcher) LastScanCount() int {
 
 func (w *Watcher) scan(ctx context.Context) {
 	now := time.Now()
-	cutoff := now.Add(-w.cfg.recencyWindow())
+	idleCutoff := now.Add(-w.cfg.idleTimeout())
+	recencyCutoff := now.Add(-w.cfg.recencyWindow())
 	cands, err := w.src.SelectCompactionCandidates(
-		w.cfg.minMessages(), cutoff, w.cfg.maxCandidates())
+		w.cfg.minDeltaMessages(),
+		idleCutoff,
+		recencyCutoff,
+		w.compactor.MaxTokenRatio(),
+		w.cfg.maxCandidates(),
+	)
 	if err != nil {
 		slog.Warn("compact: scan candidates failed", "err", err)
 		return
 	}
 	w.mu.Lock()
 	w.lastN = len(cands)
+	w.lastScanAt = time.Now()
 	w.mu.Unlock()
 
 	for _, c := range cands {
@@ -165,6 +270,7 @@ func (w *Watcher) scan(ctx context.Context) {
 			return
 		}
 		if w.excludeCWD != "" && strings.HasPrefix(c.CWD, w.excludeCWD) {
+			w.recordOutcome(c.SessionID, outcomeSkippedSelf)
 			slog.Debug("compact: tick",
 				"session_id", c.SessionID,
 				"outcome", string(outcomeSkippedSelf))
@@ -183,22 +289,69 @@ const (
 	outcomeNothingToCompact tickOutcome = "nothing_to_compact"
 	outcomeBudgetExceeded   tickOutcome = "budget_exceeded"
 	outcomeFailed           tickOutcome = "failed"
+	outcomeTimeout          tickOutcome = "timeout"
 	outcomeSkippedSelf      tickOutcome = "skipped_self"
 )
 
-// tick runs one compaction attempt for one candidate session. The
-// candidate's CWD has already been checked against excludeCWD at
-// scan time; we still load the target graph from cwd to anchor the
-// summariser prompt.
+// recordOutcome bumps the lifetime counter for outcome and records
+// the most recent tick state. Safe to call concurrently.
+func (w *Watcher) recordOutcome(sessionID string, outcome tickOutcome) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.counts == nil {
+		w.counts = map[tickOutcome]int64{}
+	}
+	w.counts[outcome]++
+	w.lastTickAt = time.Now()
+	w.lastTickOutcome = outcome
+	if sessionID != "" {
+		w.inFlightSession = ""
+	}
+}
+
+// markInFlight publishes which session is currently being ticked.
+// Health() readers use this to distinguish "watcher is working" from
+// "watcher is stuck".
+func (w *Watcher) markInFlight(sessionID string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.inFlightSession = sessionID
+}
+
+// tick runs one compaction attempt for one candidate session under a
+// bounded timeout (🎯T67). The candidate's CWD has already been
+// checked against excludeCWD at scan time; we still load the target
+// graph from cwd to anchor the summariser prompt. A tick that
+// exceeds w.cfg.TickTimeout is cancelled and recorded as
+// outcomeTimeout — the watcher proceeds to the next candidate rather
+// than wedging on a single stuck call.
 func (w *Watcher) tick(ctx context.Context, c store.CompactionCandidate) {
+	w.markInFlight(c.SessionID)
+
+	tickCtx, cancel := context.WithTimeout(ctx, w.cfg.tickTimeout())
+	defer cancel()
+
+	start := time.Now()
 	tc := w.loadTargetContext(c.SessionID)
-	outcome, extra := w.runTick(ctx, c, tc)
+	outcome, extra := w.runTick(tickCtx, c, tc)
+	elapsed := time.Since(start)
+
+	// runTick may have observed the context deadline as a generic
+	// failure; reclassify so the log entry and metrics call it a
+	// timeout, which the watcher treats as a non-fatal "skip and
+	// move on".
+	if outcome == outcomeFailed && tickCtx.Err() == context.DeadlineExceeded {
+		outcome = outcomeTimeout
+		extra = []any{"elapsed", elapsed}
+	}
+
+	w.recordOutcome(c.SessionID, outcome)
 
 	level := slog.LevelDebug
 	switch outcome {
-	case outcomeCompacted, outcomeBudgetExceeded:
+	case outcomeCompacted:
 		level = slog.LevelInfo
-	case outcomeFailed:
+	case outcomeFailed, outcomeTimeout:
 		level = slog.LevelWarn
 	}
 

--- a/internal/compact/watcher_test.go
+++ b/internal/compact/watcher_test.go
@@ -25,7 +25,13 @@ type fakeStoreSource struct {
 	candidates []store.CompactionCandidate
 }
 
-func (f *fakeStoreSource) SelectCompactionCandidates(minMsgs int, recencyCutoff time.Time, limit int) ([]store.CompactionCandidate, error) {
+func (f *fakeStoreSource) SelectCompactionCandidates(
+	minDeltaMsgs int,
+	idleCutoff time.Time,
+	recencyCutoff time.Time,
+	maxBudgetRatio float64,
+	limit int,
+) ([]store.CompactionCandidate, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	out := make([]store.CompactionCandidate, len(f.candidates))
@@ -264,6 +270,100 @@ func TestTickLogCompacted(t *testing.T) {
 	}
 	if !strings.Contains(got, "level=INFO") {
 		t.Errorf("compacted should be INFO, got: %s", got)
+	}
+}
+
+// TestTickLogBudgetExceededIsDebug verifies 🎯T67's log-level
+// demotion: budget_exceeded ticks log at DEBUG, not INFO, so the
+// default daemon log no longer accumulates thousands of
+// budget_exceeded INFO lines per day.
+func TestTickLogBudgetExceededIsDebug(t *testing.T) {
+	buf, restore := captureSlog()
+	defer restore()
+
+	// fakeStore configured so checkBudget returns ErrBudgetExceeded
+	// on the very first call (compTokens=100, sessTokens=100, ratio
+	// 1.0 >> 0.10).
+	// Seed: session tokens 100 in / 0 out, plus a prior compaction
+	// of 80 + 20 = 100 tokens. The ratio (100/100 = 1.0) exceeds
+	// the default 0.10 budget, so the next Compact call returns
+	// ErrBudgetExceeded.
+	fs := &fakeStore{
+		session:   "sess-broke",
+		msgs:      []store.SessionMessage{{ID: 1, Role: "user", Text: "hi"}},
+		sessionIn: 100,
+	}
+	if _, err := fs.PutCompaction(store.Compaction{
+		SessionID:    "sess-broke",
+		PromptTokens: 80,
+		OutputTokens: 20,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	src := &fakeStoreSource{}
+	src.setCandidates(store.CompactionCandidate{
+		SessionID: "sess-broke", CWD: "/work/proj",
+	})
+	llm := &stubNopLLM{}
+	compactor := New(fs, llm, Config{})
+	w := NewWatcher(src, compactor, WatcherConfig{
+		ScanInterval: 10 * time.Millisecond,
+	}, "")
+
+	runUntil(t, w, func() bool { return strings.Contains(buf.String(), string(outcomeBudgetExceeded)) })
+
+	got := buf.String()
+	if !strings.Contains(got, string(outcomeBudgetExceeded)) {
+		t.Errorf("expected outcome=%s in log, got: %s", outcomeBudgetExceeded, got)
+	}
+	// The pre-T67 implementation logged this at INFO. The 🎯T67 fix
+	// demotes it to DEBUG; the only INFO lines we should see are from
+	// the test harness itself (vault, etc.) — there should be no
+	// compact: tick INFO entry for budget_exceeded.
+	for _, line := range strings.Split(got, "\n") {
+		if strings.Contains(line, "compact: tick") &&
+			strings.Contains(line, string(outcomeBudgetExceeded)) &&
+			strings.Contains(line, "level=INFO") {
+			t.Errorf("budget_exceeded should be DEBUG, got INFO line: %s", line)
+		}
+	}
+}
+
+// TestWatcherHealthSnapshot verifies the runtime introspection
+// surface added in 🎯T67: Health() reflects scan/tick activity and
+// the lifetime outcome counters increment correctly.
+func TestWatcherHealthSnapshot(t *testing.T) {
+	src := &fakeStoreSource{}
+	src.setCandidates(store.CompactionCandidate{
+		SessionID: "sess-ok", CWD: "/work/proj",
+	})
+	llm := &stubNopLLM{}
+	cs := newCountingStore()
+	compactor := New(cs, llm, Config{})
+	w := NewWatcher(src, compactor, WatcherConfig{
+		ScanInterval: 10 * time.Millisecond,
+	}, "")
+
+	runUntil(t, w, func() bool { return llm.calls.Load() >= 1 })
+
+	hs := w.Health()
+	if hs.LastScanAt.IsZero() {
+		t.Errorf("expected LastScanAt to be set after at least one scan")
+	}
+	if hs.LastTickAt.IsZero() {
+		t.Errorf("expected LastTickAt to be set after at least one tick")
+	}
+	if hs.LastTickOutcome != string(outcomeCompacted) {
+		t.Errorf("expected LastTickOutcome=%s, got %q", outcomeCompacted, hs.LastTickOutcome)
+	}
+	if hs.Counts[string(outcomeCompacted)] < 1 {
+		t.Errorf("expected compacted count >= 1, got %d", hs.Counts[string(outcomeCompacted)])
+	}
+	if hs.ScanInterval == 0 {
+		t.Errorf("expected ScanInterval to be reported")
+	}
+	if hs.MinDeltaMessages == 0 {
+		t.Errorf("expected MinDeltaMessages default to be reported")
 	}
 }
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -91,7 +91,8 @@ type Registry struct {
 // transcript ingest pipeline are unaffected by a vault path change.
 type userEntry struct {
 	store             *store.Store
-	vault             *vault.Exporter // nil when vault_path is not configured
+	vault             *vault.Exporter  // nil when vault_path is not configured
+	compactWatcher    *compact.Watcher // background compaction watcher; nil before startWorkers
 	workers           sync.WaitGroup
 	vaultCancel       context.CancelFunc // cancels the vault sub-context; nil when vault disabled
 	vaultWorkers      sync.WaitGroup     // tracks only vault goroutines, so reload can wait for them
@@ -190,6 +191,20 @@ func (r *Registry) VaultFor(username string) *vault.Exporter {
 	return nil
 }
 
+// CompactWatcherFor returns the compaction Watcher for username, or
+// nil when the user has not yet been initialised. Used by the
+// mnemo_compactor_status MCP tool (🎯T67) to surface watcher health
+// — last scan / tick timestamps, in-flight session, lifetime tick
+// counts — without grepping the daemon log.
+func (r *Registry) CompactWatcherFor(username string) *compact.Watcher {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if e, ok := r.stores[username]; ok {
+		return e.compactWatcher
+	}
+	return nil
+}
+
 // startWorkers kicks off the per-user ingest / watcher / compactor /
 // CI-poll goroutines. Each goroutine runs until r.baseCtx is
 // cancelled (Registry.Close) or until it hits a terminal error.
@@ -276,6 +291,7 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 		caller := compact.NewClaudiaCaller(r.mnemoRepoDir, r.compactorModel)
 		compactor := compact.New(e.store, caller, compact.Config{})
 		watcher := compact.NewWatcher(e.store, compactor, compact.WatcherConfig{}, r.mnemoRepoDir)
+		e.compactWatcher = watcher
 		logger.Info("compact: watcher starting")
 		watcher.Run(r.baseCtx)
 	}()

--- a/internal/store/compactions.go
+++ b/internal/store/compactions.go
@@ -201,43 +201,116 @@ type CompactionCandidate struct {
 	ConnectionID string
 }
 
-// SelectCompactionCandidates returns sessions whose substantive
-// message count is at least minMsgs and whose last_msg falls after
-// recencyCutoff. Ordered most-recently-active first; capped at
-// limit rows. Used by the activity-driven compactor watcher
-// (🎯T59) to pick targets independently of any MCP connection
-// binding, so sessions that never called mnemo_self still get
-// compacted.
+// SelectCompactionCandidates returns sessions worth a compaction tick
+// under 🎯T67's dual-trigger model (replaces the pre-T67 lifetime-
+// substantive AND-gated filter that left already-compacted sessions
+// spinning forever and starved small sessions of compaction
+// entirely).
 //
-// ConnectionID is filled from the most recent connection_sessions
-// row for the session if one exists, otherwise left empty. The
-// compactor passes the empty value straight through and
-// PutCompaction stores NULL — the schema column is unchanged
-// (additive policy).
-func (s *Store) SelectCompactionCandidates(minMsgs int, recencyCutoff time.Time, limit int) ([]CompactionCandidate, error) {
+// A session qualifies when its last_msg falls within recencyCutoff
+// (an absolute "don't pointlessly resurrect old sessions" floor) AND
+// it has new substantive messages since the most recent compaction's
+// entry_id_to (or since first_msg if none) — measured against the
+// messages table directly, not the lifetime substantive_msgs counter.
+// Among new-content sessions, EITHER of two triggers fires:
+//
+//  1. delta_substantive_msgs >= minDeltaMsgs (the original T59
+//     spirit, but counted as a delta from latest entry_id_to rather
+//     than from session start).
+//  2. delta_substantive_msgs >= 1 AND last_msg <= idleCutoff —
+//     captures small but settled sessions that never reach
+//     minDeltaMsgs but have gone quiet long enough to be worth
+//     summarising for restore.
+//
+// Sessions whose cumulative compaction-token cost already meets or
+// exceeds maxBudgetRatio of the session's assistant token cost are
+// filtered out at the candidate level, not just inside
+// Compactor.Compact's checkBudget path. This eliminates the
+// budget_exceeded tick storm where the same exhausted session was
+// re-selected every scan until recencyCutoff aged it out.
+//
+// Ordered most-recently-active first; capped at limit rows.
+// ConnectionID is best-effort attribution: the most recently
+// observed connection bound to this session, or empty when no
+// binding exists (additive-only schema, NULL-tolerated).
+func (s *Store) SelectCompactionCandidates(
+	minDeltaMsgs int,
+	idleCutoff time.Time,
+	recencyCutoff time.Time,
+	maxBudgetRatio float64,
+	limit int,
+) ([]CompactionCandidate, error) {
 	s.rwmu.RLock()
 	defer s.rwmu.RUnlock()
 	if limit <= 0 {
 		limit = 100
 	}
-	cutoff := recencyCutoff.UTC().Format(time.RFC3339Nano)
+	if maxBudgetRatio <= 0 {
+		maxBudgetRatio = 0.10
+	}
+	idleCutoffStr := idleCutoff.UTC().Format(time.RFC3339Nano)
+	recencyCutoffStr := recencyCutoff.UTC().Format(time.RFC3339Nano)
 	rows, err := s.db.Query(`
-		SELECT
-		  ss.session_id,
-		  COALESCE(sm.cwd, '') AS cwd,
-		  COALESCE((
-		    SELECT cs.connection_id FROM connection_sessions cs
-		    WHERE cs.session_id = ss.session_id
-		    ORDER BY cs.last_seen_at DESC
-		    LIMIT 1
-		  ), '') AS connection_id
-		FROM session_summary ss
-		LEFT JOIN session_meta sm ON sm.session_id = ss.session_id
-		WHERE ss.last_msg > ?
-		  AND ss.substantive_msgs >= ?
-		ORDER BY ss.last_msg DESC
+		WITH session_state AS (
+		  SELECT
+		    ss.session_id,
+		    ss.last_msg,
+		    COALESCE(sm.cwd, '')                                                                    AS cwd,
+		    COALESCE((
+		      SELECT cs.connection_id FROM connection_sessions cs
+		      WHERE cs.session_id = ss.session_id
+		      ORDER BY cs.last_seen_at DESC
+		      LIMIT 1
+		    ), '')                                                                                  AS connection_id,
+		    COALESCE((
+		      SELECT MAX(entry_id_to) FROM compactions
+		      WHERE session_id = ss.session_id
+		    ), 0)                                                                                   AS last_entry_id,
+		    COALESCE((
+		      SELECT SUM(prompt_tokens + output_tokens) FROM compactions
+		      WHERE session_id = ss.session_id
+		    ), 0)                                                                                   AS comp_tokens,
+		    COALESCE((
+		      SELECT SUM(input_tokens + output_tokens) FROM entries
+		      WHERE session_id = ss.session_id AND type = 'assistant'
+		    ), 0)                                                                                   AS sess_tokens
+		  FROM session_summary ss
+		  LEFT JOIN session_meta sm ON sm.session_id = ss.session_id
+		  WHERE ss.last_msg > ?
+		)
+		SELECT s.session_id, s.cwd, s.connection_id
+		FROM session_state s
+		WHERE
+		  -- Budget filter: skip sessions whose summariser cost has
+		  -- already met the configured ratio. Unmeasurable sessions
+		  -- (zero session tokens) are allowed through; the first
+		  -- compaction has to run before there's anything to measure.
+		  (s.sess_tokens = 0 OR s.comp_tokens * 1.0 / s.sess_tokens < ?)
+		  AND (
+		    -- Trigger A: enough new substantive messages since the
+		    -- session's latest compaction (or since the start of the
+		    -- transcript if none exists).
+		    (SELECT COUNT(*) FROM messages m
+		     WHERE m.session_id = s.session_id
+		       AND m.entry_id > s.last_entry_id
+		       AND m.is_noise = 0
+		    ) >= ?
+		    OR
+		    -- Trigger B: at least one new substantive message AND
+		    -- the session has been idle long enough. Captures small
+		    -- one-shot sessions that never reach the message
+		    -- threshold but are worth summarising once they settle.
+		    (s.last_msg <= ?
+		     AND EXISTS (
+		       SELECT 1 FROM messages m
+		       WHERE m.session_id = s.session_id
+		         AND m.entry_id > s.last_entry_id
+		         AND m.is_noise = 0
+		     ))
+		  )
+		ORDER BY s.last_msg DESC
 		LIMIT ?
-	`, cutoff, minMsgs, limit)
+	`, recencyCutoffStr, maxBudgetRatio, minDeltaMsgs, idleCutoffStr, limit)
 	if err != nil {
 		return nil, fmt.Errorf("select compaction candidates: %w", err)
 	}

--- a/internal/store/compactions_test.go
+++ b/internal/store/compactions_test.go
@@ -94,7 +94,8 @@ func TestSelectCompactionCandidatesUnboundSession(t *testing.T) {
 		t.Fatalf("IngestAll: %v", err)
 	}
 
-	cands, err := s.SelectCompactionCandidates(3, now.Add(-1*time.Hour), 100)
+	cands, err := s.SelectCompactionCandidates(
+		3, now.Add(-15*time.Minute), now.Add(-1*time.Hour), 0.10, 100)
 	if err != nil {
 		t.Fatalf("SelectCompactionCandidates: %v", err)
 	}
@@ -136,7 +137,8 @@ func TestSelectCompactionCandidatesBoundSession(t *testing.T) {
 	// Simulate a live MCP binding for this session.
 	s.RecordConnectionSessionAt("conn-xyz", "sess-bound", now)
 
-	cands, err := s.SelectCompactionCandidates(2, now.Add(-1*time.Hour), 100)
+	cands, err := s.SelectCompactionCandidates(
+		2, now.Add(-15*time.Minute), now.Add(-1*time.Hour), 0.10, 100)
 	if err != nil {
 		t.Fatalf("SelectCompactionCandidates: %v", err)
 	}
@@ -184,7 +186,8 @@ func TestSelectCompactionCandidatesFilters(t *testing.T) {
 		t.Fatalf("IngestAll: %v", err)
 	}
 
-	cands, err := s.SelectCompactionCandidates(3, now.Add(-1*time.Hour), 100)
+	cands, err := s.SelectCompactionCandidates(
+		3, now.Add(-15*time.Minute), now.Add(-1*time.Hour), 0.10, 100)
 	if err != nil {
 		t.Fatalf("SelectCompactionCandidates: %v", err)
 	}
@@ -200,6 +203,195 @@ func TestSelectCompactionCandidatesFilters(t *testing.T) {
 	}
 	if ids["sess-stale"] {
 		t.Errorf("sess-stale should be filtered (outside recency)")
+	}
+}
+
+// TestSelectCompactionCandidatesDeltaTrigger verifies 🎯T67's
+// trigger A: candidate qualifies when delta messages SINCE the
+// session's latest compaction.entry_id_to clear the threshold —
+// even if the lifetime substantive_msgs count is much higher
+// (i.e. the session has already been compacted past most of its
+// history).
+func TestSelectCompactionCandidatesDeltaTrigger(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+
+	// 6 substantive messages, all recent.
+	entries := []map[string]any{
+		msg("user", "m1", now.Add(-6*time.Minute).Format(time.RFC3339)),
+		msg("assistant", "m2", now.Add(-5*time.Minute).Format(time.RFC3339)),
+		msg("user", "m3", now.Add(-4*time.Minute).Format(time.RFC3339)),
+		msg("assistant", "m4", now.Add(-3*time.Minute).Format(time.RFC3339)),
+		msg("user", "m5", now.Add(-2*time.Minute).Format(time.RFC3339)),
+		msg("assistant", "m6", now.Add(-1*time.Minute).Format(time.RFC3339)),
+	}
+	writeJSONL(t, dir, "p", "sess-delta", entries)
+
+	s := newTestStore(t, dir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatalf("IngestAll: %v", err)
+	}
+
+	// Plant a compaction that covers ALL six messages so the delta
+	// drops to zero. Even though lifetime substantive_msgs is 6
+	// (which would qualify under the pre-T67 filter), the session
+	// must NOT be selected because there's nothing new since the
+	// compaction.
+	var maxMsgID int64
+	if err := s.db.QueryRow(`SELECT MAX(id) FROM messages WHERE session_id = 'sess-delta'`).Scan(&maxMsgID); err != nil {
+		t.Fatalf("max msg id: %v", err)
+	}
+	var maxEntryID int64
+	if err := s.db.QueryRow(`SELECT MAX(entry_id) FROM messages WHERE session_id = 'sess-delta'`).Scan(&maxEntryID); err != nil {
+		t.Fatalf("max entry id: %v", err)
+	}
+	if _, err := s.PutCompaction(Compaction{
+		SessionID:    "sess-delta",
+		EntryIDFrom:  0,
+		EntryIDTo:    maxEntryID,
+		PromptTokens: 100,
+		OutputTokens: 20,
+		Summary:      "covers everything",
+	}); err != nil {
+		t.Fatalf("PutCompaction: %v", err)
+	}
+
+	cands, err := s.SelectCompactionCandidates(
+		3, now.Add(-15*time.Minute), now.Add(-1*time.Hour), 0.10, 100)
+	if err != nil {
+		t.Fatalf("SelectCompactionCandidates: %v", err)
+	}
+	for _, c := range cands {
+		if c.SessionID == "sess-delta" {
+			t.Errorf("sess-delta should be filtered: prior compaction covers all messages")
+		}
+	}
+}
+
+// TestSelectCompactionCandidatesIdleTrigger verifies 🎯T67's
+// trigger B: a session with fewer than MinDeltaMessages new
+// substantive messages still qualifies when last_msg is older than
+// idleCutoff. Captures small one-shot sessions that would otherwise
+// never be compacted.
+func TestSelectCompactionCandidatesIdleTrigger(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+
+	// 2 substantive messages, both posted ~30 min ago — below the
+	// MinDeltaMessages=10 threshold but past the idleCutoff=15min mark.
+	writeJSONL(t, dir, "p", "sess-idle", []map[string]any{
+		msg("user", "small q", now.Add(-30*time.Minute).Format(time.RFC3339)),
+		msg("assistant", "small a", now.Add(-29*time.Minute).Format(time.RFC3339)),
+	})
+
+	s := newTestStore(t, dir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatalf("IngestAll: %v", err)
+	}
+
+	cands, err := s.SelectCompactionCandidates(
+		10,                       // minDeltaMsgs — well above the 2 we have
+		now.Add(-15*time.Minute), // idleCutoff: last_msg must be older than this
+		now.Add(-2*time.Hour),    // recencyCutoff: last_msg must be newer than this
+		0.10,
+		100,
+	)
+	if err != nil {
+		t.Fatalf("SelectCompactionCandidates: %v", err)
+	}
+	found := false
+	for _, c := range cands {
+		if c.SessionID == "sess-idle" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("sess-idle should qualify via the idle trigger; got %+v", cands)
+	}
+}
+
+// TestSelectCompactionCandidatesBudgetFilter verifies 🎯T67's
+// candidate-level budget filter: a session whose cumulative
+// compaction tokens already meet maxBudgetRatio of its assistant
+// token cost is dropped from the candidate set, so the watcher
+// never wakes up just to log budget_exceeded.
+func TestSelectCompactionCandidatesBudgetFilter(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+
+	// Build a session with assistant entries carrying real token
+	// counts so the budget ratio resolves to something meaningful.
+	asst := func(text string, ts time.Time, in, out int) map[string]any {
+		return map[string]any{
+			"type":      "assistant",
+			"timestamp": ts.Format(time.RFC3339),
+			"message": map[string]any{
+				"role":    "assistant",
+				"content": text,
+				"usage": map[string]any{
+					"input_tokens":  in,
+					"output_tokens": out,
+				},
+			},
+		}
+	}
+	writeJSONL(t, dir, "p", "sess-broke", []map[string]any{
+		asst("a1", now.Add(-10*time.Minute), 100, 50),
+		msg("user", "u1", now.Add(-9*time.Minute).Format(time.RFC3339)),
+		asst("a2", now.Add(-8*time.Minute), 100, 50),
+		msg("user", "u2", now.Add(-7*time.Minute).Format(time.RFC3339)),
+		asst("a3", now.Add(-6*time.Minute), 100, 50),
+		msg("user", "u3", now.Add(-5*time.Minute).Format(time.RFC3339)),
+		msg("user", "u4", now.Add(-4*time.Minute).Format(time.RFC3339)),
+		msg("user", "u5", now.Add(-3*time.Minute).Format(time.RFC3339)),
+	})
+
+	s := newTestStore(t, dir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatalf("IngestAll: %v", err)
+	}
+
+	// Plant a compaction whose prompt+output already exceed 50% of
+	// the session's 450-token cost (3 × (100+50)).
+	if _, err := s.PutCompaction(Compaction{
+		SessionID:    "sess-broke",
+		EntryIDFrom:  0,
+		EntryIDTo:    1,
+		PromptTokens: 300,
+		OutputTokens: 100,
+		Summary:      "spent",
+	}); err != nil {
+		t.Fatalf("PutCompaction: %v", err)
+	}
+
+	// 50% budget — already exceeded.
+	cands, err := s.SelectCompactionCandidates(
+		3, now.Add(-15*time.Minute), now.Add(-1*time.Hour), 0.50, 100)
+	if err != nil {
+		t.Fatalf("SelectCompactionCandidates: %v", err)
+	}
+	for _, c := range cands {
+		if c.SessionID == "sess-broke" {
+			t.Errorf("sess-broke should be filtered by the budget ratio; got %+v", cands)
+		}
+	}
+
+	// Raising the budget to 200% lets it through (now well under).
+	cands, err = s.SelectCompactionCandidates(
+		3, now.Add(-15*time.Minute), now.Add(-1*time.Hour), 2.0, 100)
+	if err != nil {
+		t.Fatalf("SelectCompactionCandidates: %v", err)
+	}
+	found := false
+	for _, c := range cands {
+		if c.SessionID == "sess-broke" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("sess-broke should pass when budget ratio raised; got %+v", cands)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2496,6 +2496,16 @@ func (s *Store) PollCI() error {
 }
 
 // pollCIForRepo fetches and upserts CI runs for a single repo.
+//
+// 🎯T67: the gh subprocess calls (both `gh run list` and the per-
+// failed-run `gh run view --log`) happen OUTSIDE the rwmu write lock.
+// Previously the function took the write lock before iterating runs
+// and called fetchRunLog inside the loop, so a poll cycle held the
+// write lock across many seconds of subprocess + HTTP latency per
+// repo. With ~11 'CI poll failed' messages per 5-min cycle, this
+// starved the compactor's RLock long enough to wedge its scan loop
+// for hours. Now logs are fetched first (no lock), then a short
+// upsert-only critical section completes per repo.
 func (s *Store) pollCIForRepo(ghPath, repo string) error {
 	out, err := exec.Command(ghPath, "run", "list",
 		"--repo", repo,
@@ -2511,15 +2521,21 @@ func (s *Store) pollCIForRepo(ghPath, repo string) error {
 		return fmt.Errorf("parse gh output: %w", err)
 	}
 
+	// Fetch logs for failed runs BEFORE taking the write lock so the
+	// compactor (and other readers) can make progress while we wait on
+	// the gh subprocess. Order preserved so the subsequent upsert loop
+	// keeps the runs/logSummaries arrays in step.
+	logSummaries := make([]string, len(runs))
+	for i, run := range runs {
+		if run.Conclusion == "failure" {
+			logSummaries[i] = s.fetchRunLog(ghPath, repo, run.DatabaseID)
+		}
+	}
+
 	s.rwmu.Lock()
 	defer s.rwmu.Unlock()
 
-	for _, run := range runs {
-		var logSummary string
-		if run.Conclusion == "failure" {
-			logSummary = s.fetchRunLog(ghPath, repo, run.DatabaseID)
-		}
-
+	for i, run := range runs {
 		_, err := s.db.Exec(`
 			INSERT INTO ci_runs (repo, run_id, workflow, branch, commit_sha, status, conclusion, started_at, completed_at, log_summary, url)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -2530,7 +2546,7 @@ func (s *Store) pollCIForRepo(ghPath, repo string) error {
 				log_summary = COALESCE(excluded.log_summary, ci_runs.log_summary),
 				updated_at = datetime('now')
 		`, repo, run.DatabaseID, run.WorkflowName, run.HeadBranch, run.HeadSHA,
-			run.Status, run.Conclusion, run.CreatedAt, run.UpdatedAt, logSummary, run.URL)
+			run.Status, run.Conclusion, run.CreatedAt, run.UpdatedAt, logSummaries[i], run.URL)
 		if err != nil {
 			slog.Warn("upsert ci_run failed", "run_id", run.DatabaseID, "err", err)
 		}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -34,6 +34,34 @@ type VaultSyncer interface {
 	Path() string
 }
 
+// CompactorHealthReporter is satisfied by *compact.Watcher.
+// Surfaced as an interface so this package doesn't need to import
+// the compact package (which would create a circular dependency
+// hierarchy in tests and main). Backed by Watcher.Health() — see
+// internal/compact/watcher.go.
+type CompactorHealthReporter interface {
+	Health() CompactorHealth
+}
+
+// CompactorHealth is the externally-visible snapshot returned by the
+// mnemo_compactor_status MCP tool (🎯T67). Mirrors
+// compact.HealthSnapshot field-for-field; duplicated here to keep
+// the tools→compact import direction clean.
+type CompactorHealth struct {
+	LastScanAt       time.Time
+	LastScanCount    int
+	LastTickAt       time.Time
+	LastTickOutcome  string
+	InFlightSession  string
+	Counts           map[string]int64
+	ScanInterval     time.Duration
+	IdleTimeout      time.Duration
+	RecencyWindow    time.Duration
+	TickTimeout      time.Duration
+	MinDeltaMessages int
+	MaxTokenRatio    float64
+}
+
 // ConfigReport mirrors registry.ReloadReport without importing the
 // registry package. The mnemo_config write handler returns these four
 // slices verbatim so the caller can see which fields were applied live,
@@ -64,10 +92,11 @@ type ConfigController interface {
 // hierarchy in tests and future refactors). seen deduplicates the
 // first-call RecordConnectionOpen per (username, MCP session) pair.
 type Handler struct {
-	resolve      func(username string) (store.Backend, error)
-	resolveVault func(username string) VaultSyncer // nil when vault disabled
-	cfgCtl       ConfigController                  // nil when mnemo_config disabled
-	seen         sync.Map
+	resolve          func(username string) (store.Backend, error)
+	resolveVault     func(username string) VaultSyncer             // nil when vault disabled
+	resolveCompactor func(username string) CompactorHealthReporter // nil when compactor health not wired
+	cfgCtl           ConfigController                              // nil when mnemo_config disabled
+	seen             sync.Map
 }
 
 // NewHandler creates a tool handler that resolves each call's
@@ -82,6 +111,15 @@ func NewHandler(resolve func(string) (store.Backend, error)) *Handler {
 // the vault tools report "vault not configured".
 func (h *Handler) SetVaultResolver(fn func(string) VaultSyncer) {
 	h.resolveVault = fn
+}
+
+// SetCompactorResolver configures a per-user compactor health
+// resolver. Calling this is optional; when not called (or when the
+// resolver returns nil) mnemo_compactor_status reports that the
+// watcher's runtime state is not available (typically the daemon's
+// startup hasn't completed yet for the calling user).
+func (h *Handler) SetCompactorResolver(fn func(string) CompactorHealthReporter) {
+	h.resolveCompactor = fn
 }
 
 // SetConfigController wires the mnemo_config tool to a live config
@@ -564,6 +602,22 @@ Vault must be configured via vault_path in ~/.mnemo/config.json.`),
 		mcp.NewTool("mnemo_vault_status",
 			mcp.WithDescription("Report vault configuration: whether vault is enabled, the vault root path, the active indexing scope (vault_indexing_scope) with its includes and .mnemoignore file state, and a count of notes on disk by section."),
 		),
+		mcp.NewTool("mnemo_compactor_status",
+			mcp.WithDescription(`Report the live state of mnemo's background session compactor (🎯T67). Returns:
+
+  - Last scan timestamp and number of candidates the scan returned.
+  - Last tick timestamp and its outcome (one of: compacted,
+    nothing_to_compact, budget_exceeded, failed, timeout, skipped_self).
+  - In-flight session ID, if a tick is currently running.
+  - Lifetime counts of each tick outcome since the daemon started.
+  - Configuration in effect: scan interval, idle timeout, recency
+    window, per-tick timeout, minimum delta-messages trigger, and
+    the configured max token-budget ratio.
+
+Use this to answer "is the compactor working?" without grepping the
+daemon log. A LastScanAt that is older than ScanInterval × 2 is the
+clearest "watcher is wedged" signal.`),
+		),
 		mcp.NewTool("mnemo_config",
 			mcp.WithDescription(`Read or update mnemo's runtime configuration (~/.mnemo/config.json).
 
@@ -693,6 +747,8 @@ func (h *Handler) Call(ctx context.Context, cc CallContext, name string, args ma
 		return ch.vaultSync()
 	case "mnemo_vault_status":
 		return ch.vaultStatus(h.cfgCtl)
+	case "mnemo_compactor_status":
+		return ch.compactorStatus(h.resolveCompactor)
 	case "mnemo_config":
 		return ch.config(args, h.cfgCtl)
 	default:
@@ -2229,6 +2285,75 @@ func (h *callHandler) vaultStatus(ctl ConfigController) (string, bool, error) {
 		fmt.Fprintf(&b, "  %-12s %d\n", sec, count)
 	}
 	fmt.Fprintf(&b, "  %-12s %d\n", "total", total)
+	return b.String(), false, nil
+}
+
+// compactorStatus implements mnemo_compactor_status (🎯T67). It
+// returns a snapshot of the compactor watcher's runtime state so
+// callers can answer "is the compactor working?" without grepping
+// the daemon log.
+//
+// The resolver may be nil (daemon started without compactor health
+// wired) or may return nil (the user's workers haven't started
+// yet); both surface as a helpful "not available" message rather
+// than an error.
+func (h *callHandler) compactorStatus(resolve func(username string) CompactorHealthReporter) (string, bool, error) {
+	if resolve == nil {
+		return "Compactor status not available (daemon was started without the compactor health resolver wired).", false, nil
+	}
+	reporter := resolve(h.cc.Username)
+	if reporter == nil {
+		return "Compactor status not available (the watcher hasn't started for this user yet — usually the daemon is still booting).", false, nil
+	}
+	hs := reporter.Health()
+
+	var b strings.Builder
+	b.WriteString("Compactor watcher status:\n\n")
+
+	now := time.Now()
+	formatAge := func(t time.Time) string {
+		if t.IsZero() {
+			return "never"
+		}
+		return fmt.Sprintf("%s (%s ago)", t.Format(time.RFC3339), now.Sub(t).Round(time.Second))
+	}
+
+	fmt.Fprintf(&b, "  last_scan_at:        %s\n", formatAge(hs.LastScanAt))
+	fmt.Fprintf(&b, "  last_scan_count:     %d\n", hs.LastScanCount)
+	fmt.Fprintf(&b, "  last_tick_at:        %s\n", formatAge(hs.LastTickAt))
+	if hs.LastTickOutcome != "" {
+		fmt.Fprintf(&b, "  last_tick_outcome:   %s\n", hs.LastTickOutcome)
+	}
+	if hs.InFlightSession != "" {
+		fmt.Fprintf(&b, "  in_flight_session:   %s\n", hs.InFlightSession)
+	} else {
+		b.WriteString("  in_flight_session:   (idle)\n")
+	}
+
+	b.WriteString("\nLifetime tick counts:\n")
+	outcomes := []string{"compacted", "nothing_to_compact", "budget_exceeded", "failed", "timeout", "skipped_self"}
+	for _, o := range outcomes {
+		fmt.Fprintf(&b, "  %-20s %d\n", o+":", hs.Counts[o])
+	}
+
+	b.WriteString("\nConfiguration:\n")
+	fmt.Fprintf(&b, "  scan_interval:       %s\n", hs.ScanInterval)
+	fmt.Fprintf(&b, "  idle_timeout:        %s\n", hs.IdleTimeout)
+	fmt.Fprintf(&b, "  recency_window:      %s\n", hs.RecencyWindow)
+	fmt.Fprintf(&b, "  tick_timeout:        %s\n", hs.TickTimeout)
+	fmt.Fprintf(&b, "  min_delta_messages:  %d\n", hs.MinDeltaMessages)
+	fmt.Fprintf(&b, "  max_token_ratio:     %.2f\n", hs.MaxTokenRatio)
+
+	// Health heuristic: if the watcher hasn't scanned in more than
+	// 2x its configured interval, something is wrong. Surface it.
+	if !hs.LastScanAt.IsZero() {
+		stale := 2 * hs.ScanInterval
+		if now.Sub(hs.LastScanAt) > stale {
+			fmt.Fprintf(&b, "\n⚠ Watcher appears stuck: last scan was %s ago (> 2× scan_interval).\n",
+				now.Sub(hs.LastScanAt).Round(time.Second))
+		}
+	}
+
 	return b.String(), false, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.43.0"
+	version              = "0.44.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/marcelocantos/mnemo/internal/api"
+	"github.com/marcelocantos/mnemo/internal/compact"
 	"github.com/marcelocantos/mnemo/internal/endpoint"
 	"github.com/marcelocantos/mnemo/internal/federation"
 	"github.com/marcelocantos/mnemo/internal/mcpconfig"
@@ -570,6 +571,18 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 		return v
 	})
 
+	// Wire the per-user compactor health reporter so
+	// mnemo_compactor_status (🎯T67) can surface live watcher state.
+	// Returns nil when the user's workers haven't started yet; the
+	// tool gracefully reports "not available" in that case.
+	handler.SetCompactorResolver(func(username string) tools.CompactorHealthReporter {
+		w := reg.CompactWatcherFor(username)
+		if w == nil {
+			return nil
+		}
+		return compactorAdapter{w: w}
+	})
+
 	// Wire the mnemo_config tool to the live Registry. Get returns a
 	// snapshot of the current Config; Put persists the new config to
 	// disk via store.WriteConfig (which re-runs the same validation as
@@ -688,6 +701,33 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 			}
 		}
 		return nil
+	}
+}
+
+// compactorAdapter satisfies tools.CompactorHealthReporter by
+// projecting a *compact.Watcher's HealthSnapshot into the tools
+// package's CompactorHealth type. Lives in main so the tools and
+// compact packages stay free of each other (compact has no business
+// importing tools and vice versa).
+type compactorAdapter struct {
+	w *compact.Watcher
+}
+
+func (a compactorAdapter) Health() tools.CompactorHealth {
+	hs := a.w.Health()
+	return tools.CompactorHealth{
+		LastScanAt:       hs.LastScanAt,
+		LastScanCount:    hs.LastScanCount,
+		LastTickAt:       hs.LastTickAt,
+		LastTickOutcome:  hs.LastTickOutcome,
+		InFlightSession:  hs.InFlightSession,
+		Counts:           hs.Counts,
+		ScanInterval:     hs.ScanInterval,
+		IdleTimeout:      hs.IdleTimeout,
+		RecencyWindow:    hs.RecencyWindow,
+		TickTimeout:      hs.TickTimeout,
+		MinDeltaMessages: hs.MinDeltaMessages,
+		MaxTokenRatio:    hs.MaxTokenRatio,
 	}
 }
 


### PR DESCRIPTION
## Summary

Lands all seven acceptance criteria of 🎯T67 in one PR. Bumps version
0.43.0 → 0.44.0.

The compactor watcher was silent for 5+ hours yesterday despite the
daemon being healthy and ~441 substantive messages accumulating in
an uncompacted session. Root cause analysis pinned the load-bearing
issues:

**Candidate selection.** SelectCompactionCandidates filtered on
lifetime substantive_msgs (T59 design drift — the design specified
\"since the most recent compaction\"). So already-compacted sessions
stayed in the candidate set forever and got re-ticked into
budget_exceeded every minute. Small sessions (< 50 substantive)
never compacted at all. This PR replaces it with a dual OR-trigger:

```
(delta_substantive_msgs ≥ N)                 OR
(delta_substantive_msgs ≥ 1  AND  idle ≥ t)
```

where delta is measured against compactions.entry_id_to and idle
against last_msg. Also adds a candidate-level budget filter so the
watcher no longer wakes just to log budget_exceeded.

**Lock scope.** pollCIForRepo held s.rwmu.Lock() across `gh run
view --log` per failed run. With ~11 failed runs per 5-min cycle,
the write lock was held for many seconds at a time, starving the
compactor's RLock. Logs now fetched before the lock.

**Hardening.** Per-tick context.WithTimeout (default 5 min) so a
stuck call cannot wedge the loop. outcomeBudgetExceeded demoted
from INFO to DEBUG.

**Observability.** New MCP tool `mnemo_compactor_status` reports
last_scan_at, last_tick_at, in_flight_session, per-outcome counters,
and effective config. Flags watcher-appears-stuck when last scan is
older than 2× scan_interval.

Retires 🎯T67.

## Test plan
- [x] `go test -tags \"sqlite_fts5\" ./...` — new tests for delta trigger, idle trigger, budget filter, log demotion, Health snapshot all green; existing tests still pass
- [x] `make bullseye` — fmt / vet / build / tests / clean (modulo dirty tree pre-merge)
- [ ] CI green on ubuntu + windows
- [ ] Post-release \`mnemo_compactor_status\` shows a healthy watcher running on this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)