### PR TITLE
🎯T93: index usage analytics (v0.54.0) — open dashboard no longer burns CPU

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2906,3 +2906,22 @@ targets:
     origin: manual
     discovered: 2026-06-21
     achieved: 2026-06-22
+  T93:
+    name: Usage/cost analytics queries are index-served, so an open dashboard doesn't sustain CPU on a large DB
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - 'Store.Usage and activeHours no longer scan all assistant entries (all time) to satisfy a bounded time window: a covering index lets the window range-scan index-only. Verified by EXPLAIN QUERY PLAN using the new index (not idx_entries_type) and the /api/usage cold-query time dropping from ~2.8s to well under ~0.5s on the production-size DB.'
+    - With the dashboard open on its default auto-refresh, daemon CPU stays low (no sustained multi-core load from repeated usage queries).
+    - The index is additive (migrates under sqlift AllowNone); go test -tags sqlite_fts5 ./... is green.
+    context: 'Follow-up to T92, surfaced immediately after v0.53.0: with the decision-detection burn fixed, the remaining CPU spikes were entirely the open dashboard''s /api/usage analytics. Root cause (EXPLAIN QUERY PLAN on the live 15GB DB): Store.Usage''s main aggregation and activeHours both filter `type=''assistant'' AND timestamp BETWEEN ...` but the only usable index is idx_entries_type, so SQLite SEARCHes all 763,309 assistant entries (of 2.3M total) and table-fetches each to apply the timestamp filter, keeping only ~199k for a 30-day window — ~2.8s per cold query, re-run by the dashboard''s auto-refresh (default 10s) across 4 query variants. The 15s response cache (T92) caps but doesn''t eliminate it. Fix: a partial covering index `entries(timestamp, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, session_id) WHERE type=''assistant''` so the window range-scans index-only. T92''s human-gate (dashboard-open cost) is the trigger; the user confirmed it''s not acceptable.'
+    tags:
+    - perf
+    - daemon
+    - cpu
+    - dashboard
+    - sqlite
+    - index
+    origin: manual
+    discovered: 2026-06-22

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2908,7 +2908,7 @@ targets:
     achieved: 2026-06-22
   T93:
     name: Usage/cost analytics queries are index-served, so an open dashboard doesn't sustain CPU on a large DB
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -2925,3 +2925,4 @@ targets:
     - index
     origin: manual
     discovered: 2026-06-22
+    achieved: 2026-06-22

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -257,6 +257,12 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 		if err := e.store.IngestTodos(); err != nil {
 			logger.Error("todo ingest failed", "err", err)
 		}
+		// 🎯T93: refresh planner statistics once the initial ingest has
+		// landed its bulk writes. On a fresh install (which skips the
+		// migration ANALYZE) this gives the planner its first stats so
+		// covering indexes are used; on an upgrade it keeps them current
+		// after the startup catch-up. Cheap and self-tuning.
+		e.store.Optimize()
 		// Initial vault sync: materialise all knowledge-graph entities as
 		// Markdown notes. Spawned in its own goroutine so Watch() starts
 		// immediately and live JSONL ingestion is not delayed. The SQLite
@@ -322,6 +328,27 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 			reviewer.Run(r.baseCtx, rev)
 		}()
 	}
+
+	// Planner-statistics maintenance (🎯T93): periodically run
+	// `PRAGMA optimize` so the query planner keeps choosing the right
+	// indexes as the DB grows over a long-running daemon's lifetime.
+	// Self-tuning and cheap (analyses only tables whose stats have
+	// drifted). The post-ingest call covers startup; this covers the days
+	// a daemon stays up between restarts.
+	e.workers.Add(1)
+	go func() {
+		defer e.workers.Done()
+		ticker := time.NewTicker(6 * time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-r.baseCtx.Done():
+				return
+			case <-ticker.C:
+				e.store.Optimize()
+			}
+		}
+	}()
 
 	// External mirror reconciler (🎯T68.5): divergence-driven reconcile
 	// of the mirror streams (CI today; GitHub/commits as they convert).

--- a/internal/store/migration_test.go
+++ b/internal/store/migration_test.go
@@ -193,6 +193,56 @@ func TestUpgradeAddsDecisionScanState(t *testing.T) {
 	}
 }
 
+// TestUpgradeAddsUsageIndex pins the 🎯T93 additive migration: the usage
+// covering index is added to an existing entries table under AllowNone
+// (a new index, the simplest additive change).
+func TestUpgradeAddsUsageIndex(t *testing.T) {
+	path := freshDB(t)
+	applyDDL(t, path, `
+		CREATE TABLE entries (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id TEXT NOT NULL,
+			type TEXT NOT NULL,
+			timestamp TEXT,
+			raw BLOB,
+			model TEXT GENERATED ALWAYS AS (raw->>'$.message.model'),
+			input_tokens INTEGER GENERATED ALWAYS AS (json_extract(raw, '$.message.usage.input_tokens')),
+			output_tokens INTEGER GENERATED ALWAYS AS (json_extract(raw, '$.message.usage.output_tokens')),
+			cache_read_tokens INTEGER GENERATED ALWAYS AS (json_extract(raw, '$.message.usage.cache_read_input_tokens')),
+			cache_creation_tokens INTEGER GENERATED ALWAYS AS (json_extract(raw, '$.message.usage.cache_creation_input_tokens'))
+		);
+	`)
+	if err := tryUpgrade(t, path, `
+		CREATE TABLE entries (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id TEXT NOT NULL,
+			type TEXT NOT NULL,
+			timestamp TEXT,
+			raw BLOB,
+			model TEXT GENERATED ALWAYS AS (raw->>'$.message.model'),
+			input_tokens INTEGER GENERATED ALWAYS AS (json_extract(raw, '$.message.usage.input_tokens')),
+			output_tokens INTEGER GENERATED ALWAYS AS (json_extract(raw, '$.message.usage.output_tokens')),
+			cache_read_tokens INTEGER GENERATED ALWAYS AS (json_extract(raw, '$.message.usage.cache_read_input_tokens')),
+			cache_creation_tokens INTEGER GENERATED ALWAYS AS (json_extract(raw, '$.message.usage.cache_creation_input_tokens'))
+		);
+		CREATE INDEX idx_entries_assistant_usage
+			ON entries(timestamp, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, session_id)
+			WHERE type = 'assistant';
+	`); err != nil {
+		t.Fatalf("AllowNone upgrade adding the usage index must succeed: %v", err)
+	}
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var name string
+	if err := db.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='index' AND name='idx_entries_assistant_usage'`).Scan(&name); err != nil {
+		t.Fatalf("expected idx_entries_assistant_usage after upgrade: %v", err)
+	}
+}
+
 func TestUpgradePreservesData(t *testing.T) {
 	// Criterion 7: an additive upgrade (new column + new table + new
 	// index + new trigger) preserves rows in pre-existing tables.

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -621,6 +621,19 @@ CREATE INDEX idx_entries_agent_id ON entries(agent_id) WHERE agent_id IS NOT NUL
 
 CREATE INDEX idx_entries_assistant_tokens ON entries(session_id, input_tokens, output_tokens) WHERE type = 'assistant';
 
+-- 🎯T93 usage-analytics covering index. Store.Usage (token/cost rollups by
+-- day/model/repo) and activeHours both filter assistant entries by a
+-- timestamp window. Without a timestamp-leading index they fall back to
+-- idx_entries_type and SEARCH every assistant entry ever (~763k), table-
+-- fetching each to apply the window filter (~2.8s on a large DB, re-run by
+-- the dashboard's auto-refresh). Leading timestamp makes the window a range
+-- scan; the materialised token columns + model + session_id make both
+-- queries index-only over just the window's rows. Partial on type so it
+-- covers only assistant entries (matching the queries' WHERE type clause).
+CREATE INDEX idx_entries_assistant_usage
+			ON entries(timestamp, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, session_id)
+			WHERE type = 'assistant';
+
 -- 🎯T72 addenda-token metric: SUM(output_tokens + cache_creation_tokens)
 -- over assistant entries past a cursor (entries.id > cursor_entry_id),
 -- computed for every session on every compactor scan. Keyed

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -624,7 +624,57 @@ func applySchema(dbPath string) error {
 		}
 	}
 
-	return sqlift.Apply(sdb, plan, sqlift.ApplyOptions{Allow: sqlift.AllowNone})
+	if err := sqlift.Apply(sdb, plan, sqlift.ApplyOptions{Allow: sqlift.AllowNone}); err != nil {
+		return err
+	}
+
+	// 🎯T93: refresh planner statistics after a schema change. A migration
+	// that adds an index leaves it without sqlite_stat1 data, and SQLite's
+	// cost model will keep choosing the old (worse) index until ANALYZE
+	// runs — e.g. the usage covering index is ignored, reverting to a full
+	// assistant-table scan (~2.8s vs ~0.1s). Runs only here, on a real
+	// migration (rare; this path already took a pre-migration backup), so
+	// it is not a per-startup cost. Best-effort: a failure only costs
+	// planner stats, never correctness.
+	analyzeForPlanner(dbPath)
+	return nil
+}
+
+// Optimize runs `PRAGMA optimize`, SQLite's lightweight, self-tuning
+// statistics maintenance (🎯T93). It analyses only the tables whose
+// statistics have drifted enough to matter (including tables that have
+// never been analysed), so it is cheap to call periodically and on a
+// long-running daemon keeps the planner's index choices correct as the
+// DB grows. Complements the one-shot post-migration ANALYZE: that gives a
+// newly-added index immediate stats; this keeps them fresh over time and
+// covers fresh installs (which take the no-migration schema path). Runs on
+// the writer connection (PRAGMA optimize records analysis results).
+// Best-effort: a failure only affects planner quality.
+func (s *Store) Optimize() {
+	if s.writeDB == nil {
+		return
+	}
+	if _, err := s.writeDB.Exec("PRAGMA optimize"); err != nil {
+		slog.Warn("PRAGMA optimize failed; planner stats may drift", "err", err)
+	}
+}
+
+// analyzeForPlanner runs ANALYZE so the query planner has up-to-date
+// index statistics. Opens its own short-lived connection (mirroring the
+// backup hook) and is best-effort. Called after a schema migration adds
+// or changes indexes (🎯T93).
+func analyzeForPlanner(dbPath string) {
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		slog.Warn("post-migration ANALYZE: open failed; planner stats may be stale", "err", err)
+		return
+	}
+	defer db.Close()
+	if _, err := db.Exec("ANALYZE"); err != nil {
+		slog.Warn("post-migration ANALYZE failed; planner stats may be stale", "err", err)
+		return
+	}
+	slog.Info("post-migration ANALYZE complete (planner statistics refreshed)")
 }
 
 // applyFreshSchema creates the full schema by executing schema.sql

--- a/internal/store/usage_index_test.go
+++ b/internal/store/usage_index_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// TestUsageIndexPresentAndAnalyzable verifies the 🎯T93 fix end to end at
+// unit scale: the usage covering index ships in the fresh schema, Optimize
+// runs cleanly, and ANALYZE produces a planner-statistics row for the
+// index — the missing piece that previously left the index unused (the
+// planner fell back to a full assistant-table scan). A plan-choice
+// assertion is intentionally omitted: SQLite rightly prefers a full scan
+// on a tiny test table, so index selection is validated on the
+// production-size DB, not here.
+func TestUsageIndexPresentAndAnalyzable(t *testing.T) {
+	s := newTestStore(t, t.TempDir())
+
+	// The index is part of the fresh schema.
+	var name string
+	if err := s.readDB.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='index' AND name='idx_entries_assistant_usage'`,
+	).Scan(&name); err != nil {
+		t.Fatalf("usage index missing from fresh schema: %v", err)
+	}
+
+	// Seed assistant entries so the index has rows to analyse.
+	raw := `{"message":{"model":"claude","usage":{"input_tokens":10,"output_tokens":5,"cache_read_input_tokens":1,"cache_creation_input_tokens":2}}}`
+	now := time.Now().UTC().Format(time.RFC3339)
+	for range 50 {
+		if _, err := s.writeDB.Exec(
+			`INSERT INTO entries (session_id, project, type, timestamp, raw) VALUES (?,?,?,?,?)`,
+			"s1", "p", "assistant", now, raw); err != nil {
+			t.Fatalf("insert entry: %v", err)
+		}
+	}
+
+	// Optimize must be a clean no-op-or-analyze (best-effort maintenance).
+	s.Optimize()
+
+	// An explicit ANALYZE must record statistics for the usage index — the
+	// signal the query planner needs to choose it over the type index.
+	if _, err := s.writeDB.Exec("ANALYZE"); err != nil {
+		t.Fatalf("ANALYZE: %v", err)
+	}
+	var n int
+	if err := s.readDB.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_stat1 WHERE idx='idx_entries_assistant_usage'`).Scan(&n); err != nil {
+		t.Fatalf("read sqlite_stat1: %v", err)
+	}
+	if n == 0 {
+		t.Fatalf("expected a sqlite_stat1 row for idx_entries_assistant_usage after ANALYZE")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.53.0"
+	version              = "0.54.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
Follow-up to v0.53.0 (T91+T92). With the decision-detection burn fixed, the remaining CPU spikes were entirely the **open dashboard's `/api/usage` analytics**.

## Root cause (EXPLAIN QUERY PLAN on the live 15 GB DB)
`Store.Usage` (token/cost rollups) and `activeHours` filter `type='assistant' AND timestamp BETWEEN …`, but the only usable index was `idx_entries_type` → SQLite `SEARCH`ed **all 763k assistant entries (all time)** and table-fetched each to apply the window filter, keeping ~199k for a 30-day window. **~2.8s per query**, re-run by the dashboard's 10s auto-refresh across 4 usage variants → ~2.3 cores.

## Fix
Partial covering index:
```
entries(timestamp, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, session_id) WHERE type='assistant'
```
The window becomes an index-only range scan. **Measured on the live DB: usage query 2.8s → ~0.1s warm; daemon CPU with dashboard open ~2.3 cores → ~0.1.**

## The ANALYZE dependency (why `PRAGMA optimize` is also here)
The planner ignores a new index until `sqlite_stat1` exists, and mnemo never analysed — so the index would ship **dead**. Added:
- **post-migration `ANALYZE`** — upgraders get stats for the new index immediately,
- **`Store.Optimize()` (`PRAGMA optimize`)** — run after the initial ingest and on a 6h ticker, so fresh installs gain stats and they stay fresh as the DB grows.

## Schema / tests
Index is additive (migrates under `sqlift` `AllowNone`). Adds migration + index-stats tests. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)