### PR TITLE
🎯T96: mnemo_config patch allowlist is drift-proof (derive from struct)

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -3158,9 +3158,10 @@ targets:
     achieved: 2026-06-29
   T96:
     name: mnemo_config patch validation is drift-proof — every Config field is patchable without a hand-maintained allowlist
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
+    actual_cost: 2.0
     acceptance:
     - The mnemo_config patch key-allowlist is derived from store.Config's json tags via reflection, not a hand-maintained map, so adding a Config field automatically makes it patchable.
     - 'mnemo_config op=write with {menu_bar_app: ...} (and threads_root, todo_globs, backup, etc.) is accepted, not rejected as an unknown config key; genuine typos still error.'
@@ -3173,3 +3174,4 @@ targets:
     - robustness
     origin: manual
     discovered: 2026-06-29
+    achieved: 2026-06-29

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -3156,3 +3156,20 @@ targets:
     origin: manual
     discovered: 2026-06-29
     achieved: 2026-06-29
+  T96:
+    name: mnemo_config patch validation is drift-proof — every Config field is patchable without a hand-maintained allowlist
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - The mnemo_config patch key-allowlist is derived from store.Config's json tags via reflection, not a hand-maintained map, so adding a Config field automatically makes it patchable.
+    - 'mnemo_config op=write with {menu_bar_app: ...} (and threads_root, todo_globs, backup, etc.) is accepted, not rejected as an unknown config key; genuine typos still error.'
+    - A regression test asserts the previously-broken keys are in the derived allowlist and that a menu_bar_app patch merges and applies; go test -tags sqlite_fts5 ./... is green.
+    context: 'Bug found during the v0.57.0 live-toggle demo: mnemo_config rejected {menu_bar_app: false} with ''unknown config keys''. The config tool validated patch keys against a hand-maintained knownConfigKeys map that was never updated when menu_bar_app (v0.56.0), threads_root, todo_globs, disable_health_notifications, and the nested backup/cost_reconciliation/connection_sweep fields were added — so those keys were unpatchable and read-modify-write of the config failed. The opt-in/live-toggle features shipped in v0.56.0/v0.57.0 were therefore only settable by editing ~/.mnemo/config.json directly. Fixed by deriving the allowlist from the struct so it can never drift again. Ships as v0.58.0.'
+    tags:
+    - config
+    - bugfix
+    - mnemo_config
+    - robustness
+    origin: manual
+    discovered: 2026-06-29

--- a/internal/tools/config_tool_test.go
+++ b/internal/tools/config_tool_test.go
@@ -76,6 +76,29 @@ func TestMergeConfigPatchRejectsUnknownKeys(t *testing.T) {
 	}
 }
 
+func TestMergeConfigPatchAcceptsStructKeys(t *testing.T) {
+	// Regression: menu_bar_app and threads_root were added to store.Config but
+	// not to the (formerly hand-maintained) allowlist, so mnemo_config rejected
+	// them as "unknown config keys". The allowlist is now derived from the
+	// struct, so every top-level config key is patchable.
+	for _, key := range []string{
+		"menu_bar_app", "threads_root", "todo_globs",
+		"disable_health_notifications", "backup", "cost_reconciliation",
+	} {
+		if _, ok := knownConfigKeys[key]; !ok {
+			t.Errorf("config key %q missing from the derived allowlist", key)
+		}
+	}
+	// The formerly-rejected key must now merge and apply.
+	merged, err := mergeConfigPatch(store.Config{}, map[string]any{"menu_bar_app": true})
+	if err != nil {
+		t.Fatalf("mergeConfigPatch(menu_bar_app): %v", err)
+	}
+	if !merged.MenuBarApp {
+		t.Errorf("menu_bar_app not applied after merge: %+v", merged)
+	}
+}
+
 func TestConfigToolReadReturnsJSON(t *testing.T) {
 	ctl := &fakeCtl{cur: store.Config{VaultPath: "/v"}}
 	ch := &callHandler{}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -12,6 +12,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -3009,15 +3010,33 @@ func (h *callHandler) callerHome() string {
 // in a patch. Anything else is rejected up-front so a typo like
 // "vaultpath" produces an error rather than being silently dropped by
 // json.Unmarshal's unknown-field handling.
-var knownConfigKeys = map[string]struct{}{
-	"workspace_roots":            {},
-	"extra_project_dirs":         {},
-	"synthesis_roots":            {},
-	"vault_path":                 {},
-	"vault_indexing_scope":       {},
-	"vault_indexing_includes":    {},
-	"vault_indexing_ignore_file": {},
-	"linked_instances":           {},
+// knownConfigKeys is the set of top-level keys a mnemo_config patch may
+// set. It is derived from store.Config's json tags via reflection so it can
+// never drift from the struct: adding a Config field automatically makes it
+// patchable. A hand-maintained parallel list silently left menu_bar_app and
+// threads_root unpatchable (the tool rejected them as "unknown config keys")
+// after they were added to the struct but not the list — reflection removes
+// that failure mode entirely.
+var knownConfigKeys = configKeySet()
+
+// configKeySet reflects over store.Config's exported fields and collects
+// their json key names (the part before any comma; "-" and untagged fields
+// are skipped).
+func configKeySet() map[string]struct{} {
+	keys := make(map[string]struct{})
+	t := reflect.TypeOf(store.Config{})
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("json")
+		if tag == "" {
+			continue
+		}
+		name := strings.SplitN(tag, ",", 2)[0]
+		if name == "" || name == "-" {
+			continue
+		}
+		keys[name] = struct{}{}
+	}
+	return keys
 }
 
 // mergeConfigPatch round-trips current through JSON so the patch's

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.57.0"
+	version              = "0.58.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
**Bug:** `mnemo_config op=write patch:{"menu_bar_app": ...}` was rejected with `unknown config keys: menu_bar_app`. The patch validator checked keys against a **hand-maintained** `knownConfigKeys` map that drifted from `store.Config` — it never gained `menu_bar_app` (v0.56.0), nor `threads_root`, `todo_globs`, `disable_health_notifications`, or the nested `backup`/`cost_reconciliation`/`connection_sweep` fields. So those keys were unpatchable, and a read-modify-write of the config failed outright. The v0.56.0 menu-bar opt-in and the v0.57.0 live-toggle were only settable by editing `~/.mnemo/config.json` by hand — the documented `mnemo_config` path didn't work.

**Fix:** derive the allowlist from `store.Config`'s json tags via reflection, so it can never drift from the struct again — any field added later is patchable automatically. Genuine typos (`vaultpath`, …) still error. Adds `TestMergeConfigPatchAcceptsStructKeys`.

Version → v0.58.0. Retires 🎯T96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)