### PR TITLE
ci: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: mnemo
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: marcelocantos/sqldeep
           ref: v0.22.0
@@ -70,7 +70,7 @@ jobs:
           "$CC" -w -Idist -Ivendor/include -c dist/sqldeep_xml.c -o build/sqldeep_xml.o
           "$AR" rcs build/libsqldeep.a build/sqldeep.o build/deepparser/*.o
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: mnemo/go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,11 +69,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: mnemo
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: marcelocantos/sqldeep
           ref: v0.22.0
@@ -131,7 +131,7 @@ jobs:
           "$CC" -w -Idist -Ivendor/include -c dist/sqldeep_xml.c -o build/sqldeep_xml.o
           "$AR" rcs build/libsqldeep.a build/sqldeep.o build/deepparser/*.o
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: mnemo/go.mod
 
@@ -219,10 +219,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: mnemo
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: marcelocantos/sqldeep
           ref: v0.22.0
@@ -240,7 +240,7 @@ jobs:
           c++ -std=c++20 -Wall -Wextra -Wpedantic -Idist -Ivendor/include -I${DP_SRC} -c dist/sqldeep.cpp -o build/sqldeep.o
           cc -w -Idist -Ivendor/include -c dist/sqldeep_xml.c -o build/sqldeep_xml.o
           ar rcs build/libsqldeep.a build/sqldeep.o build/deepparser/*.o
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: mnemo/go.mod
       - run: cd mnemo && go test -tags "sqlite_fts5" ./...


### PR DESCRIPTION
## What

Bump GitHub Actions to their Node-24-native majors to clear the Node-20 runtime deprecation. GitHub force-migrates deprecated (Node-20) actions to Node 24 on **2026-06-16**; pinning ahead avoids surprise behaviour changes.

## Bump map

| action | after |
|---|---|
| actions/checkout | v6 |
| actions/setup-go | v6 |
| actions/setup-node | v6 |
| actions/cache | v5 |
| actions/setup-java | v5 |
| actions/setup-python | v6 |
| actions/upload-artifact | v7 |
| actions/download-artifact | v8 |

upload/download bumped as a matched pair (v7 ↔ v8) so the artifact handshake stays compatible.

Part of 🎯T4 (fleet-wide Actions deprecation sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)