### PR TITLE
De-flake internal/e2e — env-gate out of the blocking CI, nightly coverage, harden races

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,69 @@
+name: E2E Nightly
+
+# Runs the internal/e2e daemon-subprocess suite on a schedule so flakes
+# are caught in a non-blocking context. The suite is excluded from the
+# standard CI gate (ci.yml) via the MNEMO_E2E env-gate in TestMain;
+# this workflow sets MNEMO_E2E=1 to opt in.
+#
+# Trigger:
+#   - Daily at 03:00 UTC
+#   - Manual via workflow_dispatch for ad-hoc debugging
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: mnemo
+
+      - uses: actions/checkout@v4
+        with:
+          repository: marcelocantos/sqldeep
+          ref: v0.22.0
+          path: sqldeep
+          submodules: recursive
+
+      - name: Build sqldeep
+        working-directory: sqldeep
+        env:
+          CC: cc
+          CXX: c++
+          AR: ar
+        run: |
+          mkdir -p build/deepparser
+          DP_SRC=vendor/deepparser/src
+          DP_CFLAGS="-Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -O2 -DNDEBUG -I${DP_SRC}"
+          for f in arena liteparser lp_tokenize lp_unparse parse; do
+            "$CC" $DP_CFLAGS -c "${DP_SRC}/${f}.c" -o "build/deepparser/${f}.o"
+          done
+          "$CXX" -std=c++20 -Wall -Wextra -Wpedantic -Idist -Ivendor/include -I${DP_SRC} -c dist/sqldeep.cpp -o build/sqldeep.o
+          "$CC" -w -Idist -Ivendor/include -c dist/sqldeep_xml.c -o build/sqldeep_xml.o
+          "$AR" rcs build/libsqldeep.a build/sqldeep.o build/deepparser/*.o
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: mnemo/go.mod
+
+      - name: Build daemon binary
+        working-directory: mnemo
+        env:
+          CGO_ENABLED: "1"
+        run: go build -tags sqlite_fts5 -o bin/mnemo .
+
+      - name: Run e2e tests
+        working-directory: mnemo
+        env:
+          CGO_ENABLED: "1"
+          MNEMO_E2E: "1"
+        # -timeout=10m is generous for linux; the suite should finish
+        # in well under 5m on an unloaded ubuntu-latest runner.
+        run: go test -tags sqlite_fts5 -timeout=10m -v -run . ./internal/e2e/

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2629,9 +2629,10 @@ targets:
     achieved: 2026-06-17
   T81:
     name: 'The internal/e2e suite never flakes a release: it is excluded from the default `go test ./...` gate (env-gated) and exercised by a dedicated nightly workflow, and the known timing races are hardened'
-    status: converging
+    status: achieved
     value: 0.0
     cost: 0.0
+    actual_cost: 3.0
     acceptance:
     - '`go test -tags sqlite_fts5 ./...` (without MNEMO_E2E set) reports `[no test files]` or `ok` (skip) for `internal/e2e` — the suite contributes zero test results and cannot block a PR or release.'
     - A `TestMain` in `internal/e2e` skips all tests when `MNEMO_E2E` is unset; `MNEMO_E2E=1 go test -tags sqlite_fts5 ./internal/e2e/ -v` runs all tests including those that currently exist.
@@ -2642,6 +2643,7 @@ targets:
     context: 'The internal/e2e tests (TestVaultSyncViaMCP, TestSmoke, TestIsolation, TestCompactorStatusDefaultUserViaMCP) have flaked repeatedly on loaded CI runners — both ubuntu-latest (missing mnemo:generated fence, 0.42s fast-fail) and windows-latest (daemon never becomes ready, 30s timeout). These flakes forced multiple release force-merges. Root causes: (1) on windows-latest the daemon takes >30s to start because go test spawns the e2e binary compile inside the same already-loaded runner, (2) on ubuntu-latest vault-sync coalescing races cause the index.md to be written without the mnemo:generated fence before the hot-reload completes. The fix is three-part: env-gate the suite out of the default gate, add a nightly workflow, and harden the timing-sensitive assertions.'
     origin: manual
     discovered: 2026-06-18
+    achieved: 2026-06-18
   T9:
     name: Full-fidelity ingest and observability tools
     status: achieved

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2627,6 +2627,21 @@ targets:
     origin: manual
     discovered: 2026-06-17
     achieved: 2026-06-17
+  T81:
+    name: 'The internal/e2e suite never flakes a release: it is excluded from the default `go test ./...` gate (env-gated) and exercised by a dedicated nightly workflow, and the known timing races are hardened'
+    status: converging
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - '`go test -tags sqlite_fts5 ./...` (without MNEMO_E2E set) reports `[no test files]` or `ok` (skip) for `internal/e2e` — the suite contributes zero test results and cannot block a PR or release.'
+    - A `TestMain` in `internal/e2e` skips all tests when `MNEMO_E2E` is unset; `MNEMO_E2E=1 go test -tags sqlite_fts5 ./internal/e2e/ -v` runs all tests including those that currently exist.
+    - A `.github/workflows/e2e-nightly.yml` workflow runs on a daily schedule and on `workflow_dispatch`, sets `MNEMO_E2E=1`, and executes `go test -tags sqlite_fts5 -run . ./internal/e2e/ -v` with the same CGO/sqlite_fts5/Go toolchain setup as ci.yml.
+    - The `TestVaultSyncViaMCP` file-poll deadline is extended (30s+) and the vault-sync wait loop is hardened against the coalescing race so the test cannot fail within 0.4s on a loaded runner.
+    - All e2e tests that poll for daemon readiness or background effects use bounded retry loops rather than point-in-time assertions, so transient scheduling jitter does not produce false negatives.
+    - The `ci.yml` and `release.yml` workflows are unchanged — they continue to run `go test ./...` without `MNEMO_E2E`, guaranteeing e2e tests are never in the blocking gate.
+    context: 'The internal/e2e tests (TestVaultSyncViaMCP, TestSmoke, TestIsolation, TestCompactorStatusDefaultUserViaMCP) have flaked repeatedly on loaded CI runners — both ubuntu-latest (missing mnemo:generated fence, 0.42s fast-fail) and windows-latest (daemon never becomes ready, 30s timeout). These flakes forced multiple release force-merges. Root causes: (1) on windows-latest the daemon takes >30s to start because go test spawns the e2e binary compile inside the same already-loaded runner, (2) on ubuntu-latest vault-sync coalescing races cause the index.md to be written without the mnemo:generated fence before the hot-reload completes. The fix is three-part: env-gate the suite out of the default gate, add a nightly workflow, and harden the timing-sensitive assertions.'
+    origin: manual
+    discovered: 2026-06-18
   T9:
     name: Full-fidelity ingest and observability tools
     status: achieved

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -110,7 +110,11 @@ func Start(t *testing.T, opts ...Options) *Daemon {
 		o = opts[0]
 	}
 	if o.StartTimeout == 0 {
-		o.StartTimeout = 30 * time.Second
+		// 60s is generous enough for cold daemon startup on a loaded
+		// Windows CI runner where the preceding test packages have
+		// already saturated the CPU. The previous 30s ceiling caused
+		// intermittent false-red failures on windows-latest.
+		o.StartTimeout = 60 * time.Second
 	}
 	if o.Home == "" {
 		o.Home = t.TempDir()

--- a/internal/e2e/main_test.go
+++ b/internal/e2e/main_test.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain gates the entire e2e suite behind MNEMO_E2E=1.
+//
+// Without the env var the package reports no tests, so the standard
+// `go test ./...` run (used by ci.yml and release.yml) never executes
+// or blocks on these daemon-subprocess tests. Set MNEMO_E2E=1 to
+// opt in; the nightly workflow does this automatically.
+func TestMain(m *testing.M) {
+	if os.Getenv("MNEMO_E2E") == "" {
+		// Exit 0 with no output — `go test` treats this as "no tests
+		// to run" and reports the package as skipped.
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/e2e/vault_sync_test.go
+++ b/internal/e2e/vault_sync_test.go
@@ -37,7 +37,7 @@ func TestVaultSyncViaMCP(t *testing.T) {
 	// default user just like every other tool, so the explicit-user
 	// workaround this test used to need is gone.
 	d := Start(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	// Tempdir for the vault, outside MNEMO_HOME so the test verifies
@@ -60,29 +60,42 @@ func TestVaultSyncViaMCP(t *testing.T) {
 	}
 
 	// The mnemo_config hot-reload kicks off an automatic vault sync
-	// in the background; an explicit mnemo_vault_sync called too
-	// soon coalesces with "already in flight, skipping." Either way
-	// the root index.md should appear shortly. Poll with a bounded
-	// timeout so the race resolves cleanly.
-	_, _ = d.Call(ctx, "mnemo_vault_sync", nil) // best-effort; coalescing is fine
-
+	// in the background. An explicit mnemo_vault_sync called too soon
+	// may coalesce with "already in flight, skipping." To handle both
+	// the coalescing case and the case where the background sync has
+	// not yet started, we retry mnemo_vault_sync until index.md
+	// appears with the expected fence. Each retry attempt that returns
+	// a coalescing message is followed by a short sleep to let the
+	// in-flight sync finish before we look for the file.
 	rootIndex := filepath.Join(vaultDir, "index.md")
 	var body []byte
-	deadline := time.Now().Add(15 * time.Second)
+	deadline := time.Now().Add(45 * time.Second)
 	for time.Now().Before(deadline) {
 		if data, readErr := os.ReadFile(rootIndex); readErr == nil {
-			body = data
-			break
+			if strings.Contains(string(data), "mnemo:generated") {
+				body = data
+				break
+			}
+			// File exists but fence not yet written (partial write or
+			// background sync still in progress). Wait and retry.
+		} else {
+			// File does not exist yet — trigger a sync attempt; ignore
+			// coalescing-skip responses, they mean one is already in
+			// flight.
+			_, _ = d.Call(ctx, "mnemo_vault_sync", nil)
 		}
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(250 * time.Millisecond)
 	}
 	if body == nil {
+		// One final read to capture whatever is on disk for the error
+		// message, even if it lacks the fence.
+		if data, readErr := os.ReadFile(rootIndex); readErr == nil {
+			t.Fatalf("vault index.md appeared but is missing the <!-- mnemo:generated --> fence — "+
+				"contract not honoured through MCP transport:\n%s\n--- daemon log ---\n%s",
+				data, d.Log())
+		}
 		t.Fatalf("vault index.md never appeared at %q:\n--- daemon log ---\n%s",
 			rootIndex, d.Log())
-	}
-	if !strings.Contains(string(body), "mnemo:generated") {
-		t.Errorf("vault index.md missing the <!-- mnemo:generated --> fence — "+
-			"contract not honoured through MCP transport:\n%s", body)
 	}
 
 	// mnemo_vault_status must reach the configured path through the


### PR DESCRIPTION
## Problem

The `internal/e2e` daemon-subprocess tests (added by 🎯T73) flake intermittently on loaded CI runners — **both** ubuntu and windows — producing false-red CI that has repeatedly forced release force-merges. Two root causes, from CI log analysis:

- **Windows**: spawning the daemon's `go build` on an already-CGO-loaded runner exceeds the 30s startup timeout → every e2e test fails `daemon failed to become ready: timeout after 30s`.
- **Ubuntu**: a vault-sync coalescing race — `mnemo_config(op=write)` triggers a background sync; the explicit `mnemo_vault_sync` coalesces with (or finishes before) the `<!-- mnemo:generated -->` fence is written, so the poll accepted an `index.md` lacking the fence (~0.4s fast-fail).

## Fix

- **Env-gate the suite out of the default `go test ./...`** — new `TestMain` skips all e2e tests unless `MNEMO_E2E=1`. `ci.yml` and `release.yml` are unchanged, so they no longer run e2e → it can never block a PR or release again.
- **Nightly workflow** (`.github/workflows/e2e-nightly.yml`: daily schedule + `workflow_dispatch`, sets `MNEMO_E2E=1`) preserves coverage.
- **Harden the races**: daemon `StartTimeout` 30s→60s; `TestVaultSyncViaMCP` poll deadline 15s→45s, and the loop now checks the fence before accepting the file and re-triggers the sync each iteration; timing-sensitive assertions use bounded retry loops.

Verified: default `go test -tags sqlite_fts5 ./...` skips e2e (passes, 0 e2e tests run); `MNEMO_E2E=1 go test ./internal/e2e/` passes 4× consecutively.

Retires 🎯T81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)