### PR TITLE
Release v0.48.0 (🎯T72 token-volume compaction + 🎯T75 status ingest-freshness diagnostics)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,9 @@ Full setup guide: [`internal/vault/README.md`](internal/vault/README.md)
 | `mnemo_search` | Full-text search with context (like `grep -C`). Repo filter, configurable before/after context. |
 | `mnemo_sessions` | List sessions by recency; filter by project, repo, work type, or session type |
 | `mnemo_read_session` | Read messages from a specific session (supports prefix IDs) |
+| `mnemo_compacted_session` | Distilled view of a session — compaction summaries plus the live addenda tail past the latest cursor |
 | `mnemo_recent_activity` | Per-repo summary of recent session activity with work types and topics |
-| `mnemo_status` | Rich status report: repos, sessions, and conversation excerpts |
+| `mnemo_status` | Rich status report: repos, sessions, and conversation excerpts, plus a transcript-ingest freshness/lag diagnostics block |
 | `mnemo_chain` | Retrieve the full `/clear`-bounded session chain for any session |
 | `mnemo_self` | Discover the calling session's ID via two-phase nonce protocol |
 | `mnemo_decisions` | Search past decisions (proposal + confirmation pairs) across sessions |

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.47.0"
+	version              = "0.48.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
## v0.48.0

### Compactor: token-volume convergence (🎯T72)

- Redesigned the compactor convergence model around **token volume**, an **addenda-as-tail** retrieval form, and a **precise recursion guard**.
- A single metric — `SUM(output_tokens + cache_creation_tokens)` past the latest compaction cursor — is **both** the size floor and the re-compaction trigger (default 50k budget), replacing the message-count and idle-timeout heuristics.
- The recursion guard moved from the over-broad `excludeCWD` prefix check (which wrongly skipped genuine dev sessions in the mnemo repo and never drained the backlog) to a precise marker stamped on the summariser prompt and detected at ingest.
- Compaction summaries are FTS5-indexed (`compactions_fts`) and weighted **above** raw message hits in `mnemo_search`; raw hits a matching compaction covers are suppressed, while uncovered addenda flow through unchanged.
- New `mnemo_compacted_session` tool: a session's distilled retrieval form — compaction summaries plus the live addenda tail past the cursor.
- Failure-path hardening: NUL-byte prompt sanitisation (the dominant exec-failure cause — a NUL made `claude`'s exec fail with EINVAL and re-fail one session every scan), robust JSON extraction for prose-before-JSON output, and rate-limit/API-outage classification with a watcher-wide cooldown plus per-session exponential backoff. `mnemo_compactor_status` now reports the failed/compacted ratio.

### mnemo_status: transcript-ingest freshness diagnostics (🎯T75)

- `mnemo_status` is now the **first-line ingest-freshness health check**. A new additive `diagnostics` block answers "is the index stale, where, and by how much?" without grepping `~/.claude/projects` or running ad-hoc SQL:
  - **freshness** — daemon `now_utc`, freshest indexed timestamp, and lag.
  - **divergence** — per-stream gap, including `transcript_index` pending bytes/files.
  - **transcript_sources** — per configured project dir: total files, never-ingested count, files behind, pending bytes, newest on-disk mtime, and forensic examples of the largest behind files (`new`/`append_behind`/`truncated`/`rewritten`).
  - **repo_diagnostic** (when a `repo` filter is supplied) — the Claude project dirs the repo maps to, latest indexed vs newest on-disk mtime, and explicit notes when no source maps to the filter or when on-disk transcripts are newer than the index.

### Schema

All changes are strictly additive (sqlift `AllowNone`): `session_meta.compactor_internal`, the `compactions_fts` virtual table, and the `idx_entries_addenda` covering index. No destructive migrations.
