### PR TITLE
Release v0.50.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.49.0"
+	version              = "0.50.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
## Changed

- **TODO discovery covers all known roots (🎯T80)** — `mnemo_todos` now indexes `TODO.md` / `todos.md` under non-git `synthesis_roots` (planning spaces such as `~/think`), not only git repos. The TODO feature (shipped in v0.49.0) was built on the repo-discovery primitive, which silently required a `.git` ancestor — so TODO files in non-git trees were missed. Git-repo discovery is unchanged; synthesis roots are additively included, with root deduplication and a shared seen-set so a file reachable from two overlapping roots isn't ingested twice. The existing bounding (`.gitignore`, doc-exclude dirs, loop-safety exclusion fence) applies to every root.
