### PR TITLE
🎯T95: menu_bar_app toggles live (no daemon restart)

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -3135,3 +3135,22 @@ targets:
     origin: manual
     discovered: 2026-06-28
     achieved: 2026-06-28
+  T95:
+    name: menu_bar_app toggles live — opting the menu-bar app in/out takes effect with no daemon restart
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - The menu-bar shim runs under a supervisor goroutine that reconciles against the live menu_bar_app flag on a ticker and on demand, rather than being gated once at startup.
+    - configController.Put pokes the supervisor on every config change, so setting menu_bar_app via mnemo_config starts (true) or stops (false) supervising Mnemo.app immediately, with no daemon restart.
+    - Disabling does not force-quit a running app (a manually-launched instance is never killed); it simply stops relaunching. Off-darwin / no-app-found stays a clean no-op.
+    - config.go and the mnemo_config tool docs describe menu_bar_app as applied-live; go test -tags sqlite_fts5 ./... is green incl. a supervisor unit test.
+    context: Follow-up to the v0.56.0 threads release, which made the macOS menu-bar app opt-in via menu_bar_app but gated it at daemon startup — so toggling required a restart. The user asked for the toggle to take effect immediately. The hot-reload machinery already exists for vault_path/workspace_roots (registry.Reload via configController.Put); this extends it to menu_bar_app by introducing a shimSupervisor that SetEnabled can poke live.
+    tags:
+    - threads
+    - ui
+    - config
+    - macos
+    - hot-reload
+    origin: manual
+    discovered: 2026-06-29

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -3137,9 +3137,10 @@ targets:
     achieved: 2026-06-28
   T95:
     name: menu_bar_app toggles live — opting the menu-bar app in/out takes effect with no daemon restart
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
+    actual_cost: 2.0
     acceptance:
     - The menu-bar shim runs under a supervisor goroutine that reconciles against the live menu_bar_app flag on a ticker and on demand, rather than being gated once at startup.
     - configController.Put pokes the supervisor on every config change, so setting menu_bar_app via mnemo_config starts (true) or stops (false) supervising Mnemo.app immediately, with no daemon restart.
@@ -3154,3 +3155,4 @@ targets:
     - hot-reload
     origin: manual
     discovered: 2026-06-29
+    achieved: 2026-06-29

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -60,10 +60,10 @@ type Config struct {
 	// Mnemo.app. The Threads feature itself stays fully available
 	// regardless — via the mnemo_thread_* MCP tools, the `mnemo thread`
 	// CLI, and the HTTP thread routes; only the menu-bar button is gated.
-	// Set true to have the daemon launch and supervise the app. The shim
-	// supervisor is wired at startup, so toggling this via mnemo_config
-	// takes effect on the next daemon start (or just launch Mnemo.app
-	// yourself).
+	// Set true to have the daemon launch and supervise the app. Applied
+	// live: toggling this via mnemo_config starts/stops supervising the app
+	// immediately, with no daemon restart. (Disabling won't force-quit a
+	// running app — it just won't be relaunched.)
 	MenuBarApp bool `json:"menu_bar_app,omitempty"`
 
 	// TodoGlobs are extra repo-relative globs (filepath.Match semantics)

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -719,7 +719,7 @@ Hot-reload coverage:
   - vault_path: applied live. The existing vault workers stop, a fresh exporter is built at the new path, and an initial sync starts in the background. Set vault_path to "" to disable vault export entirely.
   - workspace_roots, extra_project_dirs, synthesis_roots: applied live; subsequent ingest passes pick up the new roots.
   - linked_instances: persisted to disk but requires a daemon restart to take effect (the federation client is built once at startup).
-  - menu_bar_app: opt-in (default false) for the macOS menu-bar Threads app. Persisted to disk but takes effect on the next daemon start (the shim supervisor is wired at startup). The Threads daemon API — mnemo_thread_* tools, the "mnemo thread" CLI, the HTTP thread routes — stays available regardless of this flag.
+  - menu_bar_app: opt-in (default false) for the macOS menu-bar Threads app. Applied live — toggling it starts/stops the daemon supervising Mnemo.app immediately, no restart (disabling won't force-quit a running app, it just won't be relaunched). The Threads daemon API — mnemo_thread_* tools, the "mnemo thread" CLI, the HTTP thread routes — stays available regardless of this flag.
 
 Response includes which fields changed, which were adopted live, and which require a restart.`),
 			mcp.WithString("op", mcp.Description("Operation: \"read\" (default) or \"write\".")),

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.56.0"
+	version              = "0.57.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )

--- a/main.go
+++ b/main.go
@@ -694,7 +694,13 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	// disk via store.WriteConfig (which re-runs the same validation as
 	// LoadConfig) and asks the Registry to adopt it across every
 	// already-initialised per-user Store.
-	handler.SetConfigController(configController{reg: reg})
+	// The menu-bar shim supervisor (🎯T85.5) honours the menu_bar_app flag and
+	// is hot-reloadable: configController.Put pokes it on every config change,
+	// so toggling menu_bar_app via mnemo_config takes effect immediately, with
+	// no daemon restart.
+	shimSup := newShimSupervisor()
+	shimSup.SetEnabled(cfg.MenuBarApp)
+	handler.SetConfigController(configController{reg: reg, shim: shimSup})
 
 	// Wire the self-diagnostics registry into mnemo_doctor (🎯T83) — the
 	// same registry that backs the /health endpoint and the scheduler.
@@ -792,15 +798,13 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	errCh := make(chan error, 1)
 	go func() { errCh <- httpServer.ListenAndServe() }()
 
-	// Launch and supervise the Threads menu-bar shim (🎯T85.5) only when the
-	// user has opted in via `menu_bar_app: true` in ~/.mnemo/config.json. The
-	// Threads daemon API (mnemo_thread_* tools, the `mnemo thread` CLI, the
-	// HTTP thread routes) stays available unconditionally; only the menu-bar
-	// app auto-launch is opt-in. Best-effort, macOS-only; a no-op when no
-	// Mnemo.app is installed.
-	if cfg.MenuBarApp {
-		go superviseThreadsShim(ctx)
-	}
+	// Start the menu-bar shim supervisor (🎯T85.5). It honours menu_bar_app
+	// (initial value set above) and reacts to live toggles via Put, so the
+	// menu-bar app is opt-in and the toggle needs no restart. The Threads
+	// daemon API (mnemo_thread_* tools, the `mnemo thread` CLI, the HTTP
+	// thread routes) stays available unconditionally; only the menu-bar app
+	// is gated. Best-effort, macOS-only; a no-op when no Mnemo.app is found.
+	go shimSup.run(ctx)
 
 	// Optionally start the federated mTLS server in parallel
 	// (🎯T15.3). A startup failure here is non-fatal — we log and
@@ -877,7 +881,8 @@ func (a compactorAdapter) Health() tools.CompactorHealth {
 // importing the tools package (a cycle we already avoid for
 // dependency hygiene).
 type configController struct {
-	reg *registry.Registry
+	reg  *registry.Registry
+	shim *shimSupervisor
 }
 
 func (c configController) Get() store.Config {
@@ -889,6 +894,11 @@ func (c configController) Put(newCfg store.Config) (tools.ConfigReport, error) {
 		return tools.ConfigReport{}, err
 	}
 	rep := c.reg.Reload(newCfg)
+	// Adopt menu_bar_app live: start/stop supervising the menu-bar app
+	// without a daemon restart (🎯T85.5).
+	if c.shim != nil {
+		c.shim.SetEnabled(newCfg.MenuBarApp)
+	}
 	return tools.ConfigReport{
 		Changed:         rep.Changed,
 		Adopted:         rep.Adopted,

--- a/threads_shim.go
+++ b/threads_shim.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sync/atomic"
 	"time"
 )
 
@@ -17,38 +18,82 @@ import (
 // menu-bar shim is still running.
 const threadsShimCheckInterval = 30 * time.Second
 
-// superviseThreadsShim launches and keeps alive the Mnemo menu-bar app
-// (🎯T85.5, Integration §0.1). The shim is its own signed .app — for a stable
-// Accessibility TCC identity — but the daemon launches it (via `open -g`, so it
-// never steals focus) and relaunches it if it exits, so there is no separate
-// install step or second LaunchAgent.
+// shimSupervisor launches and keeps alive the Mnemo menu-bar app (🎯T85.5,
+// Integration §0.1), gated on the menu_bar_app config flag — which is
+// hot-reloadable: SetEnabled wires the running daemon to the live config so
+// toggling menu_bar_app via mnemo_config takes effect immediately, no
+// restart. The shim is its own signed .app (a stable Accessibility TCC
+// identity) but the daemon launches it (via `open -g`, so it never steals
+// focus) and relaunches it if it exits, so there is no separate install step
+// or second LaunchAgent.
 //
-// It is best-effort and conservative: it only does anything on macOS and only
-// when a Mnemo.app is actually found (at $MNEMO_THREADS_APP or a known
-// install location). A daemon without the app installed is a silent no-op, so
-// pulling this code never makes a menu-bar item appear unexpectedly.
-func superviseThreadsShim(ctx context.Context) {
-	if runtime.GOOS != "darwin" {
-		return
-	}
-	app := resolveThreadsApp()
-	if app == "" {
-		slog.Debug("threads shim: no Mnemo.app found; menu-bar app not launched")
-		return
-	}
-	slog.Info("threads shim: supervising menu-bar app", "app", app)
+// It is best-effort and conservative: it only does anything on macOS and
+// only when a Mnemo.app is actually found (at $MNEMO_THREADS_APP or a known
+// install location). A daemon without the app installed is a silent no-op,
+// so pulling this code never makes a menu-bar item appear unexpectedly.
+type shimSupervisor struct {
+	app     string      // resolved Mnemo.app path; "" disables the supervisor entirely
+	enabled atomic.Bool // mirrors menu_bar_app from live config
+	wake    chan struct{}
+}
 
-	launchThreadsShimIfNeeded(app)
+// newShimSupervisor resolves Mnemo.app once. The supervisor is inert (a
+// permanent no-op) off macOS or when no app is found.
+func newShimSupervisor() *shimSupervisor {
+	s := &shimSupervisor{wake: make(chan struct{}, 1)}
+	if runtime.GOOS == "darwin" {
+		s.app = resolveThreadsApp()
+	}
+	return s
+}
+
+// SetEnabled records the desired state (menu_bar_app) and pokes the
+// supervisor to reconcile immediately. Called at startup with the initial
+// config and from configController.Put on every live config change.
+func (s *shimSupervisor) SetEnabled(on bool) {
+	s.enabled.Store(on)
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+}
+
+// run reconciles the menu-bar app against the desired state on a ticker and
+// on demand (SetEnabled). When enabled it keeps Mnemo.app running; when
+// disabled it stops launching it (a running instance is left alone rather
+// than force-quit, so a manually-launched app is never killed out from
+// under the user — it simply won't be relaunched). Returns immediately when
+// there is nothing to supervise.
+func (s *shimSupervisor) run(ctx context.Context) {
+	if s.app == "" {
+		if runtime.GOOS == "darwin" {
+			slog.Debug("threads shim: no Mnemo.app found; menu-bar supervision disabled")
+		}
+		return
+	}
+	slog.Info("threads shim: supervisor started", "app", s.app)
 	ticker := time.NewTicker(threadsShimCheckInterval)
 	defer ticker.Stop()
+	s.reconcile()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			launchThreadsShimIfNeeded(app)
+			s.reconcile()
+		case <-s.wake:
+			s.reconcile()
 		}
 	}
+}
+
+func (s *shimSupervisor) reconcile() {
+	if s.enabled.Load() {
+		launchThreadsShimIfNeeded(s.app)
+	}
+	// Disabled: do nothing. We deliberately don't force-quit a running app —
+	// it may have been launched manually, and killing it on every tick would
+	// be hostile. It just won't be relaunched once it exits.
 }
 
 // resolveThreadsApp returns the path to Mnemo.app, or "" when none is

--- a/threads_shim_test.go
+++ b/threads_shim_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestShimSupervisorNoAppIsInert verifies the safety properties of the
+// menu-bar shim supervisor without launching anything: when no Mnemo.app is
+// resolved (app == ""), run() returns immediately rather than hanging or
+// shelling out, and SetEnabled never blocks even when toggled repeatedly
+// against a full wake channel. This covers the non-darwin / app-not-installed
+// path and the hot-reload poke being fire-and-forget.
+func TestShimSupervisorNoAppIsInert(t *testing.T) {
+	s := &shimSupervisor{wake: make(chan struct{}, 1)} // app == "" → inert
+
+	// SetEnabled must be non-blocking even when the wake channel is already
+	// full (the second/third calls hit the default case).
+	s.SetEnabled(true)
+	s.SetEnabled(false)
+	s.SetEnabled(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { s.run(ctx); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run() did not return for an app-less supervisor")
+	}
+}


### PR DESCRIPTION
v0.56.0 made the macOS menu-bar app opt-in via `menu_bar_app`, but gated it once at daemon startup — so toggling required a restart. This makes it **live**.

## Change
- A `shimSupervisor` replaces the startup-gated `superviseThreadsShim` goroutine. It reconciles the menu-bar app against the live `menu_bar_app` flag on a ticker **and** on demand.
- `configController.Put` (which already calls `registry.Reload` to adopt `vault_path`/`workspace_roots` live) now also pokes the supervisor via `SetEnabled`. So `mnemo_config op=write patch:{"menu_bar_app": true}` launches the app immediately; `false` stops supervising — **no restart**.
- Disabling never force-quits a running app (a manually-launched instance is left alone); it just stops relaunching. Off-darwin / no-`Mnemo.app` is a clean no-op.
- `config.go` + `mnemo_config` docs updated to "applied live". Adds a supervisor unit test.

## Tests
`go build` + full suite (incl. e2e) green; new `TestShimSupervisorNoAppIsInert` covers the no-app/no-launch and non-blocking-`SetEnabled` safety properties.

Retires 🎯T95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)