### PR TITLE
Release v0.47.0 (🎯T71 stuck-watcher heuristic accounts for in-batch tick time)

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.46.0"
+	version              = "0.47.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
🎯T71 — `mnemo_compactor_status` stops crying wolf.

## Fixed

- **"Watcher appears stuck" warning** no longer fires when the watcher is actively ticking through a batch (🎯T71). Observed against v0.46.0's 7.7K compactor backlog: one scan returned 100 candidates and the watcher spent ~10 minutes ticking through 20 of them per the per-scan cap before the next scan ran, so `last_scan_at` legitimately sat well past `2 × scan_interval` even though work was happening. The heuristic now treats `last_tick_at` as proof of life alongside `last_scan_at` — warns only when **both** are stale. Genuine wedged cases (no scans AND no ticks) still surface; startup before the first tick also still surfaces.
