### PR TITLE
Release v0.46.0 (🎯T70 compactor scan decoupled from write path)

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.45.0"
+	version              = "0.46.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
🎯T70 — Compactor candidate scan decoupled from the write path.

The candidate-selection query `SelectCompactionCandidates` was scanning ~594K assistant entries per session via `idx_entries_type`, ballooning to 30+ minutes on a 7.6K-session DB. While it ran, it held `rwmu.RLock()`, blocking every writer (transcript ingest, memory/skill/plan/target ingest) for the full duration. The daemon's 99% CPU + multi-thousand-entry compactor backlog traced to this.

## Fixed

- **Partial covering index** `idx_entries_assistant_tokens ON entries(session_id, input_tokens, output_tokens) WHERE type = 'assistant'`. Turns the per-session `SUM(input_tokens + output_tokens)` subquery into an indexed range scan with the summed columns inline. Measured: scan time dropped from ~30 min to 142 ms on a representative DB (38,000× speedup). Migration is additive; sqlift applies it on first daemon start. (🎯T70.1)

## Changed

- **`Store` now uses two `*sql.DB` handles** — `readDB` (default multi-conn pool) and `writeDB` (`SetMaxOpenConns(1)`). SQLite WAL handles read/write concurrency natively; the Go pool serialises writers via channel-park (no `SQLITE_BUSY` in normal operation). Long reads can no longer block writes at the application layer. (🎯T70.2)
- **`rwmu` renamed to `rootsMu` and scoped to in-memory roots state only** — `workspaceRoots`, `extraProjectDirs`, `synthesisRoots`. Every lock pair that wrapped pure DB code is gone, along with the `*Locked` helper suffix on functions whose lock evaporated. Net: −269 lines. (🎯T70.3)

## Added

- **`compact: scan` log line per scan tick**, emitting `candidates`, `backlog`, and `elapsed` at INFO, escalating to WARN past a 5s soak threshold. The 30-min scan that prompted this work was invisible in logs because only per-compaction outcomes were recorded. (🎯T70.4)
