### PR TITLE
🎯T71: stuck-watcher heuristic accounts for in-batch tick time

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2293,6 +2293,19 @@ targets:
     origin: manual
     discovered: 2026-05-31
     achieved: 2026-05-31
+  T71:
+    name: mnemo_compactor_status "watcher appears stuck" heuristic accounts for in-batch tick time
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - The 'watcher appears stuck' warning does NOT fire when the watcher is actively ticking through a batch of candidates (last_tick_at recent, even if last_scan_at is older than 2 × scan_interval)
+    - The warning DOES still fire when the watcher is genuinely wedged (no recent scan AND no recent tick)
+    - Heuristic threshold derived from scan_interval + (tick_timeout × max_compactions_per_scan), or equivalent — observable via mnemo_compactor_status output not asserting 'stuck' on a healthy daemon mid-batch
+    context: 'Observed on 2026-05-31 after deploying T70: with backlog ~7,700 and the per-scan cap at 20, the watcher runs `SelectCompactionCandidates` once, gets 100 candidates, then spends ~10 minutes ticking 20 of them (LLM call per tick, ~30s each) before the next scan fires. The current threshold (`2 × scan_interval` = 2 min) trips false-positive ''watcher appears stuck'' warnings every cycle on a perfectly healthy daemon. Heuristic limitation, not a real bug — but the warning is noise that misleads anyone reading status output. The fix is to either (a) widen the threshold to account for in-batch tick time, or (b) suppress the warning when last_tick_at is recent.'
+    origin: manual
+    discovered: 2026-06-01
+    achieved: 2026-06-01
   T8:
     name: sqldeep integration
     status: achieved

--- a/internal/tools/compactor_status_test.go
+++ b/internal/tools/compactor_status_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeHealthReporter struct{ h CompactorHealth }
+
+func (f fakeHealthReporter) Health() CompactorHealth { return f.h }
+
+func resolver(h CompactorHealth) func(string) CompactorHealthReporter {
+	return func(string) CompactorHealthReporter { return fakeHealthReporter{h: h} }
+}
+
+// TestCompactorStatusStuckHeuristic verifies 🎯T71: the "watcher
+// appears stuck" warning only fires when BOTH the last scan AND the
+// last tick are older than 2× scan_interval. A scan returning a full
+// batch can legitimately push last_scan_at well past the threshold
+// while the watcher ticks through candidates, so last_tick_at carries
+// the proof-of-life signal alongside last_scan_at.
+func TestCompactorStatusStuckHeuristic(t *testing.T) {
+	now := time.Now()
+	const scanInterval = time.Minute
+	stale := 5 * scanInterval // well past 2 × scan_interval
+
+	cases := []struct {
+		name      string
+		lastScan  time.Time
+		lastTick  time.Time
+		wantStuck bool
+	}{
+		{
+			name:      "recent_scan_recent_tick",
+			lastScan:  now.Add(-10 * time.Second),
+			lastTick:  now.Add(-5 * time.Second),
+			wantStuck: false,
+		},
+		{
+			name:      "stale_scan_recent_tick", // T71 regression: was false-positive
+			lastScan:  now.Add(-stale),
+			lastTick:  now.Add(-10 * time.Second),
+			wantStuck: false,
+		},
+		{
+			name:      "recent_scan_stale_tick",
+			lastScan:  now.Add(-10 * time.Second),
+			lastTick:  now.Add(-stale),
+			wantStuck: false,
+		},
+		{
+			name:      "stale_scan_stale_tick", // genuinely wedged
+			lastScan:  now.Add(-stale),
+			lastTick:  now.Add(-stale),
+			wantStuck: true,
+		},
+		{
+			name:      "stale_scan_no_tick_yet", // startup before first tick
+			lastScan:  now.Add(-stale),
+			lastTick:  time.Time{},
+			wantStuck: true,
+		},
+		{
+			name:      "no_scan_yet", // daemon just started
+			lastScan:  time.Time{},
+			lastTick:  time.Time{},
+			wantStuck: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h := CompactorHealth{
+				LastScanAt:   c.lastScan,
+				LastTickAt:   c.lastTick,
+				ScanInterval: scanInterval,
+				Counts:       map[string]int64{},
+			}
+			ch := &callHandler{cc: CallContext{Username: "test"}}
+			out, _, err := ch.compactorStatus(resolver(h))
+			if err != nil {
+				t.Fatalf("compactorStatus: %v", err)
+			}
+			hasWarning := strings.Contains(out, "appears stuck")
+			if hasWarning != c.wantStuck {
+				t.Errorf("warning=%v want=%v\noutput:\n%s", hasWarning, c.wantStuck, out)
+			}
+		})
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -2377,13 +2377,26 @@ func (h *callHandler) compactorStatus(resolve func(username string) CompactorHea
 	fmt.Fprintf(&b, "  max_compactions_per_scan: %d\n", hs.MaxCompactionsPerScan)
 	fmt.Fprintf(&b, "  max_token_ratio:         %.2f\n", hs.MaxTokenRatio)
 
-	// Health heuristic: if the watcher hasn't scanned in more than
-	// 2x its configured interval, something is wrong. Surface it.
+	// Health heuristic (🎯T71): the watcher is genuinely stuck only when
+	// neither the per-scan loop NOR the per-tick loop has progressed in
+	// a while. A single scan can return up to MaxCompactionsPerScan
+	// candidates and then spend many minutes ticking through them
+	// (TickTimeout per LLM call), so last_scan_at can legitimately sit
+	// well past 2× scan_interval on a busy daemon. Use last_tick_at as
+	// the proof-of-life signal alongside last_scan_at — if either is
+	// recent, we're working, not wedged.
 	if !hs.LastScanAt.IsZero() {
 		stale := 2 * hs.ScanInterval
-		if now.Sub(hs.LastScanAt) > stale {
-			fmt.Fprintf(&b, "\n⚠ Watcher appears stuck: last scan was %s ago (> 2× scan_interval).\n",
-				now.Sub(hs.LastScanAt).Round(time.Second))
+		scanStale := now.Sub(hs.LastScanAt) > stale
+		tickStale := hs.LastTickAt.IsZero() || now.Sub(hs.LastTickAt) > stale
+		if scanStale && tickStale {
+			tickAge := "never"
+			if !hs.LastTickAt.IsZero() {
+				tickAge = now.Sub(hs.LastTickAt).Round(time.Second).String() + " ago"
+			}
+			fmt.Fprintf(&b, "\n⚠ Watcher appears stuck: last scan was %s ago and last tick was %s (> 2× scan_interval).\n",
+				now.Sub(hs.LastScanAt).Round(time.Second),
+				tickAge)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Stops `mnemo_compactor_status` from reporting *"Watcher appears stuck"* on a healthy daemon mid-batch. Observed against v0.46.0's 7.7K compactor backlog: the watcher would scan once, return 100 candidates, then spend ~10 minutes ticking through 20 of them per the per-scan cap before the next scan ran. The old threshold (`last_scan_at > 2 × scan_interval`) tripped every cycle even though the watcher was visibly progressing.

## Fix

Treat `last_tick_at` as the proof-of-life signal alongside `last_scan_at`. Warn only when **both** are older than `2 × scan_interval` (or `last_tick_at` is zero, meaning no tick has happened yet — the genuine-startup-wedged case).

## Test plan

- [x] `go build -tags "sqlite_fts5" ./...`
- [x] `go test -tags "sqlite_fts5" ./...` — all packages pass
- [x] New `TestCompactorStatusStuckHeuristic` table-driven test covers six cases:
  - recent scan + recent tick → no warning
  - **stale scan + recent tick → no warning** (T71 regression case)
  - recent scan + stale tick → no warning
  - stale scan + stale tick → warning (genuine wedged)
  - stale scan + no tick yet → warning (startup-wedged)
  - no scan yet → no warning (daemon just started)
