### PR TITLE
🎯T73: three-tier test architecture (MNEMO_HOME, e2e harness, snapshot helper)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__spyder__screenshot",
+      "mcp__spyder__app_channel_list",
+      "mcp__bullseye__bullseye_get",
+      "mcp__spyder__logs",
+      "mcp__spyder__app_state",
+      "mcp__spyder__devices",
+      "mcp__spyder__is_running",
+      "mcp__spyder__crashes",
+      "mcp__mobile-mcp__mobile_get_screen_size"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ bin/
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
 bullseye.yaml.lock
+# 🎯T73: Tier 3 test snapshots may default to this conventional
+# location; belt-and-braces against the helper or a wayward test
+# ever materialising a clone inside a worktree.
+mnemo-test-snapshots/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-.PHONY: bullseye build test vet fmt-check
+.PHONY: bullseye build test test-scale snapshot vet fmt-check
 
 BUILD_TAGS := sqlite_fts5
+# 🎯T73 Tier 3 also requires the `scale` tag so the snapshot-gated
+# tests (`//go:build scale`) compile and run.
+SCALE_TAGS := sqlite_fts5 scale
 
 bullseye:
 	@test -z "$$(gofmt -l .)" && echo "✓ fmt" || \
@@ -14,8 +17,27 @@ bullseye:
 build:
 	go build -tags "$(BUILD_TAGS)" -o bin/mnemo .
 
+# 🎯T73: `make test` runs Tier 1 + Tier 2 (default build tag set).
+# Tier 3 scale tests are deliberately excluded so default CI stays
+# fast and never reaches at the user's real data.
 test:
 	go test -tags "$(BUILD_TAGS)" ./...
+
+# 🎯T73: `make test-scale` runs Tier 1 + Tier 2 + Tier 3. Tier 3
+# tests skip with a clear message when MNEMO_TEST_SNAPSHOT is unset
+# (see internal/e2e/scale_test.go). Run `make snapshot` first to
+# materialise a snapshot and capture the env var.
+test-scale:
+	@if [ -z "$$MNEMO_TEST_SNAPSHOT" ]; then \
+	  echo "MNEMO_TEST_SNAPSHOT is not set — Tier 3 tests will SKIP."; \
+	  echo "Run \`make snapshot\` first and export the resulting path."; \
+	fi
+	go test -tags "$(SCALE_TAGS)" ./...
+
+# 🎯T73: invoke the snapshot helper. Prints `MNEMO_HOME=<path>` on
+# its last stdout line for `eval $(make snapshot)` workflows.
+snapshot:
+	@go run ./cmd/mnemo-test-snapshot
 
 vet:
 	go vet -tags "$(BUILD_TAGS)" ./...

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2532,6 +2532,68 @@ targets:
     origin: manual
     discovered: 2026-06-16
     achieved: 2026-06-16
+  T79:
+    name: mnemo_vault_status and mnemo_compactor_status fall back to the default user when ?user= is omitted, matching the store resolver
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - '`mnemo_vault_status`, `mnemo_vault_sync`, and `mnemo_compactor_status` succeed against a daemon''s default user when the MCP request omits `?user=` — matching the behaviour of `mnemo_search` / `mnemo_stats` / every other tool today. Today they return "vault not configured" / "compactor not available" respectively in that case because the per-tool resolver lambdas look up `reg.VaultFor("")` / `reg.CompactWatcherFor("")` directly instead of falling back to `defaultUser` the way the shared `resolve(username)` closure does.'
+    - 'The fix lives in `main.go` (the resolver closures wired via `handler.SetVaultResolver` and `handler.SetCompactorResolver`) and mirrors the shape of the existing `resolve := func(username string) ...` closure: empty username → `defaultUser`, unless `defErr != nil` in which case the resolver returns nil (Windows-Service no-default-user path).'
+    - 'Regression test in `internal/e2e/` exercises both tools through the MCP harness without passing `?user=`. The pre-fix vault sync e2e test (`TestVaultSyncViaMCP`) — currently sets `Options{User: cur.Username}` as a workaround — drops the explicit user, with a one-line comment explaining the workaround is no longer needed.'
+    - Multi-user (Windows-Service) deployments are unchanged. An explicit `?user=alice` still routes to Alice's per-user vault / compactor exactly as today. The fallback only applies to the empty-username (default-identity) path.
+    context: |-
+      ## Bug
+
+      Discovered while building the 🎯T73 e2e harness. The daemon has three places where per-tool resolvers are wired in `main.go`:
+
+      ```go
+      resolve := func(username string) (store.Backend, error) {
+          if username == "" {
+              if defErr != nil {
+                  return nil, errors.New("no user identity on request; ...")
+              }
+              username = defaultUser
+          }
+          return reg.ForUser(username)
+      }
+      handler := tools.NewHandler(resolve)
+
+      handler.SetVaultResolver(func(username string) tools.VaultSyncer {
+          v := reg.VaultFor(username)        // ← no defaultUser fallback
+          if v == nil { return nil }
+          return v
+      })
+
+      handler.SetCompactorResolver(func(username string) tools.CompactorHealthReporter {
+          w := reg.CompactWatcherFor(username) // ← no defaultUser fallback
+          if w == nil { return nil }
+          return compactorAdapter{w: w}
+      })
+      ```
+
+      `tools.go` calls each resolver with `cc.Username` (the `?user=` query parameter value, empty if not set). The store resolver normalises the empty case to `defaultUser`; the vault and compactor resolvers do not. So an MCP client that does not bother with `?user=` (the default Claude Code wiring against a single-user daemon) gets store-backed tools working fine and vault/compactor tools reporting "not configured."
+
+      ## Why nobody hit it before
+
+      In production the user's Claude Code MCP registration is the URL produced by `mnemo register-mcp` which DOES include `?user=<name>`. So the bug only surfaces when:
+      - Tests call MCP without a username (the T73 e2e harness's default).
+      - A user manually registers mnemo without the query param.
+
+      The T73 vault sync test sets `Options{User: cur.Username}` to work around this, with a TODO-shaped comment naming the bug.
+
+      ## Fix shape
+
+      Lift the username-normalisation logic into a small helper inside `main.go` (the `runServe` function already has `defaultUser` and `defErr` in scope) and apply it inside the vault and compactor resolver closures. The closure shape stays identical — only the username computation changes.
+
+      Alternative considered: move the fallback into `tools.go` so it's central. Rejected because the existing `resolve` closure has the right shape and the multi-user / Windows-Service case (where `defErr != nil` means "no sensible default") is a `main.go`-level concern, not a tool-handler concern.
+
+      ## Out of scope
+
+      - The `Config.ResolvedSynthesisRoots()` "wrong-home" bug noted in the T73 audit (uses `os.UserHomeDir()` directly even when called with a non-default user). Separate target if you want it tracked.
+      - Any deeper refactor of the per-tool resolver pattern. Cheap pointed fix, not a redesign.
+    origin: manual
+    discovered: 2026-06-16
   T8:
     name: sqldeep integration
     status: achieved

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2370,7 +2370,7 @@ targets:
     achieved: 2026-06-08
   T73:
     name: A three-tier test architecture exists so synthetic and production-scale system tests run against an MCP-driven daemon without putting live data at risk
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -2434,6 +2434,7 @@ targets:
       - **The exact location and `.gitignore` rule for the conventional snapshot dir** — `~/.mnemo-test-snapshots/` is a sensible default but worth confirming the user's preference.
     origin: manual
     discovered: 2026-06-08
+    achieved: 2026-06-16
   T74:
     name: Ad-hoc read queries run under a bounded execution deadline, so a pathological mnemo_query can't wedge the read pool indefinitely
     status: identified

--- a/cmd/mnemo-test-snapshot/main.go
+++ b/cmd/mnemo-test-snapshot/main.go
@@ -1,0 +1,263 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+// mnemo-test-snapshot creates a safe, isolated copy of the user's mnemo
+// data (~/.mnemo and ~/.claude/projects) for Tier 3 system tests. The
+// destination is a fresh directory outside any git working tree; on
+// macOS the copy uses APFS clone-by-reference (cp -c -R) so it is
+// effectively free.
+//
+// The last line printed on stdout is `MNEMO_HOME=<dest>`; tests can
+// either eval that, parse it, or just read the directory path.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// forceFallback lets tests exercise the recursive-copy path on darwin.
+// It is also flipped automatically when GOOS is not darwin.
+var forceFallback = false
+
+const usage = `usage: mnemo-test-snapshot [--dest <path>] [--force] [--source-home <path>]
+
+Creates an isolated copy of ~/.mnemo and ~/.claude/projects for Tier 3
+system tests. The destination must NOT be inside a git working tree.
+
+Flags:
+  --dest <path>          Destination directory.
+                         Default: <MNEMO_HOME or $HOME>/.mnemo-test-snapshots/snapshot-<timestamp>
+  --force                Allow clobbering an existing destination.
+  --source-home <path>   Override the source $HOME (defaults to the user's home directory).
+  --help                 Print this message.
+
+On success the last line of stdout is:
+  MNEMO_HOME=<dest>
+`
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("mnemo-test-snapshot", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	var (
+		dest       string
+		force      bool
+		sourceHome string
+		help       bool
+	)
+	flags.StringVar(&dest, "dest", "", "destination directory")
+	flags.BoolVar(&force, "force", false, "allow clobbering an existing destination")
+	flags.StringVar(&sourceHome, "source-home", "", "override the source $HOME")
+	flags.BoolVar(&help, "help", false, "print usage")
+	flags.Usage = func() { fmt.Fprint(stderr, usage) }
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if help {
+		fmt.Fprint(stdout, usage)
+		return nil
+	}
+
+	// Resolve source $HOME.
+	if sourceHome == "" {
+		h, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("snapshot: resolve home: %w", err)
+		}
+		sourceHome = h
+	}
+
+	// Pick destination. Precedence: --dest > $MNEMO_HOME > $HOME.
+	if dest == "" {
+		base := os.Getenv("MNEMO_HOME")
+		if base == "" {
+			base = sourceHome
+		}
+		ts := time.Now().UTC().Format("20060102T150405Z")
+		dest = filepath.Join(base, ".mnemo-test-snapshots", "snapshot-"+ts)
+	}
+	absDest, err := filepath.Abs(dest)
+	if err != nil {
+		return fmt.Errorf("snapshot: resolve dest: %w", err)
+	}
+	dest = absDest
+
+	// Refuse to write into a git working tree. We check the destination's
+	// parent (it may not exist yet, but its parent should). Walk upward
+	// until we find an existing ancestor, then ask git about it.
+	if err := refuseIfGitTracked(dest, stderr); err != nil {
+		return err
+	}
+
+	// Refuse to clobber an existing destination without --force.
+	if _, err := os.Stat(dest); err == nil {
+		if !force {
+			return fmt.Errorf("snapshot: destination %s already exists (use --force to clobber)", dest)
+		}
+		if err := os.RemoveAll(dest); err != nil {
+			return fmt.Errorf("snapshot: remove existing dest: %w", err)
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("snapshot: stat dest: %w", err)
+	}
+
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return fmt.Errorf("snapshot: mkdir dest: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dest, ".claude"), 0o755); err != nil {
+		return fmt.Errorf("snapshot: mkdir .claude: %w", err)
+	}
+
+	// Clone sources. Missing sources are tolerated (logged); they're not
+	// fatal because a fresh user environment may legitimately lack one.
+	srcMnemo := filepath.Join(sourceHome, ".mnemo")
+	srcProjects := filepath.Join(sourceHome, ".claude", "projects")
+	dstMnemo := filepath.Join(dest, ".mnemo")
+	dstProjects := filepath.Join(dest, ".claude", "projects")
+
+	useFallback := forceFallback || runtime.GOOS != "darwin"
+	if useFallback && runtime.GOOS != "darwin" {
+		fmt.Fprintln(stderr, "[fallback] non-darwin platform: using recursive copy")
+	} else if useFallback {
+		fmt.Fprintln(stderr, "[fallback] forced: using recursive copy")
+	}
+
+	for _, p := range []struct{ src, dst string }{
+		{srcMnemo, dstMnemo},
+		{srcProjects, dstProjects},
+	} {
+		if _, err := os.Stat(p.src); errors.Is(err, fs.ErrNotExist) {
+			fmt.Fprintf(stderr, "[skip] source %s does not exist\n", p.src)
+			if err := os.MkdirAll(p.dst, 0o755); err != nil {
+				return fmt.Errorf("snapshot: mkdir %s: %w", p.dst, err)
+			}
+			continue
+		} else if err != nil {
+			return fmt.Errorf("snapshot: stat %s: %w", p.src, err)
+		}
+		if useFallback {
+			if err := copyTree(p.src, p.dst); err != nil {
+				return fmt.Errorf("snapshot: copy %s -> %s: %w", p.src, p.dst, err)
+			}
+		} else {
+			// cp -c (clonefile) -R (recursive) -p (preserve). The parent of
+			// p.dst already exists; cp will create p.dst itself.
+			cmd := exec.Command("cp", "-c", "-R", p.src, p.dst)
+			cmd.Stdout = stderr
+			cmd.Stderr = stderr
+			if err := cmd.Run(); err != nil {
+				return fmt.Errorf("snapshot: cp -c -R %s %s: %w", p.src, p.dst, err)
+			}
+		}
+	}
+
+	// Ensure a config.json exists; mnemo defaults handle the rest.
+	cfgPath := filepath.Join(dstMnemo, "config.json")
+	if _, err := os.Stat(cfgPath); errors.Is(err, fs.ErrNotExist) {
+		if err := os.WriteFile(cfgPath, []byte("{}\n"), 0o644); err != nil {
+			return fmt.Errorf("snapshot: write stub config: %w", err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("snapshot: stat config: %w", err)
+	}
+
+	// LAST line on stdout: tests rely on this.
+	fmt.Fprintf(stdout, "MNEMO_HOME=%s\n", dest)
+	return nil
+}
+
+// refuseIfGitTracked walks upward from dest looking for an existing
+// ancestor and asks git whether it is inside a working tree. If so,
+// abort with a clear message.
+func refuseIfGitTracked(dest string, stderr io.Writer) error {
+	probe := dest
+	for {
+		if info, err := os.Stat(probe); err == nil && info.IsDir() {
+			break
+		}
+		parent := filepath.Dir(probe)
+		if parent == probe {
+			// Hit the filesystem root without finding an existing dir.
+			return nil
+		}
+		probe = parent
+	}
+	cmd := exec.Command("git", "-C", probe, "rev-parse", "--show-toplevel")
+	out, err := cmd.Output()
+	if err != nil {
+		// Not a git repo (or git is missing): fine, proceed.
+		return nil
+	}
+	toplevel := strings.TrimSpace(string(out))
+	return fmt.Errorf(
+		"snapshot: destination %s is inside the git working tree at %s; "+
+			"point --dest at a non-tracked location (conventional: "+
+			"$HOME/.mnemo-test-snapshots/snapshot-<timestamp>)",
+		dest, toplevel,
+	)
+}
+
+// copyTree does a plain recursive copy of src into dst, creating dst
+// itself. Symlinks are recreated as symlinks; permissions are preserved.
+func copyTree(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		switch {
+		case d.IsDir():
+			return os.MkdirAll(target, info.Mode().Perm())
+		case info.Mode()&os.ModeSymlink != 0:
+			link, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			// Best-effort: remove existing target so Symlink doesn't fail.
+			_ = os.Remove(target)
+			return os.Symlink(link, target)
+		default:
+			in, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			defer in.Close()
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(out, in); err != nil {
+				out.Close()
+				return err
+			}
+			return out.Close()
+		}
+	})
+}

--- a/cmd/mnemo-test-snapshot/main_test.go
+++ b/cmd/mnemo-test-snapshot/main_test.go
@@ -1,0 +1,219 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// makeSourceHome lays down a minimal source $HOME with ~/.mnemo and
+// ~/.claude/projects content. Returns the home dir.
+func makeSourceHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	mnemo := filepath.Join(home, ".mnemo")
+	if err := os.MkdirAll(mnemo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mnemo, "mnemo.db"), []byte("fake db"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	projects := filepath.Join(home, ".claude", "projects", "proj-a")
+	if err := os.MkdirAll(projects, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projects, "session.jsonl"), []byte("line\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+// extractMnemoHome scans stdout for the last `MNEMO_HOME=...` line.
+func extractMnemoHome(t *testing.T, stdout string) string {
+	t.Helper()
+	var out string
+	for _, line := range strings.Split(strings.TrimRight(stdout, "\n"), "\n") {
+		if strings.HasPrefix(line, "MNEMO_HOME=") {
+			out = strings.TrimPrefix(line, "MNEMO_HOME=")
+		}
+	}
+	if out == "" {
+		t.Fatalf("no MNEMO_HOME= line in stdout: %q", stdout)
+	}
+	// Should be the LAST line.
+	lines := strings.Split(strings.TrimRight(stdout, "\n"), "\n")
+	if !strings.HasPrefix(lines[len(lines)-1], "MNEMO_HOME=") {
+		t.Fatalf("MNEMO_HOME= is not the last line of stdout: %q", stdout)
+	}
+	return out
+}
+
+func assertContent(t *testing.T, path, want string) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(b) != want {
+		t.Fatalf("%s: got %q, want %q", path, string(b), want)
+	}
+}
+
+func TestSnapshot_Darwin_CloneCopy(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only: exercises cp -c -R clonefile path")
+	}
+	home := makeSourceHome(t)
+	dest := filepath.Join(t.TempDir(), "snap")
+
+	var stdout, stderr bytes.Buffer
+	if err := run([]string{"--source-home", home, "--dest", dest}, &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v\nstderr: %s", err, stderr.String())
+	}
+	got := extractMnemoHome(t, stdout.String())
+	if got != dest {
+		t.Fatalf("MNEMO_HOME: got %q, want %q", got, dest)
+	}
+	assertContent(t, filepath.Join(dest, ".mnemo", "mnemo.db"), "fake db")
+	assertContent(t, filepath.Join(dest, ".claude", "projects", "proj-a", "session.jsonl"), "line\n")
+	// Stub config.json should exist.
+	if _, err := os.Stat(filepath.Join(dest, ".mnemo", "config.json")); err != nil {
+		t.Fatalf("expected stub config.json: %v", err)
+	}
+}
+
+func TestSnapshot_FallbackCopy(t *testing.T) {
+	prev := forceFallback
+	forceFallback = true
+	t.Cleanup(func() { forceFallback = prev })
+
+	home := makeSourceHome(t)
+	dest := filepath.Join(t.TempDir(), "snap")
+
+	var stdout, stderr bytes.Buffer
+	if err := run([]string{"--source-home", home, "--dest", dest}, &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v\nstderr: %s", err, stderr.String())
+	}
+	got := extractMnemoHome(t, stdout.String())
+	if got != dest {
+		t.Fatalf("MNEMO_HOME: got %q, want %q", got, dest)
+	}
+	if !strings.Contains(stderr.String(), "[fallback]") {
+		t.Fatalf("expected [fallback] log line in stderr, got: %s", stderr.String())
+	}
+	assertContent(t, filepath.Join(dest, ".mnemo", "mnemo.db"), "fake db")
+	assertContent(t, filepath.Join(dest, ".claude", "projects", "proj-a", "session.jsonl"), "line\n")
+}
+
+func TestSnapshot_RefusesGitTrackedDest(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	home := makeSourceHome(t)
+
+	gitRoot := t.TempDir()
+	cmd := exec.Command("git", "-C", gitRoot, "init", "-q")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	dest := filepath.Join(gitRoot, "subdir", "snap")
+
+	var stdout, stderr bytes.Buffer
+	err := run([]string{"--source-home", home, "--dest", dest}, &stdout, &stderr)
+	if err == nil {
+		t.Fatalf("expected error for git-tracked destination, got nil")
+	}
+	if !strings.Contains(err.Error(), "git working tree") {
+		t.Fatalf("error message does not mention git working tree: %v", err)
+	}
+}
+
+func TestSnapshot_RefusesExistingWithoutForce(t *testing.T) {
+	home := makeSourceHome(t)
+	dest := filepath.Join(t.TempDir(), "snap")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "marker"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := run([]string{"--source-home", home, "--dest", dest}, &stdout, &stderr)
+	if err == nil {
+		t.Fatalf("expected error for existing destination without --force")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("error does not mention 'already exists': %v", err)
+	}
+	// Marker file must still be there.
+	if _, err := os.Stat(filepath.Join(dest, "marker")); err != nil {
+		t.Fatalf("marker file was removed: %v", err)
+	}
+}
+
+func TestSnapshot_AllowsExistingWithForce(t *testing.T) {
+	home := makeSourceHome(t)
+	dest := filepath.Join(t.TempDir(), "snap")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "marker"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := run([]string{"--source-home", home, "--dest", dest, "--force"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run with --force: %v\nstderr: %s", err, stderr.String())
+	}
+	got := extractMnemoHome(t, stdout.String())
+	if got != dest {
+		t.Fatalf("MNEMO_HOME: got %q, want %q", got, dest)
+	}
+	// Old marker should be gone (clobbered).
+	if _, err := os.Stat(filepath.Join(dest, "marker")); !os.IsNotExist(err) {
+		t.Fatalf("expected marker to be clobbered, got err: %v", err)
+	}
+	// Fresh content present.
+	assertContent(t, filepath.Join(dest, ".mnemo", "mnemo.db"), "fake db")
+}
+
+func TestSnapshot_PrintsMnemoHomeLast(t *testing.T) {
+	home := makeSourceHome(t)
+	dest := filepath.Join(t.TempDir(), "snap")
+
+	var stdout, stderr bytes.Buffer
+	if err := run([]string{"--source-home", home, "--dest", dest}, &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v\nstderr: %s", err, stderr.String())
+	}
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	last := lines[len(lines)-1]
+	if last != "MNEMO_HOME="+dest {
+		t.Fatalf("last stdout line = %q, want %q", last, "MNEMO_HOME="+dest)
+	}
+}
+
+func TestSnapshot_MissingSourcesTolerated(t *testing.T) {
+	home := t.TempDir() // no .mnemo, no .claude/projects
+	dest := filepath.Join(t.TempDir(), "snap")
+
+	var stdout, stderr bytes.Buffer
+	if err := run([]string{"--source-home", home, "--dest", dest}, &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v\nstderr: %s", err, stderr.String())
+	}
+	got := extractMnemoHome(t, stdout.String())
+	if got != dest {
+		t.Fatalf("MNEMO_HOME: got %q, want %q", got, dest)
+	}
+	// Stub config.json should still be created.
+	if _, err := os.Stat(filepath.Join(dest, ".mnemo", "config.json")); err != nil {
+		t.Fatalf("expected stub config.json: %v", err)
+	}
+}

--- a/diagnose.go
+++ b/diagnose.go
@@ -355,10 +355,10 @@ func toolVersion(path string, args []string) string {
 
 func checkFilesystem() checkResult {
 	r := checkResult{title: "Filesystem"}
-	home, err := os.UserHomeDir()
+	home, err := store.EffectiveHome()
 	if err != nil {
 		r.status = statusFail
-		r.add(fmt.Sprintf("os.UserHomeDir failed: %v", err))
+		r.add(fmt.Sprintf("store.EffectiveHome failed: %v", err))
 		return r
 	}
 
@@ -439,7 +439,7 @@ func humanBytes(n int64) string {
 
 func checkDatabase() checkResult {
 	r := checkResult{title: "Database"}
-	home, err := os.UserHomeDir()
+	home, err := store.EffectiveHome()
 	if err != nil {
 		r.status = statusFail
 		r.add(err.Error())
@@ -507,7 +507,7 @@ func checkDatabase() checkResult {
 
 func checkIndexFreshness() checkResult {
 	r := checkResult{title: "Index freshness"}
-	home, err := os.UserHomeDir()
+	home, err := store.EffectiveHome()
 	if err != nil {
 		r.status = statusFail
 		r.add(err.Error())
@@ -607,7 +607,7 @@ func checkConfiguration() checkResult {
 			r.add(pathStatus(p))
 		}
 	}
-	if home, err := os.UserHomeDir(); err == nil {
+	if home, err := store.EffectiveHome(); err == nil {
 		if vp := cfg.ResolvedVaultPath(home); vp != "" {
 			count := countMDFilesLocal(vp)
 			r.add(fmt.Sprintf("vault_path: %s (%d .md files)", vp, count))

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,168 @@
+# Testing mnemo
+
+Reference for the project's three-tier test architecture (🎯T73).
+
+## TL;DR
+
+| Tier | Where it lives | When to write one | Run with |
+|------|----------------|-------------------|----------|
+| 1 — synthetic, in-tree | `*_test.go` files alongside the code they test | Most regressions. Pure unit logic, small fixtures. | `make test` |
+| 2 — programmatic mid-scale | Tests that use `internal/storetest.Generator` to synthesise hundreds of sessions | When the bug only surfaces at row counts a tiny fixture won't reach (lock contention, query-plan flips, ingest scaling) | `make test` |
+| 3 — real-data scale | Files gated by `//go:build scale`, live alongside Tier 1/2 tests | When the assertion only makes sense against a production-shape corpus (compactor convergence on actual token distributions, federation under real per-peer sizes) | `make test-scale` after `make snapshot` |
+
+Drive the daemon through the MCP transport via the `internal/e2e`
+harness whenever you're testing more than a single package's
+internals. Direct Go-package API tests miss MCP serialisation bugs,
+per-user routing bugs, and resolver wiring bugs.
+
+## Tier 1 — synthetic, in-tree
+
+The bread and butter. `internal/storetest` has primitives —
+`WriteJSONL`, `MetaMsg`, `Msg`, `NewStore` — that build a small in-
+memory transcript and a populated store. Tests assert exact values
+because the inputs are fully specified.
+
+```go
+func TestX(t *testing.T) {
+    projDir := t.TempDir()
+    storetest.WriteJSONL(t, projDir, "-Users-alice-dev-app", "sess-01", []map[string]any{
+        storetest.MetaMsg("user", "hello", "2026-05-10T10:00:00Z",
+            "/Users/alice/dev/app", "main"),
+        storetest.Msg("assistant", "world", "2026-05-10T10:00:01Z"),
+    })
+    s := storetest.NewStore(t, projDir)
+    if err := s.IngestAll(); err != nil { t.Fatal(err) }
+    // … exact-value assertions against s …
+}
+```
+
+Use Tier 1 for: ingest correctness, FTS5 query shapes, single-table
+invariants, fence/markdown parsing, schema-version checks.
+
+## Tier 2 — programmatic mid-scale
+
+`internal/storetest.Generator` writes a synthetic `~/.claude/projects/`
+tree with controllable distributions of session count, messages per
+session, token volume, repo mix, and tool-use density. Deterministic
+given a seed — same seed, byte-identical output.
+
+```go
+gen := storetest.Generator{
+    Seed:        42,
+    Sessions:    500,
+    Repos:       []string{"acme/foo", "acme/bar"},
+    MsgsDist:    storetest.Distribution{Min: 5, Max: 200, Mean: 50},
+    TokensDist:  storetest.Distribution{Min: 50, Max: 5000, Mean: 800},
+    ToolUseRate: 0.3,
+}
+projDir := t.TempDir()
+if err := gen.Write(projDir); err != nil { t.Fatal(err) }
+// Pass projDir as MNEMO_HOME's .claude/projects to an e2e.Daemon,
+// or ingest directly via storetest.NewStore.
+```
+
+Use Tier 2 for: lock contention with N writers, query-plan
+correctness as row counts grow, ingest performance regressions,
+migration backfill behaviour, compactor candidate selection at
+non-trivial corpus sizes.
+
+## Tier 3 — real-data scale
+
+Tier 3 tests operate on an **isolated copy** of the real data —
+never the live `~/.mnemo` or `~/.claude/projects`.
+
+### Safety design
+
+- **`MNEMO_HOME` controls every daemon-state path.** The daemon
+  reads its database, config, state.json, peers/, and the
+  default-user's `.claude/projects` tree from `$MNEMO_HOME`
+  exclusively. Tests launched against a tempdir or snapshot path are
+  structurally incapable of touching the real `$HOME`.
+- **Build tag gate.** Tier 3 tests live behind `//go:build scale`.
+  `go test ./...` never sees them. Only `go test -tags 'sqlite_fts5
+  scale' ./...` (or `make test-scale`) compiles them.
+- **Env-var gate.** Tier 3 tests skip with a clear message when
+  `MNEMO_TEST_SNAPSHOT` is unset. CI never sets it. A casual
+  `make test-scale` on a contributor's machine without a snapshot
+  prints skips, not failures.
+- **APFS clone for snapshots.** `cmd/mnemo-test-snapshot` uses
+  `cp -c` to clone the source tree by reference on macOS —
+  effectively free, O(1). Falls back to plain recursive copy on
+  other platforms.
+- **No git-tracked destination.** The snapshot helper refuses to
+  write into a directory inside a git working tree. The conventional
+  location (`~/.mnemo-test-snapshots/`) is also `.gitignore`d as
+  belt-and-braces.
+
+### Workflow
+
+```sh
+make snapshot                              # clones ~/.mnemo and ~/.claude/projects
+# Output ends with: MNEMO_HOME=/Users/you/.mnemo-test-snapshots/snapshot-...
+export MNEMO_TEST_SNAPSHOT=$(make snapshot 2>/dev/null | tail -n1 | cut -d= -f2)
+make test-scale
+```
+
+### Writing Tier 3 tests
+
+Tier 3 assertions are **invariants**, not exact values — the
+snapshot changes every time you take one, so a test claiming
+"exactly 500 compactions" flakes. Reach for shapes like:
+
+- **Convergence**: "backlog ≤ N within K scans"
+- **Cursor monotonicity**: "every compaction's `entry_id_from`
+  equals its predecessor's `entry_id_to + 1`"
+- **No-double-process**: "no session_id appears more than once in
+  a single scan's candidate list"
+- **Bounded resource use**: "MCP tool returns within X seconds at
+  scale"
+
+The current worked examples live in `internal/e2e/scale_test.go`.
+
+## The e2e harness (driving the daemon via MCP)
+
+`internal/e2e.Start(t, ...)` spawns `bin/mnemo` as a subprocess
+under `MNEMO_HOME=<tempdir or snapshot>`, waits for the HTTP
+transport to become ready, and returns an MCP client handle. Tests
+drive scenarios via real tool calls.
+
+```go
+func TestVaultViaMCP(t *testing.T) {
+    d := e2e.Start(t)  // tempdir-isolated daemon
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    defer cancel()
+    out, err := d.Call(ctx, "mnemo_vault_status", nil)
+    if err != nil { t.Fatal(err) }
+    // … assertions on `out` …
+}
+```
+
+Failure modes that ONLY surface end-to-end:
+
+- MCP request → tool handler → resolver wiring → backend response
+  serialisation.
+- Per-user routing and the `?user=` query-param fallback.
+- Hot-reload paths (`mnemo_config(op=write, ...)`) and their
+  in-process adoption.
+- The streamable-HTTP transport's session handling under real load.
+
+The harness uses [`mark3labs/mcp-go`](https://github.com/mark3labs/mcp-go)'s
+client for the transport layer, so test assertions read the same
+JSON-RPC responses any real MCP client (Claude Code, etc.) sees.
+
+## What `make bullseye` runs
+
+The repo's "standing invariants" check (run on every PR / referenced
+by the `bullseye_convergence` tool). It gates Tier 1 + Tier 2 only —
+`make test`, not `make test-scale`. Tier 3 is local-only.
+
+## File map
+
+| Path | Purpose |
+|------|---------|
+| `internal/storetest/storetest.go` | Tier 1 primitives — JSONL fixtures, NewStore helper |
+| `internal/storetest/generator.go` | Tier 2 deterministic generator (🎯T73) |
+| `internal/e2e/e2e.go` | Subprocess + MCP client harness (🎯T73) |
+| `internal/e2e/scale_test.go` | Tier 3 invariant examples (🎯T73) |
+| `cmd/mnemo-test-snapshot/` | Snapshot helper (🎯T73) |
+| `internal/store/homedir.go` | `EffectiveHome()` + `MNEMO_HOME` plumbing (🎯T73) |

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -476,7 +476,7 @@ func (h *Handler) dbstats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// File size
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := store.EffectiveHome()
 	if err != nil {
 		slog.Warn("api/dbstats: cannot determine home directory", "err", err)
 	}

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -1,0 +1,358 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+// Package e2e is the daemon-subprocess test harness for mnemo's
+// integration / scale tests (🎯T73). It spawns `bin/mnemo` as a
+// real subprocess with MNEMO_HOME=<tempdir>, drives it via the
+// MCP HTTP transport, and tears down cleanly when the test ends.
+//
+// Tests built on top of this package exercise the daemon as a black
+// box — through MCP, not through the in-process Go API — so failure
+// modes that only manifest at the MCP / serialisation / per-user
+// routing layer become testable.
+//
+// Typical usage:
+//
+//	func TestSomething(t *testing.T) {
+//	    d := e2e.Start(t)              // launches daemon under MNEMO_HOME=tempdir
+//	    out, err := d.Call(ctx, "mnemo_status", nil)
+//	    if err != nil { t.Fatal(err) }
+//	    // assert on out
+//	}
+//
+// d.Stop is registered via t.Cleanup so tests don't have to.
+package e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// buildOnce caches the daemon binary across all tests in a single
+// `go test` invocation. The first Start triggers `go build`; every
+// subsequent Start reuses the cached path. The binary lives under
+// the test cache dir and is removed when the test process exits.
+var (
+	buildOnce sync.Once
+	binPath   string
+	buildErr  error
+)
+
+// Daemon is a running mnemo daemon subprocess plus its MCP client.
+// Call Stop to cancel it; t.Cleanup is wired in Start so most callers
+// can ignore Stop entirely.
+type Daemon struct {
+	// Home is the MNEMO_HOME directory the daemon was launched
+	// under. Tests may write fixtures (config.json, project
+	// transcripts) under this root BEFORE calling Start, or read
+	// the daemon's state after.
+	Home string
+
+	// URL is the http://127.0.0.1:<port>/mcp endpoint the daemon
+	// is listening on. Exposed for tests that want a raw HTTP
+	// client; most should use Call instead.
+	URL string
+
+	cmd    *exec.Cmd
+	client *client.Client
+	cancel context.CancelFunc
+	stderr *strings.Builder
+}
+
+// Options controls the daemon's launch configuration. Zero-value is
+// fine for most tests.
+type Options struct {
+	// Home overrides the MNEMO_HOME directory. Empty creates a
+	// fresh tempdir (the common case).
+	Home string
+
+	// User selects the username injected into MCP requests via the
+	// ?user= query parameter. Empty defaults to the process owner.
+	User string
+
+	// StartTimeout bounds how long Start waits for the daemon's
+	// HTTP listener to become responsive. Zero defaults to 30s,
+	// which is generous enough for cold builds.
+	StartTimeout time.Duration
+
+	// Env adds extra environment variables to the daemon
+	// subprocess. Format: "KEY=value". MNEMO_HOME is always
+	// injected and wins over any duplicate here.
+	Env []string
+
+	// Args appends extra CLI flags to the daemon invocation.
+	// Useful for tests that want to disable federation, change
+	// log level, etc.
+	Args []string
+}
+
+// Start launches a mnemo daemon subprocess, waits for its MCP
+// endpoint to become ready, returns a connected Daemon handle, and
+// registers a t.Cleanup that calls Stop on test exit. Use opts...
+// to override the default tempdir / timeout / args.
+func Start(t *testing.T, opts ...Options) *Daemon {
+	t.Helper()
+	o := Options{}
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+	if o.StartTimeout == 0 {
+		o.StartTimeout = 30 * time.Second
+	}
+	if o.Home == "" {
+		o.Home = t.TempDir()
+	}
+
+	bin, err := ensureBinary()
+	if err != nil {
+		t.Fatalf("e2e: build daemon: %v", err)
+	}
+	port, err := freePort()
+	if err != nil {
+		t.Fatalf("e2e: allocate port: %v", err)
+	}
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	args := append([]string{"--addr", addr, "--federated-addr", ""}, o.Args...)
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Env = append(os.Environ(),
+		"MNEMO_HOME="+o.Home,
+		// Disable optional features that would surprise tests by
+		// reaching out: backup worker, GitHub poller, federation
+		// client all default to disabled-on-no-config and stay that
+		// way under a fresh tempdir HOME.
+	)
+	cmd.Env = append(cmd.Env, o.Env...)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stderr
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatalf("e2e: spawn daemon: %v", err)
+	}
+
+	url := fmt.Sprintf("http://%s/mcp", addr)
+	if o.User != "" {
+		url += "?user=" + o.User
+	}
+
+	d := &Daemon{
+		Home:   o.Home,
+		URL:    url,
+		cmd:    cmd,
+		cancel: cancel,
+		stderr: &stderr,
+	}
+	t.Cleanup(d.Stop)
+
+	if err := d.waitReady(o.StartTimeout); err != nil {
+		// On readiness failure, the captured stderr is the most
+		// useful single artefact — surface it on the t.Fatal.
+		t.Fatalf("e2e: daemon failed to become ready: %v\n--- daemon log ---\n%s", err, stderr.String())
+	}
+
+	cli, err := client.NewStreamableHttpClient(url)
+	if err != nil {
+		t.Fatalf("e2e: build MCP client: %v", err)
+	}
+	if err := cli.Start(ctx); err != nil {
+		t.Fatalf("e2e: start MCP client: %v", err)
+	}
+	initCtx, initCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer initCancel()
+	_, err = cli.Initialize(initCtx, mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo:      mcp.Implementation{Name: "mnemo-e2e", Version: "1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("e2e: MCP initialize: %v", err)
+	}
+	d.client = cli
+	return d
+}
+
+// Stop shuts down the MCP client and daemon subprocess. Safe to call
+// multiple times; idempotent. Wired via t.Cleanup in Start so most
+// callers should not call this explicitly.
+func (d *Daemon) Stop() {
+	if d.client != nil {
+		_ = d.client.Close()
+		d.client = nil
+	}
+	if d.cancel != nil {
+		d.cancel()
+		d.cancel = nil
+	}
+	if d.cmd != nil {
+		_ = d.cmd.Wait()
+		d.cmd = nil
+	}
+}
+
+// Call invokes an MCP tool by name and returns the first text-content
+// block of the response. Arguments encode as JSON via the standard
+// MCP CallToolRequest shape. A nil args map sends no parameters.
+//
+// When the tool returns an isError result, Call returns a non-nil
+// error whose message is the tool's first text-content block.
+//
+// For multi-content responses or non-text content, use CallFull
+// instead (returns the raw *mcp.CallToolResult).
+func (d *Daemon) Call(ctx context.Context, tool string, args map[string]any) (string, error) {
+	res, err := d.CallFull(ctx, tool, args)
+	if err != nil {
+		return "", err
+	}
+	text := firstText(res)
+	if res.IsError {
+		return text, fmt.Errorf("tool %q returned error: %s", tool, text)
+	}
+	return text, nil
+}
+
+// CallFull is Call without the text/error post-processing — returns
+// the raw MCP CallToolResult. Use this when you need access to
+// multi-block content or the IsError flag explicitly.
+func (d *Daemon) CallFull(ctx context.Context, tool string, args map[string]any) (*mcp.CallToolResult, error) {
+	if d.client == nil {
+		return nil, errors.New("e2e: daemon not started or already stopped")
+	}
+	req := mcp.CallToolRequest{}
+	req.Params.Name = tool
+	if args != nil {
+		req.Params.Arguments = args
+	}
+	return d.client.CallTool(ctx, req)
+}
+
+// Log returns everything the daemon has written to stdout/stderr
+// since Start. Useful for failure diagnostics in tests that don't
+// want to register their own stderr capture.
+func (d *Daemon) Log() string { return d.stderr.String() }
+
+// waitReady polls the daemon's HTTP listener until it accepts a TCP
+// connection on /mcp, then succeeds. Timeout returns an error.
+//
+// We deliberately don't probe MCP-level readiness here; an HTTP-
+// listener-accepts probe is enough — the MCP client's Initialize
+// call below catches any deeper failure mode with a richer error.
+func (d *Daemon) waitReady(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	addr := strings.TrimPrefix(strings.SplitN(d.URL, "/mcp", 2)[0], "http://")
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 250*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		// If the process died, surface that immediately rather
+		// than waiting out the deadline.
+		if d.cmd.ProcessState != nil && d.cmd.ProcessState.Exited() {
+			return fmt.Errorf("daemon exited before ready: %s", d.cmd.ProcessState)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("timeout after %v", timeout)
+}
+
+// freePort asks the kernel for an unused TCP port by listening on
+// :0 and immediately closing. Race-free in practice for tests; a
+// rare collision will surface as the daemon failing to bind, which
+// waitReady catches.
+func freePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+// ensureBinary builds the mnemo daemon binary once per test process
+// and caches the resulting path. Subsequent Start calls reuse it.
+// The build runs from the repo root (located by walking up from this
+// source file's directory) with the sqlite_fts5 tag, matching what
+// `make build` produces in normal use.
+func ensureBinary() (string, error) {
+	buildOnce.Do(func() {
+		root, err := repoRoot()
+		if err != nil {
+			buildErr = err
+			return
+		}
+		dir, err := os.MkdirTemp("", "mnemo-e2e-bin-")
+		if err != nil {
+			buildErr = err
+			return
+		}
+		out := filepath.Join(dir, "mnemo")
+		if runtime.GOOS == "windows" {
+			out += ".exe"
+		}
+		cmd := exec.Command("go", "build", "-tags", "sqlite_fts5", "-o", out, ".")
+		cmd.Dir = root
+		if combined, err := cmd.CombinedOutput(); err != nil {
+			buildErr = fmt.Errorf("go build: %v\n%s", err, combined)
+			return
+		}
+		binPath = out
+	})
+	return binPath, buildErr
+}
+
+// repoRoot locates the mnemo repository root by walking up from this
+// source file's directory until a go.mod is found whose module path
+// is github.com/marcelocantos/mnemo. Anchored to the *file* rather
+// than the test's working directory so tests in any package can
+// build the daemon correctly.
+func repoRoot() (string, error) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", errors.New("runtime.Caller failed")
+	}
+	dir := filepath.Dir(thisFile)
+	for i := 0; i < 16; i++ {
+		gm := filepath.Join(dir, "go.mod")
+		if b, err := os.ReadFile(gm); err == nil {
+			if strings.Contains(string(b), "module github.com/marcelocantos/mnemo") {
+				return dir, nil
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", errors.New("mnemo repo root not found from " + thisFile)
+}
+
+// firstText extracts the first text-content block from a tool call
+// result. Returns empty string when no text content is present —
+// callers that care about non-text content should use CallFull
+// instead.
+func firstText(res *mcp.CallToolResult) string {
+	for _, c := range res.Content {
+		if tc, ok := c.(mcp.TextContent); ok {
+			return tc.Text
+		}
+	}
+	return ""
+}

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSmoke launches a daemon with an empty MNEMO_HOME tempdir,
+// confirms the MCP transport is reachable, and round-trips one tool
+// call (mnemo_stats — a read-only call that works against an empty
+// index). Proves the harness end-to-end. Skip on -short.
+func TestSmoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e smoke test skipped under -short")
+	}
+	d := Start(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	out, err := d.Call(ctx, "mnemo_stats", nil)
+	if err != nil {
+		t.Fatalf("mnemo_stats: %v\n--- daemon log ---\n%s", err, d.Log())
+	}
+	if out == "" {
+		t.Fatal("mnemo_stats returned empty body")
+	}
+	// mnemo_stats response should mention "sessions" or "entries"
+	// somewhere in its rendering. Loose check; we're verifying the
+	// channel works, not the tool's specific output shape.
+	if !strings.Contains(strings.ToLower(out), "session") &&
+		!strings.Contains(strings.ToLower(out), "entries") {
+		t.Errorf("mnemo_stats output unexpected:\n%s", out)
+	}
+}
+
+// TestIsolation verifies the 🎯T73 keystone invariant: a daemon
+// launched with MNEMO_HOME=<tempdir> writes its state under that
+// tempdir, NOT under the real ~/.mnemo. Belt-and-braces against the
+// "test accidentally hits live data" failure mode.
+func TestIsolation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e isolation test skipped under -short")
+	}
+	d := Start(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Issue any tool call so the daemon definitely touches its
+	// data root; mnemo_stats is cheap.
+	if _, err := d.Call(ctx, "mnemo_stats", nil); err != nil {
+		t.Fatalf("mnemo_stats: %v\n%s", err, d.Log())
+	}
+	d.Stop() // flush + close DB so the file is observable
+
+	// The daemon's database must live under Home/.mnemo/mnemo.db.
+	dbPath := filepath.Join(d.Home, ".mnemo", "mnemo.db")
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Errorf("expected daemon DB at %q (under MNEMO_HOME): %v", dbPath, err)
+	}
+}

--- a/internal/e2e/scale_test.go
+++ b/internal/e2e/scale_test.go
@@ -1,0 +1,177 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build scale
+// +build scale
+
+// Tier 3 — real-data scale tests (🎯T73). These tests run only with
+// the `scale` build tag (`go test -tags 'sqlite_fts5 scale' ./...`)
+// and require MNEMO_TEST_SNAPSHOT to point at an isolated snapshot
+// of the user's mnemo data. Default `go test ./...` invocations
+// never see these.
+//
+// The cmd/mnemo-test-snapshot helper produces the snapshot; see
+// docs/testing.md for the workflow.
+//
+// Tier 3 assertions are INVARIANTS rather than exact values — a
+// snapshot's contents change daily as transcript history grows, so
+// a test that asserts "exactly N compactions" would flake. The
+// invariants below hold against any reasonable snapshot.
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// snapshotHome reads MNEMO_TEST_SNAPSHOT and skips the test with a
+// clear message when it is unset. Centralised so every Tier 3 test
+// gets the same skip behaviour.
+func snapshotHome(t *testing.T) string {
+	t.Helper()
+	home := os.Getenv("MNEMO_TEST_SNAPSHOT")
+	if home == "" {
+		t.Skip("MNEMO_TEST_SNAPSHOT not set; skipping Tier 3 scale test " +
+			"(run cmd/mnemo-test-snapshot first, then set the env var)")
+	}
+	if _, err := os.Stat(home); err != nil {
+		t.Skipf("MNEMO_TEST_SNAPSHOT=%q not accessible: %v", home, err)
+	}
+	return home
+}
+
+// TestScaleBacklogConvergence is a worked example of a Tier 3
+// invariant assertion (🎯T73 acceptance #6 — backlog convergence).
+// On any production-shape snapshot, the compactor's reported
+// backlog must be a bounded, observable number — not an unbounded
+// runaway. Concretely, mnemo_compactor_status returns a numeric
+// "backlog" line and the value must be parseable, non-negative, and
+// (loosely) less than the total session count (a backlog larger
+// than the entire session set means the trigger is broken).
+//
+// This assertion is intentionally weak: it tests the SHAPE of the
+// convergence model, not a particular threshold. A snapshot taken
+// two months from now still passes if the compactor is healthy.
+func TestScaleBacklogConvergence(t *testing.T) {
+	home := snapshotHome(t)
+	d := Start(t, Options{Home: home})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Pull the live compactor status. Look for "backlog:" and
+	// parse the integer.
+	out, err := d.Call(ctx, "mnemo_compactor_status", nil)
+	if err != nil {
+		t.Fatalf("mnemo_compactor_status: %v\n%s", err, d.Log())
+	}
+	backlog, ok := parseBacklog(out)
+	if !ok {
+		t.Fatalf("mnemo_compactor_status: could not parse backlog from:\n%s", out)
+	}
+	if backlog < 0 {
+		t.Errorf("compactor backlog is negative (%d) — invariant broken", backlog)
+	}
+
+	// Sanity bound: backlog must not exceed total session count.
+	// Read mnemo_stats to get the total. We allow some slack for
+	// race conditions between the two MCP calls — backlog ≤ 1.2 ×
+	// total is enough to catch a runaway without spurious flakes.
+	statsOut, err := d.Call(ctx, "mnemo_stats", nil)
+	if err != nil {
+		t.Fatalf("mnemo_stats: %v\n%s", err, d.Log())
+	}
+	total, ok := parseTotalSessions(statsOut)
+	if !ok {
+		t.Logf("could not parse total sessions from mnemo_stats; relying on backlog≥0 invariant alone")
+		return
+	}
+	if total > 0 && float64(backlog) > 1.2*float64(total) {
+		t.Errorf("compactor backlog %d exceeds 1.2 × total sessions %d — "+
+			"convergence model is broken", backlog, total)
+	}
+
+	t.Logf("backlog=%d, total_sessions=%d — within bounds", backlog, total)
+}
+
+// TestScaleVaultStatusReachable is a second worked example: even
+// against a production-scale snapshot the basic MCP surface
+// (mnemo_vault_status) must remain reachable and return a parseable
+// response within a few seconds. Validates the e2e harness against
+// real data sizes without any specific value claims.
+func TestScaleVaultStatusReachable(t *testing.T) {
+	home := snapshotHome(t)
+	d := Start(t, Options{Home: home})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	out, err := d.Call(ctx, "mnemo_vault_status", nil)
+	if err != nil {
+		t.Fatalf("mnemo_vault_status: %v\n%s", err, d.Log())
+	}
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Errorf("mnemo_vault_status took %v — exceeds 10s budget at scale", elapsed)
+	}
+	if len(out) == 0 {
+		t.Errorf("mnemo_vault_status returned empty body at scale")
+	}
+}
+
+// parseBacklog extracts the integer following the literal "backlog:"
+// in the mnemo_compactor_status output. The status tool formats it
+// like "backlog: 8633" (possibly indented).
+func parseBacklog(s string) (int, bool) {
+	const key = "backlog:"
+	i := strings.Index(s, key)
+	if i < 0 {
+		return 0, false
+	}
+	rest := strings.TrimSpace(s[i+len(key):])
+	// Take the first whitespace-bounded token, drop any trailing
+	// "(...)" hint the tool may append.
+	tok := strings.Fields(rest)
+	if len(tok) == 0 {
+		return 0, false
+	}
+	var n int
+	if _, err := fmt.Sscanf(tok[0], "%d", &n); err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// parseTotalSessions looks for a "TotalSessions" or "sessions" field
+// in mnemo_stats output. The exact key varies by version — try a
+// couple of candidates and fall back to JSON decoding if the output
+// happens to be JSON.
+func parseTotalSessions(s string) (int, bool) {
+	for _, key := range []string{"total_sessions:", "sessions:", "TotalSessions:"} {
+		if i := strings.Index(s, key); i >= 0 {
+			rest := strings.TrimSpace(s[i+len(key):])
+			tok := strings.Fields(rest)
+			if len(tok) == 0 {
+				continue
+			}
+			var n int
+			if _, err := fmt.Sscanf(tok[0], "%d", &n); err == nil {
+				return n, true
+			}
+		}
+	}
+	// JSON fallback.
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(s), &doc); err == nil {
+		for _, key := range []string{"total_sessions", "TotalSessions", "sessions"} {
+			if v, ok := doc[key].(float64); ok {
+				return int(v), true
+			}
+		}
+	}
+	return 0, false
+}

--- a/internal/e2e/vault_sync_test.go
+++ b/internal/e2e/vault_sync_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestVaultSyncViaMCP is the e2e port (🎯T73 acceptance #7) of the
+// vault-sync integration tests that historically lived in
+// internal/vault/vault_test.go (TestExporterSyncCreatesFiles and
+// friends). Those tests called the in-process Go API directly. This
+// version drives the same flow through the real MCP transport
+// against a running daemon — so failures in the per-user registry
+// routing, the MCP serialisation layer, or the vault MCP tool
+// wrapper become testable.
+//
+// Flow:
+//  1. Launch a daemon under MNEMO_HOME=<tempdir>.
+//  2. Hot-reload via mnemo_config(op=write, patch={vault_path: ...}).
+//  3. Invoke mnemo_vault_sync via MCP.
+//  4. Assert <vault>/index.md exists with the standard fence
+//     contract (every mnemo-owned vault note carries the
+//     <!-- mnemo:generated --> marker).
+//  5. Assert mnemo_vault_status reports the vault path back.
+func TestVaultSyncViaMCP(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e vault sync skipped under -short")
+	}
+	// Pass ?user= explicitly. mnemo's vault resolver bypasses the
+	// default-user fallback that the store resolver applies, so a
+	// vault-touching test that omits ?user= sees "vault not
+	// configured." Setting it explicitly is the documented usage and
+	// avoids the asymmetry.
+	cur, err := user.Current()
+	if err != nil {
+		t.Skipf("user.Current unavailable: %v", err)
+	}
+	d := Start(t, Options{User: cur.Username})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Tempdir for the vault, outside MNEMO_HOME so the test verifies
+	// the daemon honours the configured path rather than a hidden
+	// default.
+	vaultDir := filepath.Join(d.Home, "vault")
+
+	// Hot-reload via mnemo_config(op=write). The patch shape is the
+	// same as ~/.mnemo/config.json — passed as a nested JSON object,
+	// not a string.
+	cfgOut, err := d.Call(ctx, "mnemo_config", map[string]any{
+		"op":    "write",
+		"patch": map[string]any{"vault_path": vaultDir},
+	})
+	if err != nil {
+		t.Fatalf("mnemo_config write: %v\n%s", err, d.Log())
+	}
+	if !strings.Contains(cfgOut, "vault_path") && !strings.Contains(cfgOut, "applied") {
+		t.Logf("mnemo_config output (informational):\n%s", cfgOut)
+	}
+
+	// The mnemo_config hot-reload kicks off an automatic vault sync
+	// in the background; an explicit mnemo_vault_sync called too
+	// soon coalesces with "already in flight, skipping." Either way
+	// the root index.md should appear shortly. Poll with a bounded
+	// timeout so the race resolves cleanly.
+	_, _ = d.Call(ctx, "mnemo_vault_sync", nil) // best-effort; coalescing is fine
+
+	rootIndex := filepath.Join(vaultDir, "index.md")
+	var body []byte
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if data, readErr := os.ReadFile(rootIndex); readErr == nil {
+			body = data
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if body == nil {
+		t.Fatalf("vault index.md never appeared at %q:\n--- daemon log ---\n%s",
+			rootIndex, d.Log())
+	}
+	if !strings.Contains(string(body), "mnemo:generated") {
+		t.Errorf("vault index.md missing the <!-- mnemo:generated --> fence — "+
+			"contract not honoured through MCP transport:\n%s", body)
+	}
+
+	// mnemo_vault_status must reach the configured path through the
+	// same MCP transport.
+	statusOut, err := d.Call(ctx, "mnemo_vault_status", nil)
+	if err != nil {
+		t.Fatalf("mnemo_vault_status: %v\n%s", err, d.Log())
+	}
+	if !strings.Contains(statusOut, vaultDir) {
+		t.Errorf("mnemo_vault_status did not surface vault_path %q:\n%s",
+			vaultDir, statusOut)
+	}
+}

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -38,6 +38,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/marcelocantos/mnemo/internal/store"
 )
 
 const (
@@ -233,7 +235,7 @@ func (e *Endpoint) PinnedClientTLSConfig(peerCert *x509.Certificate) (*tls.Confi
 
 // DefaultDir returns ~/.mnemo for the calling process's home.
 func DefaultDir() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := store.EffectiveHome()
 	if err != nil {
 		return "", fmt.Errorf("resolve home directory: %w", err)
 	}

--- a/internal/mcpconfig/mcpconfig.go
+++ b/internal/mcpconfig/mcpconfig.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/marcelocantos/mnemo/internal/store"
 )
 
 // DefaultURL is the HTTP MCP endpoint used when no user identity is
@@ -43,7 +45,7 @@ func URLForUser(username string) string {
 // ConfigPath returns the Claude Code user config file path.
 // On every supported platform this is ~/.claude.json.
 func ConfigPath() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := store.EffectiveHome()
 	if err != nil {
 		return "", fmt.Errorf("resolve home directory: %w", err)
 	}

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -355,7 +355,7 @@ type LinkedInstance struct {
 // non-https URL, unresolvable peer cert) returns an error so startup
 // fails loud rather than silently disabling federation.
 func LoadConfig() (Config, error) {
-	home, err := os.UserHomeDir()
+	home, err := EffectiveHome()
 	if err != nil {
 		return Config{}, err
 	}
@@ -388,7 +388,7 @@ func loadConfigFrom(path string) (Config, error) {
 // current process user. Returns an error only when the home directory
 // cannot be resolved.
 func ConfigPath() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := EffectiveHome()
 	if err != nil {
 		return "", err
 	}
@@ -410,7 +410,7 @@ func ConfigPath() (string, error) {
 // Used by the mnemo_config MCP tool to apply runtime configuration
 // changes (chiefly vault_path) without requiring a daemon restart.
 func WriteConfig(cfg Config) error {
-	home, err := os.UserHomeDir()
+	home, err := EffectiveHome()
 	if err != nil {
 		return err
 	}
@@ -582,7 +582,7 @@ func looksLikeInlinePEM(s string) bool {
 // This matches the convention used across the global CLAUDE.md for
 // Go-style repo layouts (~/work/github.com/org/repo).
 func DefaultWorkspaceRoots() []string {
-	home, err := os.UserHomeDir()
+	home, err := EffectiveHome()
 	if err != nil {
 		return nil
 	}
@@ -687,7 +687,7 @@ func (c Config) ResolvedSynthesisRoots() []string {
 	if len(c.SynthesisRoots) == 0 {
 		return nil
 	}
-	home, _ := os.UserHomeDir()
+	home, _ := EffectiveHome()
 	out := make([]string, 0, len(c.SynthesisRoots))
 	for _, r := range c.SynthesisRoots {
 		if r == "" {

--- a/internal/store/homedir.go
+++ b/internal/store/homedir.go
@@ -27,20 +27,59 @@ func CurrentUsername() (string, error) {
 	return normaliseUsername(u.Username), nil
 }
 
+// MnemoHomeEnv is the environment variable name that overrides the
+// daemon's notion of "home" — the directory under which sidecar state
+// (~/.mnemo/...) and the default user's data tree (~/.claude/...) are
+// resolved (🎯T73). Tests and the snapshot helper set this so a test
+// daemon launched with MNEMO_HOME=<tempdir> is *incapable* of reading
+// or mutating the real $HOME-rooted state.
+//
+// MNEMO_HOME affects only the default-identity path. Explicit
+// per-user lookups via ResolveHomeFor("alice") still consult the OS
+// user database (multi-user Windows-Service deployments preserved).
+const MnemoHomeEnv = "MNEMO_HOME"
+
+// EffectiveHome returns the directory the daemon should treat as
+// $HOME for sidecar state and default-user data. MNEMO_HOME wins
+// when set; otherwise os.UserHomeDir() is consulted (🎯T73).
+//
+// This is the ONLY function in the codebase that should consult
+// MNEMO_HOME / os.UserHomeDir() for daemon-state purposes. All other
+// call sites must route through here (or through ResolveHomeFor)
+// so MNEMO_HOME isolation holds end-to-end.
+func EffectiveHome() (string, error) {
+	if h := os.Getenv(MnemoHomeEnv); h != "" {
+		return h, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve current home: %w", err)
+	}
+	return home, nil
+}
+
 // ResolveHomeFor returns the absolute home directory for the named
 // user. On Windows this uses user.Lookup which, under the hood, calls
 // LookupAccountName + GetUserProfileDirectory. On Unix it reads the
 // user's entry from /etc/passwd (or getpwnam_r).
 //
-// The empty username resolves to the current process's home — useful
-// for interactive runs where the default identity is implicit.
+// The empty username resolves to EffectiveHome — the daemon's notion
+// of "home," respecting MNEMO_HOME for test isolation.
+//
+// An explicit username that matches the process owner ALSO routes
+// through EffectiveHome so MNEMO_HOME isolation holds end-to-end
+// (the daemon's eager-start path passes the resolved default
+// username, which would otherwise bypass MNEMO_HOME and load the
+// real DB). A different explicit username — Alice on a Windows
+// Service daemon running as SYSTEM — still consults the OS user
+// database so multi-user deployments continue to read each user's
+// real home.
 func ResolveHomeFor(username string) (string, error) {
 	if username == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("resolve current home: %w", err)
-		}
-		return home, nil
+		return EffectiveHome()
+	}
+	if cur, err := CurrentUsername(); err == nil && cur == normaliseUsername(username) {
+		return EffectiveHome()
 	}
 	u, err := user.Lookup(username)
 	if err != nil {

--- a/internal/store/homedir_test.go
+++ b/internal/store/homedir_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"os"
+	"testing"
+)
+
+// TestEffectiveHomeRespectsMNEMOHOME verifies the 🎯T73 isolation
+// invariant: when MNEMO_HOME is set, EffectiveHome returns it
+// verbatim, bypassing os.UserHomeDir entirely. This is the structural
+// guarantee that a test daemon launched with MNEMO_HOME=<tempdir>
+// cannot read or mutate the real $HOME-rooted state.
+func TestEffectiveHomeRespectsMNEMOHOME(t *testing.T) {
+	want := t.TempDir()
+	t.Setenv(MnemoHomeEnv, want)
+	got, err := EffectiveHome()
+	if err != nil {
+		t.Fatalf("EffectiveHome: %v", err)
+	}
+	if got != want {
+		t.Errorf("EffectiveHome under MNEMO_HOME=%q: got %q want %q", want, got, want)
+	}
+}
+
+func TestEffectiveHomeFallsBackToUserHomeDir(t *testing.T) {
+	// Explicitly unset to ensure the fallback path runs.
+	t.Setenv(MnemoHomeEnv, "")
+	if err := os.Unsetenv(MnemoHomeEnv); err != nil {
+		t.Fatalf("unset: %v", err)
+	}
+	got, err := EffectiveHome()
+	if err != nil {
+		t.Fatalf("EffectiveHome: %v", err)
+	}
+	osHome, _ := os.UserHomeDir()
+	if got != osHome {
+		t.Errorf("EffectiveHome without MNEMO_HOME: got %q want %q (os.UserHomeDir)", got, osHome)
+	}
+}
+
+func TestResolveHomeForEmptyUsernameRespectsMNEMOHOME(t *testing.T) {
+	// ResolveHomeFor("") is the default-identity path. It must
+	// route through EffectiveHome so the empty-username case is
+	// MNEMO_HOME-overridable.
+	want := t.TempDir()
+	t.Setenv(MnemoHomeEnv, want)
+	got, err := ResolveHomeFor("")
+	if err != nil {
+		t.Fatalf("ResolveHomeFor(\"\"): %v", err)
+	}
+	if got != want {
+		t.Errorf("ResolveHomeFor(\"\") under MNEMO_HOME=%q: got %q want %q", want, got, want)
+	}
+}
+
+func TestResolveHomeForProcessOwnerRespectsMNEMOHOME(t *testing.T) {
+	// Critical isolation invariant: when the daemon's eager-start
+	// path passes the resolved CurrentUsername() (e.g. "marcelo")
+	// to ResolveHomeFor, MNEMO_HOME must still win — otherwise the
+	// daemon under a test snapshot reads the real $HOME/.mnemo/mnemo.db
+	// and the isolation is gone.
+	cur, err := CurrentUsername()
+	if err != nil {
+		t.Skipf("CurrentUsername unavailable: %v", err)
+	}
+	want := t.TempDir()
+	t.Setenv(MnemoHomeEnv, want)
+	got, err := ResolveHomeFor(cur)
+	if err != nil {
+		t.Fatalf("ResolveHomeFor(%q): %v", cur, err)
+	}
+	if got != want {
+		t.Errorf("ResolveHomeFor(%q) under MNEMO_HOME=%q: got %q want %q (real-home leak)",
+			cur, want, got, want)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -937,7 +937,7 @@ type SkillInfo struct {
 
 // skillsDir returns the path to ~/.claude/skills/.
 func skillsDir() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := EffectiveHome()
 	if err != nil {
 		return "", err
 	}
@@ -1087,7 +1087,7 @@ func (s *Store) IngestClaudeConfigs() error {
 	}
 
 	// Also check ~/.claude/CLAUDE.md and ~/CLAUDE.md.
-	if homeDir, err := os.UserHomeDir(); err == nil {
+	if homeDir, err := EffectiveHome(); err == nil {
 		for _, extra := range []struct{ path, repo string }{
 			{filepath.Join(homeDir, ".claude", "CLAUDE.md"), "global"},
 			{filepath.Join(homeDir, "CLAUDE.md"), "home"},
@@ -5213,7 +5213,7 @@ func (s *Store) LiveSessions() map[string]int {
 	if time.Since(s.liveCacheTime) < liveSessionsTTL {
 		return s.liveCache
 	}
-	home, _ := os.UserHomeDir()
+	home, _ := EffectiveHome()
 	projectsDir := filepath.Join(home, ".claude", "projects")
 	result := parseLsofOutput(runLsof(projectsDir))
 	s.liveCache = result
@@ -6067,7 +6067,7 @@ func parsePsEnvOutput(data []byte) map[int]string {
 // under ~/.claude/projects/<encoded-cwd>/.  The encoded name replaces each '/'
 // with '-'.  Files are returned sorted newest-mtime first.
 func cwdToTranscripts(cwd string) []WhatsupTranscript {
-	home, err := os.UserHomeDir()
+	home, err := EffectiveHome()
 	if err != nil {
 		return nil
 	}
@@ -6203,7 +6203,7 @@ func (s *Store) Whatsup(postmortem bool) (*WhatsupResult, error) {
 // collectPostmortem scans ~/.claude/projects/ for transcript files modified
 // within the recency window and groups them by decoded cwd.
 func collectPostmortem(window time.Duration) []WhatsupPostmortemEntry {
-	home, err := os.UserHomeDir()
+	home, err := EffectiveHome()
 	if err != nil {
 		return nil
 	}

--- a/internal/storetest/generator.go
+++ b/internal/storetest/generator.go
@@ -1,0 +1,357 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package storetest
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Generator writes a synthetic ~/.claude/projects/-style transcript
+// tree under a project directory. Output is fully deterministic in
+// the (Seed, Sessions, Repos, MsgsDist, TokensDist, ToolUseRate)
+// tuple: identical configs produce byte-identical files. Intended
+// for tests that need realistic-shaped fixtures without taking a
+// dependency on real session data.
+//
+// The output mimics what Claude Code actually writes to
+// ~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl. Each
+// session file holds a leading user prompt followed by a chain of
+// assistant messages, optionally interleaved with tool_use blocks.
+// All envelope fields the ingest path inspects (type, timestamp,
+// sessionId, parentUuid, cwd, gitBranch, message.{role,model,usage})
+// are populated.
+//
+// Sizing: the generator is engineered for both small fixtures (tens
+// of sessions, sub-second) and mid-scale (10k+ sessions, single
+// digit minutes). No premature optimisation; the hot loop is a
+// straightforward JSONL writer.
+type Generator struct {
+	Seed        int64        // deterministic; same seed → same output
+	Sessions    int          // total sessions to write
+	Repos       []string     // repo names ("org/name") to distribute sessions across; round-robin
+	MsgsDist    Distribution // messages per session
+	TokensDist  Distribution // output_tokens per assistant message
+	ToolUseRate float64      // 0..1; fraction of assistant messages that include a tool_use block
+
+	// Model is the model slug to record on assistant messages. Empty
+	// defaults to "claude-sonnet-4-6" to match the production shape
+	// the cost-estimation code recognises.
+	Model string
+
+	// Epoch is the start of generated timestamps. Zero defaults to
+	// 2026-01-01T00:00:00Z. Per-session offsets are deterministic.
+	Epoch time.Time
+}
+
+// Distribution is a clamped triangular-style sampling spec. The
+// generator draws integers in [Min, Max] with a mean targeted at
+// Mean. Values outside [Min, Max] are clamped after sampling, so
+// extreme Mean settings near a bound will skew toward that bound.
+type Distribution struct {
+	Min, Max int // hard bounds (inclusive)
+	Mean     int // target mean; sampling centres around this
+}
+
+// sample draws an int in [d.Min, d.Max] biased around d.Mean. Uses
+// a symmetric triangular sample: average of two uniforms scaled to
+// the bracket of the chosen side. Cheap, deterministic, no dep on
+// math/big or distuv.
+func (d Distribution) sample(r *rand.Rand) int {
+	if d.Max < d.Min {
+		return d.Min
+	}
+	if d.Max == d.Min {
+		return d.Min
+	}
+	mean := d.Mean
+	if mean < d.Min {
+		mean = d.Min
+	}
+	if mean > d.Max {
+		mean = d.Max
+	}
+	// Choose side relative to mean with probability proportional to
+	// each side's width — this keeps the expected value at mean
+	// regardless of asymmetry between (mean-Min) and (Max-mean).
+	lo := mean - d.Min
+	hi := d.Max - mean
+	span := lo + hi
+	if span == 0 {
+		return mean
+	}
+	var v int
+	if r.Intn(span) < lo {
+		// Lower side: triangular peaked at mean, falling to Min.
+		// Take the max of two uniforms in [0, lo] so the density
+		// peaks near lo (i.e. near mean).
+		a, b := r.Intn(lo+1), r.Intn(lo+1)
+		if a < b {
+			a = b
+		}
+		v = d.Min + a
+	} else {
+		a, b := r.Intn(hi+1), r.Intn(hi+1)
+		if a < b {
+			a = b
+		}
+		v = mean + (hi - a)
+	}
+	if v < d.Min {
+		v = d.Min
+	}
+	if v > d.Max {
+		v = d.Max
+	}
+	return v
+}
+
+// Write materialises the configured transcript tree under
+// projectsDir. The directory is created if missing. Existing files
+// with colliding names are overwritten (the generator is intended
+// for tempdir use).
+func (g *Generator) Write(projectsDir string) error {
+	if g.Sessions <= 0 {
+		return errors.New("storetest.Generator: Sessions must be > 0")
+	}
+	if len(g.Repos) == 0 {
+		return errors.New("storetest.Generator: Repos must be non-empty")
+	}
+	if err := os.MkdirAll(projectsDir, 0o755); err != nil {
+		return err
+	}
+
+	model := g.Model
+	if model == "" {
+		model = "claude-sonnet-4-6"
+	}
+	epoch := g.Epoch
+	if epoch.IsZero() {
+		epoch = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	}
+
+	// Pre-compute per-repo cwd and encoded project-dir name. The
+	// encoding mirrors Claude Code's convention: replace `/` and
+	// `.` with `-`, prefix with `-`. The cwd must contain
+	// `/work/github.com/<repo>` for mnemo's extractRepo regex to
+	// populate session_meta.repo correctly.
+	type repoInfo struct {
+		repo      string
+		cwd       string
+		projDir   string // basename under projectsDir
+		gitBranch string
+	}
+	repos := make([]repoInfo, len(g.Repos))
+	for i, name := range g.Repos {
+		cwd := "/Users/synth/work/github.com/" + name
+		repos[i] = repoInfo{
+			repo:      name,
+			cwd:       cwd,
+			projDir:   encodeProjectDir(cwd),
+			gitBranch: "synthetic/main",
+		}
+	}
+
+	// One RNG per (this Write call). Sessions are emitted in index
+	// order; the same Seed therefore yields identical output.
+	r := rand.New(rand.NewSource(g.Seed))
+
+	for s := 0; s < g.Sessions; s++ {
+		info := repos[s%len(repos)]
+		sessionUUID := deterministicUUID(g.Seed, "session", s)
+		// Stable per-session start: 1 minute apart, deterministic.
+		sessionStart := epoch.Add(time.Duration(s) * time.Minute)
+
+		projDirPath := filepath.Join(projectsDir, info.projDir)
+		if err := os.MkdirAll(projDirPath, 0o755); err != nil {
+			return err
+		}
+		filePath := filepath.Join(projDirPath, sessionUUID+".jsonl")
+		f, err := os.Create(filePath)
+		if err != nil {
+			return err
+		}
+
+		// JSON encoder bound to a per-file writer. encoder.Encode
+		// emits one JSON value per line — exactly the JSONL shape
+		// Claude Code uses.
+		enc := json.NewEncoder(f)
+		enc.SetEscapeHTML(false)
+
+		// 1. Initial user prompt. parentUuid=nil distinguishes the
+		// session root entry, matching the real on-disk shape.
+		userUUID := deterministicUUID(g.Seed, "user", s, 0)
+		userTS := sessionStart.Format(time.RFC3339)
+		userText := fmt.Sprintf("task %d: explore the %s subsystem and propose a fix", s, info.repo)
+		userEntry := map[string]any{
+			"parentUuid": nil,
+			"type":       "user",
+			"uuid":       userUUID,
+			"sessionId":  sessionUUID,
+			"timestamp":  userTS,
+			"cwd":        info.cwd,
+			"gitBranch":  info.gitBranch,
+			"userType":   "external",
+			"version":    "2.1.172",
+			"message": map[string]any{
+				"role":    "user",
+				"content": userText,
+			},
+		}
+		if err := enc.Encode(userEntry); err != nil {
+			f.Close()
+			return err
+		}
+
+		// 2. N assistant messages chained from the user entry.
+		nMsgs := g.MsgsDist.sample(r)
+		prevUUID := userUUID
+		// Each message advances time by a deterministic small step
+		// derived from the rng so order is preserved without
+		// per-message bookkeeping.
+		curTime := sessionStart.Add(10 * time.Second)
+		for m := 0; m < nMsgs; m++ {
+			outTokens := g.TokensDist.sample(r)
+			// Filler text rougly proportional to tokens — mnemo's
+			// own ingest treats token *fields* as authoritative
+			// for usage; the text just needs to be substantive
+			// enough to pass the noise / boilerplate filters.
+			fillerLen := outTokens * 4 // ~4 chars per token
+			if fillerLen < 32 {
+				fillerLen = 32
+			}
+			fillerSeed := uint64(g.Seed) ^ uint64(s*1_000_003+m*97)
+			text := fillerText(fillerSeed, fillerLen)
+
+			assistantUUID := deterministicUUID(g.Seed, "asst", s, m)
+			content := []any{
+				map[string]any{"type": "text", "text": text},
+			}
+			// Tool use: probabilistic per-message. The tool name and
+			// input shape just need to be parseable — mnemo doesn't
+			// validate against real tool schemas.
+			if r.Float64() < g.ToolUseRate {
+				toolUUID := deterministicUUID(g.Seed, "tool", s, m)
+				content = append(content, map[string]any{
+					"type":  "tool_use",
+					"id":    toolUUID,
+					"name":  "Read",
+					"input": map[string]any{"file_path": fmt.Sprintf("/synth/repo/%s/file_%d.go", info.repo, m)},
+				})
+			}
+
+			inputTokens := outTokens / 10
+			if inputTokens < 1 {
+				inputTokens = 1
+			}
+			cacheCreate := outTokens * 2
+			assistantEntry := map[string]any{
+				"parentUuid": prevUUID,
+				"type":       "assistant",
+				"uuid":       assistantUUID,
+				"sessionId":  sessionUUID,
+				"timestamp":  curTime.Format(time.RFC3339),
+				"cwd":        info.cwd,
+				"gitBranch":  info.gitBranch,
+				"userType":   "external",
+				"version":    "2.1.172",
+				"message": map[string]any{
+					"role":    "assistant",
+					"model":   model,
+					"content": content,
+					"usage": map[string]any{
+						"input_tokens":                inputTokens,
+						"output_tokens":               outTokens,
+						"cache_creation_input_tokens": cacheCreate,
+						"cache_read_input_tokens":     0,
+					},
+				},
+			}
+			if err := enc.Encode(assistantEntry); err != nil {
+				f.Close()
+				return err
+			}
+			prevUUID = assistantUUID
+			// 5-second deterministic step. Real sessions vary but
+			// the indexer doesn't depend on the spacing.
+			curTime = curTime.Add(5 * time.Second)
+		}
+
+		if err := f.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// encodeProjectDir mirrors Claude Code's convention: cwd path with
+// `/` and `.` collapsed to `-`. Leading slash also becomes `-` so
+// `/Users/foo` → `-Users-foo`.
+func encodeProjectDir(cwd string) string {
+	enc := strings.ReplaceAll(cwd, "/", "-")
+	enc = strings.ReplaceAll(enc, ".", "-")
+	return enc
+}
+
+// deterministicUUID derives a stable RFC 4122-shaped string from
+// the seed and a tag set. The bytes are SHA-256(seed||tag||args)
+// rather than v4 random, but conform to the canonical hyphenated
+// 36-char layout that mnemo's session-id handling expects. Variant
+// and version bits are stamped so the output is a syntactically
+// valid v4 UUID, indistinguishable from a real one to consumers
+// that don't crypto-verify provenance.
+func deterministicUUID(seed int64, tag string, ints ...int) string {
+	h := sha256.New()
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], uint64(seed))
+	h.Write(buf[:])
+	h.Write([]byte(tag))
+	for _, n := range ints {
+		binary.BigEndian.PutUint64(buf[:], uint64(n))
+		h.Write(buf[:])
+	}
+	sum := h.Sum(nil)[:16]
+	// RFC 4122: version 4, variant 10xx (RFC 4122 variant).
+	sum[6] = (sum[6] & 0x0f) | 0x40
+	sum[8] = (sum[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		sum[0:4], sum[4:6], sum[6:8], sum[8:10], sum[10:16])
+}
+
+// fillerText returns a deterministic lorem-ipsum-style block of
+// roughly nChars characters. Output is whitespace-separated words
+// drawn from a fixed corpus, seeded by the supplied uint64. This
+// keeps the per-message body realistic-looking (passes mnemo's
+// isNoise/isBoilerplate filters) while remaining cheap to generate.
+func fillerText(seed uint64, nChars int) string {
+	words := []string{
+		"lorem", "ipsum", "dolor", "sit", "amet", "consectetur",
+		"adipiscing", "elit", "sed", "do", "eiusmod", "tempor",
+		"incididunt", "ut", "labore", "et", "dolore", "magna",
+		"aliqua", "ad", "minim", "veniam", "quis", "nostrud",
+		"exercitation", "ullamco", "laboris", "nisi", "aliquip",
+		"commodo", "consequat", "duis", "aute", "irure",
+		"reprehenderit", "voluptate", "velit", "esse", "cillum",
+		"refactor", "implement", "deploy", "subsystem", "module",
+		"interface", "registry", "scheduler", "compactor", "vault",
+	}
+	r := rand.New(rand.NewSource(int64(seed)))
+	var b strings.Builder
+	b.Grow(nChars + 32)
+	for b.Len() < nChars {
+		if b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(words[r.Intn(len(words))])
+	}
+	return b.String()
+}

--- a/internal/storetest/generator_test.go
+++ b/internal/storetest/generator_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package storetest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marcelocantos/mnemo/internal/store"
+)
+
+// hashTree walks dir and returns a stable composite SHA-256 over
+// (sorted relative path, file bytes). Used to assert byte-identical
+// output from the generator across two runs with the same seed.
+func hashTree(t *testing.T, dir string) string {
+	t.Helper()
+	h := sha256.New()
+	var paths []string
+	if err := filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		paths = append(paths, p)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// filepath.Walk already returns lexical order, but be explicit.
+	for _, p := range paths {
+		rel, err := filepath.Rel(dir, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		h.Write([]byte(rel))
+		h.Write([]byte{0})
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		h.Write(b)
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func newSmallGen(seed int64) *Generator {
+	return &Generator{
+		Seed:        seed,
+		Sessions:    8,
+		Repos:       []string{"acme/alpha", "acme/beta"},
+		MsgsDist:    Distribution{Min: 4, Max: 12, Mean: 7},
+		TokensDist:  Distribution{Min: 50, Max: 400, Mean: 200},
+		ToolUseRate: 0.3,
+	}
+}
+
+// TestGeneratorDeterministic asserts bit-identical output across
+// two runs with the same Seed and config — the cornerstone property
+// every downstream test relies on for reproducibility.
+func TestGeneratorDeterministic(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+
+	if err := newSmallGen(42).Write(dirA); err != nil {
+		t.Fatal(err)
+	}
+	if err := newSmallGen(42).Write(dirB); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := hashTree(t, dirA), hashTree(t, dirB); got != want {
+		t.Fatalf("same-seed runs diverged:\n A: %s\n B: %s", got, want)
+	}
+
+	// Different seed → different output, sanity check.
+	dirC := t.TempDir()
+	if err := newSmallGen(99).Write(dirC); err != nil {
+		t.Fatal(err)
+	}
+	if hashTree(t, dirA) == hashTree(t, dirC) {
+		t.Fatal("different seeds produced identical output")
+	}
+}
+
+// TestGeneratorIngests confirms the generated tree is consumable by
+// the real ingest path, not just a JSONL look-alike. If the shape
+// drifts from what mnemo expects, this test catches it before any
+// downstream consumer wires the generator into its own fixtures.
+func TestGeneratorIngests(t *testing.T) {
+	projectDir := t.TempDir()
+	gen := &Generator{
+		Seed:        7,
+		Sessions:    100,
+		Repos:       []string{"acme/alpha", "acme/beta", "acme/gamma"},
+		MsgsDist:    Distribution{Min: 6, Max: 20, Mean: 12},
+		TokensDist:  Distribution{Min: 100, Max: 500, Mean: 250},
+		ToolUseRate: 0.4,
+	}
+	if err := gen.Write(projectDir); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatalf("IngestAll: %v", err)
+	}
+
+	// Generated session count flows through to ListSessions when
+	// minMessages is set low enough to include all synthetic
+	// sessions (MsgsDist.Min=6, so a min of 1 always passes).
+	sessions, err := s.ListSessions("all", 1, 1000, "", "", "")
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) < gen.Sessions {
+		t.Fatalf("expected ≥%d sessions ingested, got %d", gen.Sessions, len(sessions))
+	}
+
+	// Repos must be threaded through cwd → session_meta.repo. With
+	// 3 repos × 100 sessions all under acme/*, ListRepos should
+	// report all three.
+	repos, err := s.ListRepos("acme/")
+	if err != nil {
+		t.Fatalf("ListRepos: %v", err)
+	}
+	if len(repos) < len(gen.Repos) {
+		t.Fatalf("expected ≥%d repos, got %d: %+v", len(gen.Repos), len(repos), repos)
+	}
+}
+
+// TestGeneratorTokenDistribution asserts the generated assistant
+// messages land near the requested mean output_tokens. The check
+// is loose (±20%) because the triangular sampler is only an
+// approximation and small samples are noisy; tighter bounds would
+// be flaky.
+func TestGeneratorTokenDistribution(t *testing.T) {
+	projectDir := t.TempDir()
+	wantMean := 300
+	gen := &Generator{
+		Seed:        13,
+		Sessions:    50,
+		Repos:       []string{"acme/alpha"},
+		MsgsDist:    Distribution{Min: 10, Max: 30, Mean: 20},
+		TokensDist:  Distribution{Min: 100, Max: 600, Mean: wantMean},
+		ToolUseRate: 0.2,
+	}
+	if err := gen.Write(projectDir); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatalf("IngestAll: %v", err)
+	}
+
+	// Use a wide explicit window so the synthetic 2026-01-01 epoch
+	// timestamps fall inside it; Usage()'s default Days=30 window
+	// is anchored on time.Now() and would exclude older fixtures.
+	usage, err := s.Usage(store.UsageParams{
+		Since:   "2025-01-01T00:00:00Z",
+		Until:   "2030-01-01T00:00:00Z",
+		GroupBy: "day",
+	})
+	if err != nil {
+		t.Fatalf("Usage: %v", err)
+	}
+	if usage.Total.Messages == 0 {
+		t.Fatal("Usage reported zero assistant messages — ingest didn't see usage rows")
+	}
+	gotMean := float64(usage.Total.OutputTokens) / float64(usage.Total.Messages)
+	lo, hi := float64(wantMean)*0.8, float64(wantMean)*1.2
+	if gotMean < lo || gotMean > hi {
+		t.Fatalf("output_tokens mean=%.1f outside ±20%% of target %d (range %.1f..%.1f)",
+			gotMean, wantMean, lo, hi)
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -2948,5 +2948,5 @@ func renderConfigWrite(merged store.Config, report ConfigReport) string {
 // resolution if needed; the current callers only need a best-effort
 // path for read-side rendering.
 func osUserHome() (string, error) {
-	return os.UserHomeDir()
+	return store.EffectiveHome()
 }

--- a/main.go
+++ b/main.go
@@ -110,7 +110,20 @@ func main() {
 	addr := flag.String("addr", defaultAddr, "HTTP listen address")
 	federatedAddr := flag.String("federated-addr", defaultFederatedAddr,
 		"mTLS federated listen address (empty disables federation)")
+	homeFlag := flag.String("home", "",
+		"daemon home directory (overrides $MNEMO_HOME; defaults to OS user home). "+
+			"Routes ~/.mnemo and the default-user data tree to this root. (🎯T73)")
 	flag.Parse()
+
+	// --home wins over MNEMO_HOME; both end up exported as MNEMO_HOME so
+	// every store.EffectiveHome() call sees the same value regardless of
+	// which entry point it came in through.
+	if *homeFlag != "" {
+		if err := os.Setenv(store.MnemoHomeEnv, *homeFlag); err != nil {
+			fmt.Fprintf(os.Stderr, "set %s: %v\n", store.MnemoHomeEnv, err)
+			os.Exit(1)
+		}
+	}
 
 	if *showVersion {
 		fmt.Println("mnemo", version)


### PR DESCRIPTION
## Summary

- Adds `MNEMO_HOME` env var + `--home` flag controlling every filesystem path the daemon resolves (db, config, state.json, peers/, default-user data tree). `EffectiveHome()` is the sole consultation point; 18 direct `os.UserHomeDir()` callers swept to it. `ResolveHomeFor(currentUser)` also routes through `EffectiveHome` so the eager-start path under `MNEMO_HOME` does not bypass isolation and load the real DB.
- Adds `cmd/mnemo-test-snapshot/` — APFS `cp -c` on darwin, recursive fallback elsewhere. Refuses git-tracked destinations and existing dests without `--force`. Prints `MNEMO_HOME=<path>` as last stdout line.
- Adds `internal/e2e/` — spawns `bin/mnemo` as a subprocess under `MNEMO_HOME`, waits for the HTTP MCP transport to be ready, returns a `mark3labs/mcp-go` client handle. Tests drive scenarios via real MCP tool calls instead of in-process Go API calls.
- Adds `internal/storetest/generator.go` — given a seed and shape spec, writes a synthetic `~/.claude/projects/`-style transcript tree. Deterministic.
- Adds `//go:build scale` tag + `MNEMO_TEST_SNAPSHOT` env gate. Default `go test ./...` never sees Tier 3 tests; they skip with a clear directive when the env is unset. Two worked invariant examples (`internal/e2e/scale_test.go`).
- Adds Makefile targets: `make test` (default), `make test-scale` (also Tier 3 with snapshot or clear skip), `make snapshot` (invokes the helper). `make bullseye` continues to gate Tier 1+2 only.
- Adds `docs/testing.md` — three-tier reference.
- `.gitignore` covers `mnemo-test-snapshots/`.

Also bundles two earlier unpushed master commits (`.claude/settings.json` tracking, T79 target file) per the squash-only bundling rule.

## Test plan

- [x] `make bullseye` green (fmt, vet, build, tests, clean tree).
- [x] `go test -tags 'sqlite_fts5' ./internal/e2e/...` — TestSmoke + TestIsolation + TestVaultSyncViaMCP pass against a real daemon subprocess.
- [x] `go test -tags 'sqlite_fts5 scale' ./internal/e2e/...` with `MNEMO_TEST_SNAPSHOT` unset skips Tier 3 tests with a clear message.
- [x] Default `go test ./...` (no scale tag) reports `no tests to run` for the scale-gated tests — they're invisible to default CI.
- [x] Manual: `make snapshot` clones `~/.mnemo` + `~/.claude/projects` via APFS in seconds and prints `MNEMO_HOME=<path>` as last stdout line.

## Follow-ups (filed)

- 🎯T79 — `mnemo_vault_status` / `mnemo_compactor_status` default-user fallback bug discovered during e2e work; the vault-sync test passes `?user=` explicitly as a workaround pending the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
