### PR TITLE
Release v0.49.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.48.0"
+	version              = "0.49.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
## Added

- **TODO ingestion (🎯T78)** — mnemo now indexes `TODO.md` / `todos.md` files across all repos in the Obsidian Tasks dialect (📅 due, ⏳ scheduled, 🛫 start, ✅/❌ done/cancelled, 🔺⏫🔼🔽⏬ priority, 🔁 recurrence, `#tags`, `[[wikilinks]]`). Three new MCP tools:
  - `mnemo_todos` — query by repo / status / tag / priority / section / full-text plus date predicates (overdue, due-soon-N-days, no-date, before/after/on). Each result carries its source `file_path` and `line`.
  - `mnemo_todo_set` — edit a task in place (status / due / priority / text). Line-precise: rewrites only the target line, preserves the rest of the file byte-for-byte, writes atomically (tmp + fsync + rename), and refuses if the line changed under it. `done`/`cancelled` stamp today's completion date.
  - `mnemo_todo_add` — append a new task to a tracked TODO file, optionally filed under a heading (created if absent).

  The source `TODO.md` stays authoritative — mutations write back to it, so a hand-edited and a tool-edited file re-ingest to identical rows.

## Fixed

- **Compaction failure ratio (🎯T77)** — the background `/clear`-span compactor now frames the transcript as inert data (fenced, JSON-only instruction), defers non-payload conversational replies instead of counting them as failures, and durably quarantines permanently un-summarisable sessions across daemon restarts. This heals the failed:compacted ratio that a handful of poison sessions and conversational-reply failures had dominated.
- **Default-user fallback for vault & compactor tools (🎯T79)** — `mnemo_vault_status`, `mnemo_vault_sync`, and `mnemo_compactor_status` now fall back to the daemon's default user when an MCP request omits `?user=`, matching every other tool. Previously they returned "not configured" / "not available" on a single-user daemon. Explicit `?user=alice` routing (Windows-Service multi-user) is unchanged.

## Changed

- **Three-tier test architecture (🎯T73)** — `MNEMO_HOME` isolation, an `internal/e2e` daemon-subprocess harness that drives the real MCP HTTP transport, and a snapshot helper. Integration tests now exercise the daemon as a black box through MCP, catching per-user routing and serialisation regressions that in-process Go-API tests miss.
