### PR TITLE
🎯T79: vault/compactor MCP tools fall back to the default user

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2535,9 +2535,10 @@ targets:
     achieved: 2026-06-16
   T79:
     name: mnemo_vault_status and mnemo_compactor_status fall back to the default user when ?user= is omitted, matching the store resolver
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
+    actual_cost: 2.0
     acceptance:
     - '`mnemo_vault_status`, `mnemo_vault_sync`, and `mnemo_compactor_status` succeed against a daemon''s default user when the MCP request omits `?user=` — matching the behaviour of `mnemo_search` / `mnemo_stats` / every other tool today. Today they return "vault not configured" / "compactor not available" respectively in that case because the per-tool resolver lambdas look up `reg.VaultFor("")` / `reg.CompactWatcherFor("")` directly instead of falling back to `defaultUser` the way the shared `resolve(username)` closure does.'
     - 'The fix lives in `main.go` (the resolver closures wired via `handler.SetVaultResolver` and `handler.SetCompactorResolver`) and mirrors the shape of the existing `resolve := func(username string) ...` closure: empty username → `defaultUser`, unless `defErr != nil` in which case the resolver returns nil (Windows-Service no-default-user path).'
@@ -2595,6 +2596,7 @@ targets:
       - Any deeper refactor of the per-tool resolver pattern. Cheap pointed fix, not a redesign.
     origin: manual
     discovered: 2026-06-16
+    achieved: 2026-06-16
   T8:
     name: sqldeep integration
     status: achieved

--- a/internal/e2e/default_user_test.go
+++ b/internal/e2e/default_user_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCompactorStatusDefaultUserViaMCP is the 🎯T79 regression: when an
+// MCP request omits ?user=, the per-user resolvers for
+// mnemo_compactor_status (and the vault tools, covered by
+// TestVaultSyncViaMCP) must fall back to the daemon's default user —
+// the same fallback every store-backed tool already applies.
+//
+// Before the fix, the compactor resolver looked up CompactWatcherFor("")
+// directly, which never matched a registered user, so the tool always
+// reported "not available" on a single-user daemon. The daemon eagerly
+// starts the default user's workers at boot, so once it is ready the
+// watcher exists and the tool must surface real state.
+func TestCompactorStatusDefaultUserViaMCP(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e compactor status skipped under -short")
+	}
+	// No Options.User — the request carries no ?user= parameter.
+	d := Start(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// The default user's workers start eagerly at boot but the watcher
+	// registration can lag daemon-readiness by a hair; poll briefly.
+	var out string
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		var err error
+		out, err = d.Call(ctx, "mnemo_compactor_status", nil)
+		if err != nil {
+			t.Fatalf("mnemo_compactor_status: %v\n%s", err, d.Log())
+		}
+		if strings.Contains(out, "Compactor watcher status:") {
+			return // fell back to the default user and reported real state
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	t.Fatalf("mnemo_compactor_status did not fall back to the default user "+
+		"without ?user= (🎯T79) — got:\n%s\n--- daemon log ---\n%s", out, d.Log())
+}

--- a/internal/e2e/vault_sync_test.go
+++ b/internal/e2e/vault_sync_test.go
@@ -6,7 +6,6 @@ package e2e
 import (
 	"context"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -34,16 +33,10 @@ func TestVaultSyncViaMCP(t *testing.T) {
 	if testing.Short() {
 		t.Skip("e2e vault sync skipped under -short")
 	}
-	// Pass ?user= explicitly. mnemo's vault resolver bypasses the
-	// default-user fallback that the store resolver applies, so a
-	// vault-touching test that omits ?user= sees "vault not
-	// configured." Setting it explicitly is the documented usage and
-	// avoids the asymmetry.
-	cur, err := user.Current()
-	if err != nil {
-		t.Skipf("user.Current unavailable: %v", err)
-	}
-	d := Start(t, Options{User: cur.Username})
+	// 🎯T79: omit ?user= — the vault resolver now falls back to the
+	// default user just like every other tool, so the explicit-user
+	// workaround this test used to need is gone.
+	d := Start(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 

--- a/main.go
+++ b/main.go
@@ -560,6 +560,24 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 		return reg.ForUser(username)
 	}
 
+	// effectiveUser maps an empty username (a request that omitted
+	// ?user=) to the default user, mirroring resolve's fallback. Returns
+	// ("", false) only on the Windows-Service path where there is no
+	// default identity (defErr != nil); callers then resolve to nil. The
+	// per-tool vault/compactor resolvers below route through this so they
+	// reach the default user's instance exactly like every Backend tool
+	// (🎯T79) — without it they returned "not configured" whenever the
+	// request omitted ?user=.
+	effectiveUser := func(username string) (string, bool) {
+		if username == "" {
+			if defErr != nil {
+				return "", false
+			}
+			return defaultUser, true
+		}
+		return username, true
+	}
+
 	// Build the MCP server, register every tool, and expose it as an
 	// HTTP streamable endpoint. Stateful mode lets clients maintain an
 	// Mcp-Session-Id across requests — the value we thread through to
@@ -577,7 +595,11 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	// mnemo_vault_status work. Returns nil when vault is not configured
 	// for the requested user; the tool handlers gracefully report this.
 	handler.SetVaultResolver(func(username string) tools.VaultSyncer {
-		v := reg.VaultFor(username)
+		u, ok := effectiveUser(username)
+		if !ok {
+			return nil
+		}
+		v := reg.VaultFor(u)
 		if v == nil {
 			return nil // avoid (*vault.Exporter)(nil) wrapped in interface
 		}
@@ -589,7 +611,11 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	// Returns nil when the user's workers haven't started yet; the
 	// tool gracefully reports "not available" in that case.
 	handler.SetCompactorResolver(func(username string) tools.CompactorHealthReporter {
-		w := reg.CompactWatcherFor(username)
+		u, ok := effectiveUser(username)
+		if !ok {
+			return nil
+		}
+		w := reg.CompactWatcherFor(u)
 		if w == nil {
 			return nil
 		}


### PR DESCRIPTION
## Bug

When an MCP request omits `?user=`, `mnemo_vault_status`, `mnemo_vault_sync`, and `mnemo_compactor_status` returned "not configured" / "not available" — unlike `mnemo_search`, `mnemo_stats`, and every other store-backed tool, which fall back to the daemon's default user. The per-tool resolver closures wired via `SetVaultResolver` / `SetCompactorResolver` looked up `reg.VaultFor("")` / `reg.CompactWatcherFor("")` directly, bypassing the fallback that the shared `resolve` closure applies.

## Fix

An `effectiveUser` helper in `main.go` mirrors `resolve`'s fallback: empty username → `defaultUser`, unless there is no default identity (the Windows-Service path where `defErr != nil`), in which case the resolver returns `nil`. Both resolver closures route through it.

Multi-user (Windows-Service) deployments are unchanged — an explicit `?user=alice` still routes to Alice's per-user vault / compactor exactly as before. The fallback only applies to the empty-username default-identity path.

## Tests

Through the `internal/e2e` MCP harness, without passing `?user=`:
- `TestVaultSyncViaMCP` drops its `Options{User: cur.Username}` workaround (the bug it was written around is fixed).
- `TestCompactorStatusDefaultUserViaMCP` (new) asserts the tool surfaces real watcher state rather than "not available".

Retires 🎯T79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)