### PR TITLE
🎯T94: serve mnemo_status from one sqldeep nested-projection query

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: marcelocantos/sqldeep
-          ref: v0.22.0
+          ref: v0.23.0
           path: sqldeep
           submodules: recursive
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: marcelocantos/sqldeep
-          ref: v0.22.0
+          ref: v0.23.0
           path: sqldeep
           submodules: recursive
 
@@ -225,7 +225,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: marcelocantos/sqldeep
-          ref: v0.22.0
+          ref: v0.23.0
           path: sqldeep
           submodules: recursive
       - name: Build sqldeep

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2928,7 +2928,7 @@ targets:
     achieved: 2026-06-22
   T94:
     name: mnemo_status is served by one sqldeep nested-projection query instead of a 3-level N+1
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -2947,3 +2947,4 @@ targets:
     - n+1
     origin: manual
     discovered: 2026-06-28
+    achieved: 2026-06-28

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2926,3 +2926,24 @@ targets:
     origin: manual
     discovered: 2026-06-22
     achieved: 2026-06-22
+  T94:
+    name: mnemo_status is served by one sqldeep nested-projection query instead of a 3-level N+1
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - 'sqldeep is bumped to v0.23.0 (the positional-parameter-order fix): go.mod require + the pinned ref in release.yml and e2e-nightly.yml all read v0.23.0, and the build/tests are green.'
+    - Store.Status fetches the repos -> sessions -> excerpts hierarchy in a single sqldeep nested-projection query (no per-repo and per-session follow-up queries); the prior 1 + R + R*S round-trips collapse to one.
+    - 'Output is behaviourally identical to the previous implementation: a golden/parity test asserts the new StatusResult (repos, sessions, excerpts, ordering, per-excerpt truncation + Truncated flag, keep-last-N) matches the old shape for representative data.'
+    - 'The delicate per-excerpt truncation and keep-last-N-excerpts semantics are preserved (hybrid: nesting in SQL, truncation/tail in a thin Go pass or via SQL substr + newest-N-then-reverse).'
+    - Named parameters are used (not positional ?) so sqldeep's clause reordering can't misbind args; a small transpile+bind test confirms sqldeep passes the params through.
+    - go test -tags sqlite_fts5 ./... is green; this is the first internal use of sqldeep.Transpile outside mnemo_query, so it is covered by a test that the transpiled SQL runs and returns the expected JSON.
+    context: 'Follow-up from the sqldeep review (the four-agent sweep after T93). Of ~150 SELECTs, Store.Status (internal/store/store.go:5043) was the single strong sqldeep nested-projection candidate, flagged independently by all four reviewers: a genuine 3-level N+1 (repos -> per-repo sessions -> per-session excerpts) whose result is marshalled straight to JSON for mnemo_status, exactly sqldeep''s sweet spot. Prereq: sqldeep v0.23.0 (''Preserve positional parameter order, or fail'', commit 9923bff) fixes ?-placeholder behaviour under sqldeep''s clause reordering; mnemo''s current sqldeep use (mnemo_query, literal SQL) doesn''t need it, but internal parameterized queries do — hence the bump is bundled here as the enabling change. mnemo consumes sqldeep via a local replace (../sqldeep/go/sqldeep), already at 0.23.0 with rebuilt artifacts; CI/release clone it at the pinned workflow ref (currently v0.22.0). Fiddly bits to preserve: keep-last-N excerpts is a TAIL not a LIMIT-head; per-excerpt truncation is byte-based in Go vs char-based substr in SQL; params thread through 3 nesting levels (use named params). Recommended shape is hybrid — nest in SQL to kill the N+1, keep truncation/tail in a thin Go post-pass. This is a code-quality + latency refactor, not a correctness/CPU fix; lower urgency than T91-T93.'
+    tags:
+    - perf
+    - sqldeep
+    - refactor
+    - status
+    - n+1
+    origin: manual
+    discovered: 2026-06-28

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require github.com/marcelocantos/sqlift/go/sqlift v0.17.0
 
 require (
 	github.com/google/jsonschema-go v0.4.2 // indirect
-	github.com/marcelocantos/sqldeep/go/sqldeep v0.22.0
+	github.com/marcelocantos/sqldeep/go/sqldeep v0.23.0
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/sys v0.43.0

--- a/internal/store/status_test.go
+++ b/internal/store/status_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import "testing"
+
+// seedStatusSession inserts a session's messages (alternating user/assistant,
+// all stamped at the given relative offset so last_msg is deterministic) and
+// its session_meta row. The messages_ai trigger builds session_summary
+// (session_type 'interactive' for a normal project, substantive_msgs = count,
+// last_msg = the stamp). Message ids are autoincrement, so insertion order is
+// excerpt order.
+func seedStatusSession(t *testing.T, s *Store, sid, repo, cwd, work, topic, offset string, texts []string) {
+	t.Helper()
+	for i, txt := range texts {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		if _, err := s.writeDB.Exec(
+			`INSERT INTO messages (session_id, project, role, text, timestamp, is_noise, content_type)
+			 VALUES (?, ?, ?, ?, datetime('now', ?), 0, 'text')`,
+			sid, repo, role, txt, offset); err != nil {
+			t.Fatalf("seed message %s/%d: %v", sid, i, err)
+		}
+	}
+	if _, err := s.writeDB.Exec(
+		`INSERT INTO session_meta (session_id, repo, cwd, work_type, topic) VALUES (?, ?, ?, ?, ?)`,
+		sid, repo, cwd, work, topic); err != nil {
+		t.Fatalf("seed meta %s: %v", sid, err)
+	}
+}
+
+// TestStatusNestedQuery verifies the 🎯T94 single-query Status reproduces the
+// old behaviour: repo ordering by recency, per-repo session cap (most recent),
+// per-session newest-N excerpts in ascending order, byte truncation + flag.
+func TestStatusNestedQuery(t *testing.T) {
+	s := newTestStore(t, t.TempDir())
+
+	longText := "this is a very long pasted block that exceeds ten chars"
+	// org/alpha: three sessions of differing recency; s-a1 has 5 messages
+	// (last two should survive maxExcerpts=2), the last being long.
+	seedStatusSession(t, s, "s-a1", "org/alpha", "/w/alpha", "branch-work", "topic A1",
+		"-2 minutes", []string{"u1", "a1", "u2", "a2", longText})
+	seedStatusSession(t, s, "s-a2", "org/alpha", "/w/alpha", "", "",
+		"-1 minutes", []string{"hello", "world"}) // most recent
+	seedStatusSession(t, s, "s-a3", "org/alpha", "/w/alpha", "", "",
+		"-10 minutes", []string{"old1", "old2"}) // oldest → excluded by maxSessions=2
+	// org/beta: one older session.
+	seedStatusSession(t, s, "s-b1", "org/beta", "/w/beta", "", "",
+		"-3 minutes", []string{"beta-only"})
+
+	res, err := s.Status(7, "", 2, 2, 10)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if len(res.Repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(res.Repos))
+	}
+
+	// Repos ordered by last_activity DESC: alpha (s-a2 @ -1m) before beta (@ -3m).
+	if res.Repos[0].Repo != "org/alpha" || res.Repos[1].Repo != "org/beta" {
+		t.Fatalf("repo order wrong: %q, %q", res.Repos[0].Repo, res.Repos[1].Repo)
+	}
+
+	alpha := res.Repos[0]
+	if alpha.Path != "/w/alpha" {
+		t.Errorf("alpha path = %q, want /w/alpha", alpha.Path)
+	}
+	// maxSessions=2 keeps the two most recent by last_msg: s-a2 then s-a1; s-a3 dropped.
+	if len(alpha.Sessions) != 2 {
+		t.Fatalf("alpha: expected 2 sessions, got %d", len(alpha.Sessions))
+	}
+	if alpha.Sessions[0].SessionID != "s-a2" || alpha.Sessions[1].SessionID != "s-a1" {
+		t.Fatalf("alpha session order wrong: %q, %q", alpha.Sessions[0].SessionID, alpha.Sessions[1].SessionID)
+	}
+	if alpha.Sessions[0].WorkType != "" || alpha.Sessions[1].WorkType != "branch-work" {
+		t.Errorf("work_type mismatch: %q, %q", alpha.Sessions[0].WorkType, alpha.Sessions[1].WorkType)
+	}
+	if alpha.Sessions[1].Messages != 5 {
+		t.Errorf("s-a1 messages = %d, want 5", alpha.Sessions[1].Messages)
+	}
+
+	// s-a1 has 5 messages; maxExcerpts=2 keeps the newest two (ids 4,5),
+	// returned in ascending id order: "a2" then the long one (truncated).
+	ex := alpha.Sessions[1].Excerpts
+	if len(ex) != 2 {
+		t.Fatalf("s-a1: expected 2 excerpts, got %d", len(ex))
+	}
+	if ex[0].Text != "a2" || ex[0].Truncated {
+		t.Errorf("excerpt[0] = %q trunc=%v, want \"a2\" false", ex[0].Text, ex[0].Truncated)
+	}
+	if !ex[1].Truncated || ex[1].Text != longText[:10]+"..." {
+		t.Errorf("excerpt[1] = %q trunc=%v, want %q true", ex[1].Text, ex[1].Truncated, longText[:10]+"...")
+	}
+	if ex[0].ID >= ex[1].ID {
+		t.Errorf("excerpts not ascending by id: %d, %d", ex[0].ID, ex[1].ID)
+	}
+
+	// beta: single session, single short excerpt (not truncated).
+	beta := res.Repos[1]
+	if len(beta.Sessions) != 1 || len(beta.Sessions[0].Excerpts) != 1 {
+		t.Fatalf("beta shape wrong: %d sessions", len(beta.Sessions))
+	}
+	if beta.Sessions[0].Excerpts[0].Text != "beta-only" {
+		t.Errorf("beta excerpt = %q", beta.Sessions[0].Excerpts[0].Text)
+	}
+}
+
+// TestStatusRepoFilter verifies the :repoPat sentinel — a filter restricts to
+// matching repos, and an empty filter returns all.
+func TestStatusRepoFilter(t *testing.T) {
+	s := newTestStore(t, t.TempDir())
+	seedStatusSession(t, s, "s-a1", "org/alpha", "/w/alpha", "", "", "-1 minutes", []string{"a"})
+	seedStatusSession(t, s, "s-b1", "org/beta", "/w/beta", "", "", "-1 minutes", []string{"b"})
+
+	filtered, err := s.Status(7, "beta", 3, 3, 200)
+	if err != nil {
+		t.Fatalf("Status(beta): %v", err)
+	}
+	if len(filtered.Repos) != 1 || filtered.Repos[0].Repo != "org/beta" {
+		t.Fatalf("repo filter failed: got %d repos", len(filtered.Repos))
+	}
+
+	all, err := s.Status(7, "", 3, 3, 200)
+	if err != nil {
+		t.Fatalf("Status(all): %v", err)
+	}
+	if len(all.Repos) != 2 {
+		t.Fatalf("unfiltered: expected 2 repos, got %d", len(all.Repos))
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5055,113 +5055,126 @@ func (s *Store) Status(days int, repoFilter string, maxSessions int, maxExcerpts
 		truncateLen = 200
 	}
 
-	// Step 1: Find repos with recent activity.
-	repoWhere := []string{
-		"ss.session_type = 'interactive'",
-		"ss.last_msg >= datetime('now', ?)",
-	}
-	repoArgs := []any{fmt.Sprintf("-%d days", days)}
-
-	if repoFilter != "" {
-		repoWhere = append(repoWhere, "(sm.repo LIKE ? OR sm.cwd LIKE ?)")
-		pattern := "%" + repoFilter + "%"
-		repoArgs = append(repoArgs, pattern, pattern)
-	}
-
-	repoQ := `
-		SELECT
-			CASE WHEN sm.repo != '' THEN sm.repo ELSE sm.cwd END AS display_repo,
-			MAX(sm.cwd) AS path,
-			MAX(ss.last_msg) AS last_activity
-		FROM session_summary ss
-		JOIN session_meta sm ON sm.session_id = ss.session_id
-		WHERE ` + strings.Join(repoWhere, " AND ") + `
-		GROUP BY display_repo
-		HAVING display_repo != ''
-		ORDER BY last_activity DESC
-	`
-
-	repoRows, err := s.readDB.Query(repoQ, repoArgs...)
+	// Fetch the repo → sessions → excerpts hierarchy in a single sqldeep
+	// nested-projection query (🎯T94). The previous version ran 1 + R + R*S
+	// queries (repos, then sessions per repo, then excerpts per session)
+	// and stitched the tree in Go; this collapses them into one round-trip
+	// whose result is the tree as JSON, one repo object per row.
+	//
+	// Mechanics worth knowing before editing this query:
+	//   - Named params (:window etc.) are reused across nesting levels and
+	//     are immune to sqldeep's clause reordering; positional `?` is not
+	//     (sqldeep v0.23.0). repoFilter is optional via the :repoPat=''
+	//     sentinel, so one query serves filtered and unfiltered calls.
+	//   - A nested SELECT with a *direct* LIMIT transpiles to a singular
+	//     object, not an array. So each level's LIMIT (maxSessions, and
+	//     newest-maxExcerpts) is pushed into a wrapped subquery; the outer
+	//     nested SELECT has no LIMIT and pluralises via json_group_array.
+	//     The excerpts subquery takes id DESC LIMIT N to pick the newest N.
+	//   - Array element order is NOT reliably controllable from SQL here:
+	//     json_group_array follows the inner subquery's order, and an outer
+	//     ORDER BY on the aggregate query is ignored. So the final ordering
+	//     (sessions by recency desc, excerpts by id asc) and the byte-based
+	//     truncation are done in the Go pass below. Excerpt truncation is
+	//     byte-based + sets Truncated; SQLite substr is char-based and would
+	//     diverge on multibyte text.
+	const statusQuery = `
+FROM (
+  SELECT
+    CASE WHEN sm.repo != '' THEN sm.repo ELSE sm.cwd END AS display_repo,
+    MAX(sm.cwd) AS path,
+    MAX(ss.last_msg) AS last_activity
+  FROM session_summary ss
+  JOIN session_meta sm ON sm.session_id = ss.session_id
+  WHERE ss.session_type = 'interactive'
+    AND ss.last_msg >= datetime('now', :window)
+    AND (:repoPat = '' OR sm.repo LIKE :repoPat OR sm.cwd LIKE :repoPat)
+  GROUP BY display_repo
+  HAVING display_repo != ''
+  ORDER BY last_activity DESC
+) r
+SELECT {
+  repo: r.display_repo,
+  path: r.path,
+  last_activity: r.last_activity,
+  sessions: SELECT {
+    session_id: sess.session_id,
+    last_msg: sess.last_msg,
+    messages: sess.substantive_msgs,
+    work_type: sess.work_type,
+    topic: sess.topic,
+    excerpts: SELECT { id: ex.id, role: ex.role, text: ex.text, timestamp: ex.timestamp }
+      FROM (
+        SELECT id, role, text, timestamp FROM messages
+        WHERE session_id = sess.session_id AND is_noise = 0 AND role IN ('user', 'assistant')
+        ORDER BY id DESC LIMIT :maxExcerpts
+      ) ex
+  } FROM (
+    SELECT ss.session_id AS session_id, ss.last_msg AS last_msg,
+           ss.substantive_msgs AS substantive_msgs,
+           COALESCE(sm.work_type, '') AS work_type, COALESCE(sm.topic, '') AS topic
+    FROM session_summary ss
+    JOIN session_meta sm ON sm.session_id = ss.session_id
+    WHERE ss.session_type = 'interactive'
+      AND ss.last_msg >= datetime('now', :window)
+      AND (sm.repo = r.display_repo OR sm.cwd = r.path)
+    ORDER BY ss.last_msg DESC LIMIT :maxSessions
+  ) sess
+}
+`
+	transpiled, err := sqldeep.Transpile(statusQuery)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("status: transpile: %w", err)
+	}
+
+	repoPat := ""
+	if repoFilter != "" {
+		repoPat = "%" + repoFilter + "%"
+	}
+
+	repoRows, err := s.readDB.Query(transpiled,
+		sql.Named("window", fmt.Sprintf("-%d days", days)),
+		sql.Named("repoPat", repoPat),
+		sql.Named("maxSessions", maxSessions),
+		sql.Named("maxExcerpts", maxExcerpts),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("status: query: %w", err)
 	}
 	defer repoRows.Close()
 
 	var repos []RepoStatus
 	for repoRows.Next() {
-		var r RepoStatus
-		if err := repoRows.Scan(&r.Repo, &r.Path, &r.LastActivity); err != nil {
+		var blob []byte
+		if err := repoRows.Scan(&blob); err != nil {
 			continue
+		}
+		var r RepoStatus
+		if err := json.Unmarshal(blob, &r); err != nil {
+			continue
+		}
+		// Order the JSON arrays (json_group_array order is not reliable) and
+		// truncate excerpts — all deterministic, on at most maxSessions ×
+		// maxExcerpts rows. Sessions: most-recent first. Excerpts: oldest
+		// first among the newest-N. Truncation is byte-based + sets the flag,
+		// matching the pre-T94 behaviour (SQLite substr is char-based).
+		sort.SliceStable(r.Sessions, func(a, b int) bool {
+			return r.Sessions[a].LastMsg > r.Sessions[b].LastMsg
+		})
+		for si := range r.Sessions {
+			exs := r.Sessions[si].Excerpts
+			sort.SliceStable(exs, func(a, b int) bool { return exs[a].ID < exs[b].ID })
+			for ei := range exs {
+				if len(exs[ei].Text) > truncateLen {
+					exs[ei].Text = exs[ei].Text[:truncateLen] + "..."
+					exs[ei].Truncated = true
+				}
+			}
 		}
 		repos = append(repos, r)
 	}
-
-	// Step 2: For each repo, find recent sessions.
-	for i := range repos {
-		sessQ := `
-			SELECT ss.session_id, ss.last_msg, ss.substantive_msgs,
-				COALESCE(sm.work_type, ''), COALESCE(sm.topic, '')
-			FROM session_summary ss
-			JOIN session_meta sm ON sm.session_id = ss.session_id
-			WHERE ss.session_type = 'interactive'
-				AND ss.last_msg >= datetime('now', ?)
-				AND (sm.repo = ? OR sm.cwd = ?)
-			ORDER BY ss.last_msg DESC
-			LIMIT ?
-		`
-		sessRows, err := s.readDB.Query(sessQ,
-			fmt.Sprintf("-%d days", days), repos[i].Repo, repos[i].Path, maxSessions)
-		if err != nil {
-			continue
-		}
-
-		for sessRows.Next() {
-			var ss SessionStatus
-			if err := sessRows.Scan(&ss.SessionID, &ss.LastMsg, &ss.Messages,
-				&ss.WorkType, &ss.Topic); err != nil {
-				continue
-			}
-			repos[i].Sessions = append(repos[i].Sessions, ss)
-		}
-		sessRows.Close()
-
-		// Step 3: For each session, pull substantive messages.
-		for j := range repos[i].Sessions {
-			sid := repos[i].Sessions[j].SessionID
-			msgQ := `
-				SELECT id, role, text, timestamp FROM messages
-				WHERE session_id = ? AND is_noise = 0
-					AND role IN ('user', 'assistant')
-				ORDER BY id ASC
-			`
-			msgRows, err := s.readDB.Query(msgQ, sid)
-			if err != nil {
-				continue
-			}
-
-			var excerpts []MessageExcerpt
-			for msgRows.Next() {
-				var m MessageExcerpt
-				if err := msgRows.Scan(&m.ID, &m.Role, &m.Text, &m.Timestamp); err != nil {
-					continue
-				}
-				// Truncate every excerpt — user pastes (logs, code,
-				// command output) inflate response size just as much
-				// as assistant tool-call serialisations do.
-				if len(m.Text) > truncateLen {
-					m.Text = m.Text[:truncateLen] + "..."
-					m.Truncated = true
-				}
-				excerpts = append(excerpts, m)
-			}
-			msgRows.Close()
-
-			// Keep last N excerpts if there are too many.
-			if len(excerpts) > maxExcerpts {
-				excerpts = excerpts[len(excerpts)-maxExcerpts:]
-			}
-			repos[i].Sessions[j].Excerpts = excerpts
-		}
+	if err := repoRows.Err(); err != nil {
+		return nil, fmt.Errorf("status: scan: %w", err)
 	}
 
 	// Per-stream backfill status.

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.54.0"
+	version              = "0.55.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
First internal use of sqldeep (beyond `mnemo_query`), from the post-T93 sqldeep review: `Store.Status` was the one strong nested-projection candidate.

## Before
`Store.Status` ran a **3-level N+1** — repos query, then a sessions query per repo, then an excerpts query per session (`1 + R + R*S` round-trips) — and stitched the repo→session→excerpt tree in Go.

## After
A single **sqldeep nested-projection** query returns the tree as JSON, one repo object per row. The Go side just unmarshals, orders, and truncates.

## Things that took iteration (captured in code comments)
- **Named params**, reused across nesting levels — immune to sqldeep's clause reordering (positional `?` is not; hence the v0.23.0 bump). `repoFilter` is optional via a `:repoPat=''` sentinel so one query serves filtered + unfiltered calls.
- **A nested `SELECT` with a direct `LIMIT` transpiles to a singular object, not an array.** So each level's `LIMIT` (maxSessions; newest-maxExcerpts) is pushed into a wrapped subquery; the outer nested `SELECT` has no `LIMIT` and pluralises via `json_group_array`.
- **`json_group_array` element order follows the inner subquery**, and an outer `ORDER BY` on the aggregate is ignored — so final ordering (sessions by recency desc, excerpts by id asc) is done in the Go pass, which also does the **byte-based** excerpt truncation (SQLite `substr` is char-based and would diverge on multibyte text).

## Dependency
Bundled enabling change: **sqldeep → v0.23.0** ("Preserve positional parameter order, or fail") — go.mod + the workflow `ref:` pins. The local `replace` checkout is already at 0.23.0.

## Tests
Deterministic tests for nesting, per-repo session cap, newest-N excerpt tail + ascending order, truncation + flag, and the repo filter; the pre-existing diagnostics/streams Status tests still pass. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)