### PR TITLE
🎯T99: ingest Codex CLI transcripts

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -3175,3 +3175,138 @@ targets:
     origin: manual
     discovered: 2026-06-29
     achieved: 2026-06-29
+  T97:
+    name: mnemo upgrades its own binary without dropping live MCP connections
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - 'A backend version change while Claude Code sessions are connected invalidates no session: none needs /mcp, no in-flight tool call is lost beyond the swap instant.'
+    - Detection + notification of a new release works with auto-apply disabled; enabling auto_upgrade.enabled performs the full swap at a quiescent window.
+    - Non-Homebrew and Windows installs degrade to notify-only; edge upgrades are the only documented connection-dropping case.
+    - docs/design/connection-preserving-upgrade.md is the design of record.
+    context: 'mnemo should self-upgrade with live agents surviving the swap. The blocker is not byte-swapping but that Claude Code caches Mcp-Session-Id and does not re-initialize on server restart (claude-code#27142). Design: a thin transparent edge proxy owns client connections and routes by Mcp-Session-Id to a swappable backend, with session-affinity draining and a single-holder lease on singleton background work. See docs/design/connection-preserving-upgrade.md. Revisits T27''s literal "no proxy" while preserving its real invariants (no custom protocol; identity via Mcp-Session-Id). Note: T95/T96 were taken by merged work; this objective is T97.'
+    tags:
+    - upgrade
+    - daemon
+    - proxy
+    - mcp
+    - ops
+    origin: manual
+    discovered: 2026-06-30
+  T97.1:
+    name: The backend daemon drains gracefully on SIGTERM/SIGINT and leaves a checkpointed WAL
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - A foreground SIGTERM/SIGINT triggers the existing drain path (httpSrv.Shutdown + httpServer.Shutdown) instead of an immediate kill — main.go installs a signal-driven cancellable context (today main.go:189 passes a never-cancelled context).
+    - 'Drain order: stop intake -> release background lease -> stop workers -> quiesce read pool -> PRAGMA wal_checkpoint(TRUNCATE) on the writer.'
+    - The checkpoint result (busy, log, ckpt) is logged; busy != 0 is surfaced as a warning.
+    - A drain exceeding the deadline (~5-10s) falls back to a hard exit, which is safe given the crash-only durability guarantees.
+    context: Foundation, independently valuable. Today there is no signal.Notify anywhere; the graceful-shutdown block at main.go:827-848 is only reachable under the Windows SCM path. brew services restart sends SIGTERM, which currently hard-kills the daemon mid-request on macOS/Linux.
+    tags:
+    - upgrade
+    - shutdown
+    - sqlite
+    - wal
+    origin: manual
+    discovered: 2026-06-30
+  T97.2:
+    name: A newer mnemo release is detected and surfaced via the T83 health pipeline
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - A low-frequency worker queries `gh release list --repo marcelocantos/mnemo` and caches the latest tag versus the version constant.
+    - A diag.Check named upgrade.available reports warn when a newer version exists, flowing to mnemo_doctor + OS notification + dashboard /health via the existing T83 path.
+    - The check is on by default and disabled by disable_upgrade_check in ~/.mnemo/config.json.
+    - No outbound call occurs when the check is disabled.
+    context: Independent of the proxy work and shippable first. Reuses the gh-shell pattern from the PR/CI backfill (store.go) and the T83 health/notify/dashboard pipeline verbatim — no new notification plumbing. On-by-default opt-out matches the always-on GitHub egress and health notifications precedent.
+    tags:
+    - upgrade
+    - github
+    - diagnostics
+    - notification
+    origin: manual
+    discovered: 2026-06-30
+  T97.3:
+    name: A transparent edge proxy owns client connections and routes by Mcp-Session-Id to a backend
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - The edge process owns the :19419 listener and all client connections; the backend listens on loopback/UDS.
+    - Requests route to a backend by Mcp-Session-Id; edge<->backend traffic is standard MCP-over-HTTP (no custom protocol).
+    - A session is pinned to the backend that handled its initialize; new initializes can be directed to a different backend.
+    - The long-lived GET/SSE stream proxies cleanly across the edge.
+    context: 'The connection-owner that routes around claude-code#27142: because the edge keeps running the old binary across a backend swap, the client''s TCP connection and Mcp-Session-Id stay valid, so the client never sees a session invalidation. Preserves T27''s invariants (no custom protocol; identity via Mcp-Session-Id). Spike mark3labs v0.47 transport reuse for the client side + SSE splicing before locking.'
+    depends_on:
+    - T97.1
+    tags:
+    - upgrade
+    - proxy
+    - mcp
+    - edge
+    origin: manual
+    discovered: 2026-06-30
+  T97.4:
+    name: Singleton background work is guarded by a single-holder lease
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - Exactly one backend holds the lease and runs ingest/compaction/mirrors/image pools.
+    - Lease handoff between two live backends completes in under ~1s with no double-ingest.
+    - A crashed lease-holder's lease is released (OS-released file lock or heartbeat expiry) and reacquired by a live backend.
+    - Lease ownership is observable via mnemo_doctor.
+    context: Connection-preserving upgrade overlaps two backend processes during drain; the singleton background role (ingest/compaction/mirrors/image pools) must run in exactly one of them. The lease is the seam between momentarily-multi-process serving and singleton background work. Also prevents accidental double-daemon independent of upgrades.
+    tags:
+    - upgrade
+    - daemon
+    - lease
+    - background
+    origin: manual
+    discovered: 2026-06-30
+  T97.5:
+    name: Opt-in auto-apply upgrades the backend at a quiescent window with connections preserved
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - auto_upgrade.enabled gates the apply path; default off (detection/notification stay on).
+    - When enabled and a newer release is detected, after 30 min of MCP traffic quiescence the daemon runs a detached `brew upgrade mnemo`, spawns the new backend, routes new sessions to it, and drains+checkpoints+reaps the old backend.
+    - Throughout the swap an existing connected session keeps working without /mcp.
+    - Installs not managed by Homebrew degrade to notify-only.
+    context: Integration node tying detection, the edge proxy, the lease, and graceful drain into the orchestrated swap. Detached brew helper outlives the backend it replaces; the edge keeps running. opt-in because auto-restarting a backend many sessions depend on is too big a default to flip silently.
+    depends_on:
+    - T97.1
+    - T97.2
+    - T97.3
+    - T97.4
+    tags:
+    - upgrade
+    - orchestration
+    - homebrew
+    - auto-apply
+    origin: manual
+    discovered: 2026-06-30
+  T97.6:
+    name: Sessions spanning a backend swap are told they were upgraded
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - A session routed to a newer backend than the one it initialized under receives a one-time `mnemo upgraded vN -> vN+1` notice in its next tool result.
+    - tools/list_changed is pushed best-effort after a version change (or the client re-lists on reconnect).
+    - The banner fires at most once per session per upgrade.
+    context: Tool-result text is the only reliably model-visible channel (notifications/message is received but not displayed by Claude Code). Under the affinity-drain model most sessions live entirely within one backend version, so the banner is mostly an edge-case courtesy plus a hook for any future forced-migration path.
+    depends_on:
+    - T97.3
+    tags:
+    - upgrade
+    - mcp
+    - notification
+    - agent
+    origin: manual
+    discovered: 2026-06-30

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -3310,3 +3310,24 @@ targets:
     - agent
     origin: manual
     discovered: 2026-06-30
+  T99:
+    name: mnemo ingests Codex CLI session transcripts into the existing searchable index
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - mnemo discovers and watches Codex rollout files under ~/.codex/sessions/** and ~/.codex/archived_sessions/ recursively; Codex roots are a configured Store field so New-based tests stay hermetic.
+    - 'A rollout is transformed into mnemo''s content model via parseCodexFile: response_item/message -> role+text, function_call/custom_tool_call/tool_search_call -> tool_use, *_output -> tool_result (paired by call_id), reasoning -> placeholder; session_meta/turn_context/event_msg/developer turns skipped.'
+    - Each Codex record gets a deterministic synthetic (session_id, line-offset) uuid injected into raw so re-ingest is idempotent via INSERT OR IGNORE; ingest resumes from the ingest_state byte offset.
+    - session_meta carries an additive `source` column (default 'claude'); Codex sessions are source='codex' and existing mnemo_search/mnemo_sessions surface them; the batch and watcher paths share one writeParsedFile writer.
+    - The parser tolerates unknown envelope/payload types and junk lines rather than failing, surviving codex-rs format churn.
+    - Unit + end-to-end tests pass (parse, search, source tagging, repo attribution, dedup); go test -tags sqlite_fts5 ./... is green. docs/design/codex-ingest.md is the design of record.
+    context: 'MVP: capture Codex transcripts. Codex records OpenAI Responses API items in a {timestamp,type,payload} envelope under ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl — not Claude''s schema. Implemented as a parseCodexFile transform into the shared parsedFile intermediate (codex.go), reusing the watcher/ingest_state/repo-attribution/search spine via a factored writeParsedFile writer. session_meta.source discriminates corpora. Codex roots configured via registry.ForUser (Store.SetCodexRoots) for test hermeticity. Out of scope: the ~/.codex/*.sqlite DBs, history.jsonl, decrypting reasoning, chain/compaction modeling, Codex-specific tooling. Design: docs/design/codex-ingest.md.'
+    tags:
+    - codex
+    - ingest
+    - multi-agent
+    - parser
+    - mvp
+    origin: manual
+    discovered: 2026-06-30

--- a/docs/design/codex-ingest.md
+++ b/docs/design/codex-ingest.md
@@ -1,0 +1,127 @@
+# Codex Transcript Ingest (MVP)
+
+*Status: design note — 2026-06-30. Anchors 🎯T99. Scope is deliberately
+narrow: capture Codex CLI session transcripts into the existing index,
+and not much else.*
+
+**Tracking.** Design source for 🎯T99. Grounded in real rollout files on
+disk (`~/.codex`, `cli_version 0.140`) and source-verified against
+`openai/codex` at `codex-rs` HEAD (`rust-v0.142.4`, 2026-06-29).
+
+---
+
+## TL;DR
+
+Codex **does not follow Claude Code's schema at all.** It records the
+**OpenAI Responses API** item stream wrapped in a thin Codex envelope.
+The MVP is a single defensive parser that maps that envelope into
+mnemo's existing content model, plus one new watched root, one
+synthetic-id rule, and one nullable `source` column. Everything else —
+search, usage, repo attribution, idempotent resumable ingest — is reused
+from the Claude ingest spine.
+
+This is a genuine **transform**, not a passthrough, but a contained one.
+
+---
+
+## The format
+
+Every rollout line is:
+
+```json
+{"timestamp": "2026-06-20T01:32:25.992Z", "type": "<envelope>", "payload": { ... }}
+```
+
+- **Location:** `~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-<ISO-ts>-<uuidv7>.jsonl`
+  (date-nested), plus `~/.codex/archived_sessions/*.jsonl` (flat). Walk
+  **recursively** — early Rust builds and archives are flat.
+- **First line is always `session_meta`** (the header). Conversation
+  content is in `response_item` lines.
+- **No per-record `uuid`, no `parentUuid` tree, no per-line cwd/branch.**
+  The only ids are the session uuidv7 (header + filename) and per-tool
+  `call_id`s. Records are ordered purely by file position.
+- It's the Rust `codex-rs` generation (`originator "Codex Desktop"`,
+  `source vscode`, model `gpt-5.5`).
+
+Envelope `type`s: `session_meta`, `response_item`, `event_msg`,
+`turn_context`, `compacted`, `world_state`, `inter_agent_communication*`.
+
+### Record taxonomy → mnemo mapping
+
+| Codex record | content | → mnemo | MVP |
+|---|---|---|---|
+| `session_meta` | `id`, `cwd`, `git{commit,branch,repository_url}`, `model_provider`, `cli_version`, `source`, `forked_from_id`/`parent_thread_id` | session row (id, cwd→repo, git, started_at) | ✅ |
+| `turn_context` | `model` (gpt-5.5), `cwd`, `workspace_roots` | per-turn model / cwd | ✅ light |
+| `response_item / message` | `role` (developer/user/**assistant**), `content:[{input_text\|output_text\|input_image}]` | message: role + text | ✅ **canonical stream** |
+| `response_item / function_call`·`custom_tool_call`·`tool_search_call`·`local_shell_call` | `name`, `arguments` (**JSON string**)/`input`, `call_id` | tool_use | ✅ |
+| `response_item / *_output` | `call_id`, `output` (string **or** `content_items[]`) | tool_result (paired by `call_id`) | ✅ |
+| `response_item / reasoning` | `summary[]`, `encrypted_content` (opaque) | thinking — **non-indexable placeholder** (index `summary` if present) | ⚠️ |
+| `event_msg / token_count` | input/cached/output/reasoning tokens | usage | optional |
+| `event_msg / user_message`·`agent_message` | clean text — **1:1 echo** of `response_item/message` | — | ❌ skip (avoid double-index) |
+| `event_msg / patch_apply_end`·`task_*`·`mcp_tool_call_end` | diffs, turn boundaries, rich results | — | ❌ later |
+| `compacted`·`turn_context`·`world_state`·`inter_agent_*` | bookkeeping | — | ❌ skip/ignore |
+
+Verified on a real session: `response_item/message` carries all roles
+(assistant 175, user 28, developer 6) and `event_msg/agent_message`
+(175) is a 1:1 echo — so **`response_item` is the single canonical
+conversation stream**; `event_msg` is UI echo plus token usage.
+
+## MVP — four adaptations, everything else reused
+
+1. **New watched root, defensively read.** Discover/watch
+   `~/.codex/sessions/**` + `~/.codex/archived_sessions/` recursively.
+   The reader must handle:
+   - **Compressed rollouts** — newer codex-rs compresses some files
+     (`compression.rs`); detect by extension/magic, decompress.
+   - **Legacy TypeScript era** — pre-Rust Codex wrote a *single
+     pretty-printed `.json`* per session (`{session, items[]}`), not
+     JSONL. Detect and skip-with-log (or read `items[]`); **never crash
+     the watcher.**
+   `~/.codex/session_index.jsonl` (`{id, thread_name, updated_at}`) is a
+   cheap discovery shortcut and gives a free session **title**.
+2. **Synthetic record id.** Codex has no per-record `uuid` but `entries`
+   keys on `(session_id, uuid)`. Synthesize a deterministic id =
+   `(session_id, line-ordinal)`. Append-only files make it stable →
+   re-ingest dedups via the existing `INSERT OR IGNORE`; resume from the
+   `ingest_state` byte offset.
+3. **A `source` discriminator** — one additive **nullable** column
+   (default `'claude'`), append-only-policy compliant. Codex entries are
+   `source='codex'`, so existing tools don't conflate the two corpora
+   and can filter.
+4. **The envelope→content transform.** Two-level unwrap (`line.type` →
+   `payload.type`); `message.role` + block type (`input_text` vs
+   `output_text`) give direction; `function_call.arguments` is a JSON
+   **string** (parse it); tool results are top-level lines re-associated
+   by `call_id`; reasoning is encrypted → placeholder.
+
+Stamp the header's `session_id` / `cwd` / `git` onto every derived
+record (Claude has these per line; Codex does not). Repo attribution can
+use `git.repository_url`/`branch` directly, falling back to `cwd`.
+
+## Parser posture (defensive by construction)
+
+There is **no schema-version field**; the format is serde-tolerant
+(`#[serde(other)]` catch-alls, field aliases) and ships near-daily. So
+map the envelope + the handful of core `response_item` inner types and
+**ignore unknown `type` / `payload.type`** rather than exhaustively
+modelling every variant. Unknown → skip-and-continue, never fail the
+file. (Aligns with the external-input defensive-coding rules.)
+
+## Explicitly out of scope (MVP)
+
+The four `~/.codex/*.sqlite` DBs (logs/memories/state/goals — the state
+DB is itself backfilled from the JSONL, which stays canonical);
+`~/.codex/history.jsonl` (global *input* keystroke history, not a
+transcript); decrypting `reasoning`; modelling Codex compaction /
+fork / `parent_thread_id` as chains; `event_msg` richness beyond
+optional `token_count`; any Codex-specific MCP / threads / decisions /
+images plumbing. **Just text + tool calls + tool results, attributed to
+a session / repo / timestamp, searchable.**
+
+## Cross-check references
+
+- Source (pinned `cfead68`): `codex-rs/rollout/src/{lib,recorder,compression,state_db}.rs`,
+  `codex-rs/protocol/src/{protocol,models}.rs`.
+- Existing third-party parsers to validate against:
+  `github.com/PixelPaw-Labs/codex-trace`,
+  `jazzyalex/agent-sessions` (both read `~/.codex/sessions/*.jsonl`).

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -155,6 +155,7 @@ func (r *Registry) ForUser(username string) (*store.Store, error) {
 	}
 	s.SetWorkspaceRoots(r.cfg.ResolvedWorkspaceRoots())
 	s.SetExtraProjectDirs(r.cfg.ExtraProjectDirs)
+	s.SetCodexRoots(store.CodexRootsFor(home)) // 🎯T99: index ~/.codex rollouts
 	s.SetTodoGlobs(r.cfg.TodoGlobs)
 
 	synthRoots := r.cfg.ResolvedSynthesisRoots()

--- a/internal/store/codex.go
+++ b/internal/store/codex.go
@@ -1,0 +1,430 @@
+// Codex transcript ingest (🎯T99). OpenAI's Codex CLI records sessions
+// as "rollout" JSONL under ~/.codex/sessions/<YYYY>/<MM>/<DD>/ (and
+// ~/.codex/archived_sessions/). The format is the OpenAI Responses API
+// item stream wrapped in a thin {timestamp, type, payload} envelope —
+// structurally unlike Claude Code's schema. This file transforms each
+// rollout into the same parsedFile intermediate the Claude path
+// produces, so the shared writer (writeParsedFile) and the entire
+// search/session machinery are reused. See docs/design/codex-ingest.md.
+package store
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// codexLine is the rollout envelope: every line is one of these.
+type codexLine struct {
+	Timestamp string          `json:"timestamp"`
+	Type      string          `json:"type"` // session_meta | response_item | event_msg | turn_context | ...
+	Payload   json.RawMessage `json:"payload"`
+}
+
+// codexPayload is the union of the payload fields we read across the
+// record types we care about. Unknown fields are ignored — the format
+// has no version stamp and evolves additively, so we pin to a tolerant
+// subset and skip what we don't recognise.
+type codexPayload struct {
+	Type string `json:"type"` // for response_item: message | function_call | reasoning | ...
+
+	// message
+	Role    string         `json:"role"`
+	Content []codexContent `json:"content"`
+
+	// tool calls (function-call shape, not Chat tool_calls)
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"` // function_call / tool_search_call
+	Input     json.RawMessage `json:"input"`     // custom_tool_call
+	CallID    string          `json:"call_id"`
+
+	// tool outputs
+	Output json.RawMessage `json:"output"`
+
+	// reasoning
+	Summary          []codexContent `json:"summary"`
+	EncryptedContent string         `json:"encrypted_content"`
+
+	// session_meta / turn_context
+	ID  string    `json:"id"`
+	Cwd string    `json:"cwd"`
+	Git *codexGit `json:"git"`
+}
+
+type codexContent struct {
+	Type string `json:"type"` // input_text | output_text | text
+	Text string `json:"text"`
+}
+
+type codexGit struct {
+	Branch        string `json:"branch"`
+	RepositoryURL string `json:"repository_url"`
+}
+
+var codexUUIDRe = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+
+// CodexRootsFor returns the candidate Codex rollout roots under a user's
+// home (honouring CODEX_HOME). These are passed to Store.SetCodexRoots by
+// registry.ForUser; existence is checked lazily by Store.codexDirs, so
+// roots that appear later (Codex installed after mnemo starts) are still
+// indexed.
+func CodexRootsFor(home string) []string {
+	base := os.Getenv("CODEX_HOME")
+	if base == "" {
+		base = filepath.Join(home, ".codex")
+	}
+	return []string{
+		filepath.Join(base, "sessions"),
+		filepath.Join(base, "archived_sessions"),
+	}
+}
+
+// isCodexRollout reports whether a path is a Codex rollout transcript
+// (rollout-<ts>-<uuid>.jsonl), so the watcher and batch ingest route it
+// to the Codex parser rather than the Claude one.
+func isCodexRollout(path string) bool {
+	base := filepath.Base(path)
+	return strings.HasPrefix(base, "rollout-") && strings.HasSuffix(base, ".jsonl")
+}
+
+// codexSessionID extracts the session UUID from a rollout filename
+// (rollout-<ts>-<uuid>.jsonl). The id is also in the session_meta line,
+// but the filename is available even when ingest resumes past that
+// header from a byte offset.
+func codexSessionID(path string) string {
+	base := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+	if m := codexUUIDRe.FindString(base); m != "" {
+		return m
+	}
+	return base
+}
+
+// codexProject derives a coarse project label from the session cwd.
+// Repo attribution proper happens in writeParsedFile via extractRepo;
+// this is just the stored project tag.
+func codexProject(cwd string) string {
+	if r := extractRepo(cwd); r != "" {
+		return r
+	}
+	if cwd != "" {
+		return filepath.Base(cwd)
+	}
+	return "codex"
+}
+
+// parseCodexFile reads a Codex rollout from the given byte offset and
+// transforms it into a parsedFile, mirroring parseFile's contract.
+// Pure computation — no DB access.
+func parseCodexFile(path string, offset int64) (parsedFile, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return parsedFile{}, err
+	}
+	defer f.Close()
+
+	if offset > 0 {
+		f.Seek(offset, 0)
+	}
+
+	pf := parsedFile{
+		path:      path,
+		sessionID: codexSessionID(path),
+		source:    "codex",
+	}
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1<<20), 8<<20) // Codex tool outputs can be large
+
+	lineStart := offset
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		thisStart := lineStart
+		lineStart += int64(len(line)) + 1 // +1 for the stripped '\n'
+		if len(line) == 0 {
+			continue
+		}
+
+		var cl codexLine
+		if json.Unmarshal(line, &cl) != nil {
+			continue // tolerate junk / unknown lines, never fail the file
+		}
+
+		switch cl.Type {
+		case "session_meta", "turn_context":
+			// Header / per-turn bookkeeping: harvest session metadata,
+			// emit no entry. cwd and git appear here, nowhere per-record.
+			var p codexPayload
+			if json.Unmarshal(cl.Payload, &p) == nil {
+				if p.Cwd != "" && pf.cwd == "" {
+					pf.cwd = p.Cwd
+				}
+				if p.Git != nil && p.Git.Branch != "" && pf.branch == "" {
+					pf.branch = p.Git.Branch
+				}
+			}
+			continue
+		case "response_item":
+			// conversation content — handled below
+		default:
+			continue // event_msg, compacted, world_state, inter_agent_* …
+		}
+
+		var p codexPayload
+		if json.Unmarshal(cl.Payload, &p) != nil {
+			continue
+		}
+
+		entryType, msgs, ok := codexRecord(&p)
+		if !ok {
+			continue
+		}
+
+		ts := cl.Timestamp
+		if ts == "" {
+			ts = time.Now().Format(time.RFC3339)
+		}
+
+		// Store the original envelope plus an injected synthetic uuid —
+		// Codex records carry none, and the entries.uuid generated
+		// column (raw->>'$.uuid') drives (session_id, uuid) dedup. The
+		// line's byte offset is a stable, content-independent
+		// discriminator, so re-ingest is idempotent.
+		uuid := fmt.Sprintf("codex-%s-%d", pf.sessionID, thisStart)
+		entryIdx := len(pf.entries)
+		pf.entries = append(pf.entries, parsedRawEntry{
+			entryType: entryType,
+			timestamp: ts,
+			raw:       injectCodexUUID(line, uuid),
+		})
+
+		for _, m := range msgs {
+			m.entryIdx = entryIdx
+			m.timestamp = ts
+			if pf.topic == "" && entryType == "user" && m.contentType == "text" &&
+				m.isNoise == 0 && len(m.text) >= 10 && !isBoilerplate(m.text) &&
+				!isCodexInjectedContext(m.text) {
+				pf.topic = m.text
+				if len(pf.topic) > 200 {
+					pf.topic = pf.topic[:197] + "..."
+				}
+			}
+			pf.messages = append(pf.messages, m)
+		}
+	}
+
+	pf.newOffset, _ = f.Seek(0, 1)
+	pf.project = codexProject(pf.cwd)
+	return pf, nil
+}
+
+// codexRecord maps one response_item payload to an entry type and its
+// content messages, in the Claude content-block vocabulary. Returns
+// ok=false for records we deliberately skip (developer/system messages,
+// unknown payload types).
+func codexRecord(p *codexPayload) (entryType string, msgs []parsedMessage, ok bool) {
+	switch p.Type {
+	case "message":
+		role := codexRole(p.Role)
+		if role == "" {
+			return "", nil, false // skip developer/system/unknown roles
+		}
+		text := codexJoinText(p.Content)
+		if text == "" {
+			return "", nil, false
+		}
+		noise := 0
+		if isNoise(text) {
+			noise = 1
+		}
+		return role, []parsedMessage{{
+			role: role, typ: role, text: text, contentType: "text", isNoise: noise,
+		}}, true
+
+	case "function_call", "custom_tool_call", "local_shell_call", "tool_search_call", "web_search_call":
+		toolInput, text := codexToolInput(p)
+		return "assistant", []parsedMessage{{
+			role: "assistant", typ: "assistant", contentType: "tool_use",
+			toolName: p.Name, toolUseID: p.CallID, toolInput: toolInput, text: text,
+		}}, true
+
+	case "function_call_output", "custom_tool_call_output", "tool_search_output":
+		return "user", []parsedMessage{{
+			role: "user", typ: "user", contentType: "tool_result",
+			toolUseID: p.CallID, text: codexOutputText(p.Output),
+		}}, true
+
+	case "reasoning":
+		return "assistant", []parsedMessage{{
+			role: "assistant", typ: "assistant", contentType: "thinking",
+			text: codexReasoningText(p),
+		}}, true
+	}
+	return "", nil, false
+}
+
+// isCodexInjectedContext reports whether a user-role message is Codex's
+// injected session preamble (the AGENTS.md blob, environment/user
+// instructions) rather than a real human turn — so it isn't mistaken for
+// the session topic.
+func isCodexInjectedContext(text string) bool {
+	return strings.HasPrefix(text, "# AGENTS.md") ||
+		strings.HasPrefix(text, "<environment_context>") ||
+		strings.HasPrefix(text, "<user_instructions>")
+}
+
+// codexRole maps a Responses-API role to the Claude entry/message role
+// vocabulary. Developer/system instruction turns are skipped (empty).
+func codexRole(role string) string {
+	switch role {
+	case "user":
+		return "user"
+	case "assistant":
+		return "assistant"
+	default:
+		return ""
+	}
+}
+
+// codexJoinText concatenates the text of input_text/output_text/text
+// content items.
+func codexJoinText(content []codexContent) string {
+	var b strings.Builder
+	for _, c := range content {
+		switch c.Type {
+		case "input_text", "output_text", "text":
+			if c.Text == "" {
+				continue
+			}
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(c.Text)
+		}
+	}
+	return b.String()
+}
+
+// codexToolInput resolves a tool call's structured input. function_call
+// arguments are a JSON-encoded *string*; custom_tool_call input is plain
+// text; tool_search_call arguments are a JSON object. Returns valid JSON
+// bytes for tool_input when the input is a JSON object (so the messages
+// tool_* generated columns work), otherwise surfaces it as searchable
+// text and leaves tool_input nil.
+func codexToolInput(p *codexPayload) (toolInput []byte, text string) {
+	raw := p.Arguments
+	if len(raw) == 0 {
+		raw = p.Input
+	}
+	if len(raw) == 0 {
+		return nil, ""
+	}
+	// A JSON string: unquote, then decide whether the inner content is a
+	// JSON object (function_call args) or plain text (apply_patch input).
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		if isJSONObject([]byte(s)) {
+			return []byte(s), ""
+		}
+		return nil, s
+	}
+	// A bare JSON value (object/array), e.g. tool_search_call args.
+	if isJSONObject(raw) {
+		return append([]byte(nil), raw...), ""
+	}
+	return nil, string(raw)
+}
+
+// codexOutputText flattens a tool-output payload (a JSON string, or a
+// structured array/object) into searchable text.
+func codexOutputText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	return string(raw)
+}
+
+// codexReasoningText returns any visible reasoning summary; encrypted
+// chains of thought are opaque, so they become a placeholder rather than
+// indexable text.
+func codexReasoningText(p *codexPayload) string {
+	if t := codexJoinText(p.Summary); t != "" {
+		return t
+	}
+	if p.EncryptedContent != "" {
+		return "[encrypted reasoning]"
+	}
+	return ""
+}
+
+// isJSONObject reports whether b is a valid JSON object (starts with
+// '{'). Only objects go into messages.tool_input, which is stored via
+// jsonb() and feeds object-shaped tool_* generated columns.
+func isJSONObject(b []byte) bool {
+	t := strings.TrimSpace(string(b))
+	return len(t) > 0 && t[0] == '{' && json.Valid(b)
+}
+
+// injectCodexUUID returns the rollout line with a synthetic "uuid" field
+// inserted right after the opening brace, preserving the original bytes
+// otherwise (full-fidelity raw + a dedup key).
+func injectCodexUUID(line []byte, uuid string) []byte {
+	if len(line) == 0 || line[0] != '{' {
+		return append([]byte(nil), line...)
+	}
+	rest := line[1:]
+	if strings.TrimSpace(string(rest)) == "}" { // empty object edge case
+		return []byte(`{"uuid":"` + uuid + `"}`)
+	}
+	prefix := `{"uuid":"` + uuid + `",`
+	out := make([]byte, 0, len(prefix)+len(rest))
+	out = append(out, prefix...)
+	out = append(out, rest...)
+	return out
+}
+
+// ingestCodexFile ingests a single Codex rollout incrementally from its
+// recorded offset, reusing the shared writer. The watcher's analogue of
+// ingestFile for the Codex source.
+func (s *Store) ingestCodexFile(path string) error {
+	s.mu.Lock()
+	offset := s.offsets[path]
+	s.mu.Unlock()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil // file deleted between event and stat
+		}
+		return err
+	}
+	if offset >= info.Size() {
+		return nil // nothing new
+	}
+
+	pf, err := parseCodexFile(path, offset)
+	if err != nil {
+		return err
+	}
+
+	ws, err := newWriterState(s.writeDB)
+	if err != nil {
+		return err
+	}
+	defer func() { ws.tx.Rollback() }()
+	defer ws.Close()
+
+	s.writeParsedFile(ws, pf)
+
+	ws.Close()
+	return ws.tx.Commit()
+}

--- a/internal/store/codex_test.go
+++ b/internal/store/codex_test.go
@@ -1,0 +1,243 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const codexSessUUID = "019ee2a8-189f-7540-a035-1cc6ee7bd02f"
+
+// codexFixtureLines returns a representative Codex rollout: header,
+// per-turn context, user/assistant messages, a function call + output,
+// an apply_patch custom tool call, encrypted reasoning, plus records we
+// must skip (a developer instruction message and an event_msg).
+func codexFixtureLines(t *testing.T, cwd string) []byte {
+	t.Helper()
+	line := func(typ string, payload map[string]any) map[string]any {
+		return map[string]any{"timestamp": "2026-06-30T10:00:00.000Z", "type": typ, "payload": payload}
+	}
+	records := []map[string]any{
+		line("session_meta", map[string]any{
+			"id":  codexSessUUID,
+			"cwd": cwd,
+			"git": map[string]any{"branch": "main", "repository_url": "https://github.com/acme/webapp"},
+		}),
+		line("turn_context", map[string]any{"cwd": cwd, "model": "gpt-5.5"}),
+		line("response_item", map[string]any{
+			"type": "message", "role": "developer",
+			"content": []map[string]any{{"type": "input_text", "text": "<permissions instructions> ... long system blob ..."}},
+		}),
+		line("response_item", map[string]any{
+			"type": "message", "role": "user",
+			"content": []map[string]any{{"type": "input_text", "text": "How do I fix the authentication bug?"}},
+		}),
+		line("response_item", map[string]any{
+			"type": "reasoning", "summary": []map[string]any{}, "encrypted_content": "gAAAAABopaque",
+		}),
+		line("response_item", map[string]any{
+			"type": "function_call", "name": "shell",
+			"arguments": `{"command":["go","build"]}`, "call_id": "call_1",
+		}),
+		line("event_msg", map[string]any{"type": "token_count", "info": map[string]any{"total_tokens": 1234}}),
+		line("response_item", map[string]any{
+			"type": "function_call_output", "call_id": "call_1", "output": "build succeeded",
+		}),
+		line("response_item", map[string]any{
+			"type": "custom_tool_call", "name": "apply_patch",
+			"input": "*** Begin Patch\n*** Update File: main.go\n*** End Patch\n", "call_id": "call_2",
+		}),
+		line("response_item", map[string]any{
+			"type": "message", "role": "assistant",
+			"content": []map[string]any{{"type": "output_text", "text": "Fixed the authentication bug in the login handler."}},
+		}),
+	}
+	var b strings.Builder
+	for _, r := range records {
+		raw, err := json.Marshal(r)
+		if err != nil {
+			t.Fatalf("marshal fixture: %v", err)
+		}
+		b.Write(raw)
+		b.WriteByte('\n')
+	}
+	return []byte(b.String())
+}
+
+func writeCodexRollout(t *testing.T, dir, cwd string) string {
+	t.Helper()
+	day := filepath.Join(dir, "sessions", "2026", "06", "30")
+	if err := os.MkdirAll(day, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(day, "rollout-2026-06-30T10-00-00-"+codexSessUUID+".jsonl")
+	if err := os.WriteFile(path, codexFixtureLines(t, cwd), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestParseCodexFile(t *testing.T) {
+	cwd := "/Users/dev/work/github.com/acme/webapp"
+	dir := t.TempDir()
+	path := writeCodexRollout(t, dir, cwd)
+
+	pf, err := parseCodexFile(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pf.source != "codex" {
+		t.Errorf("source = %q, want codex", pf.source)
+	}
+	if pf.sessionID != codexSessUUID {
+		t.Errorf("sessionID = %q, want %q", pf.sessionID, codexSessUUID)
+	}
+	if pf.cwd != cwd {
+		t.Errorf("cwd = %q, want %q", pf.cwd, cwd)
+	}
+	if pf.branch != "main" {
+		t.Errorf("branch = %q, want main", pf.branch)
+	}
+	if pf.project != "acme/webapp" {
+		t.Errorf("project = %q, want acme/webapp", pf.project)
+	}
+	if !strings.Contains(pf.topic, "authentication bug") {
+		t.Errorf("topic = %q, want first user message", pf.topic)
+	}
+
+	// 6 response_items map to entries; developer message, event_msg,
+	// session_meta and turn_context are dropped.
+	if len(pf.entries) != 6 {
+		t.Fatalf("entries = %d, want 6", len(pf.entries))
+	}
+	if len(pf.messages) != 6 {
+		t.Fatalf("messages = %d, want 6", len(pf.messages))
+	}
+
+	// The first entry's raw must carry the injected synthetic uuid so
+	// (session_id, uuid) dedup works; Codex records have none natively.
+	var first map[string]any
+	if err := json.Unmarshal(pf.entries[0].raw, &first); err != nil {
+		t.Fatalf("entry raw not valid JSON: %v", err)
+	}
+	if uuid, _ := first["uuid"].(string); !strings.HasPrefix(uuid, "codex-"+codexSessUUID+"-") {
+		t.Errorf("entry uuid = %v, want codex-<session>-<offset> prefix", first["uuid"])
+	}
+
+	// Index the messages by a (contentType, role) probe for assertions.
+	byType := map[string][]parsedMessage{}
+	for _, m := range pf.messages {
+		byType[m.contentType] = append(byType[m.contentType], m)
+	}
+
+	// user/assistant text.
+	var sawUser, sawAssistant bool
+	for _, m := range byType["text"] {
+		if m.role == "user" && strings.Contains(m.text, "authentication bug") {
+			sawUser = true
+		}
+		if m.role == "assistant" && strings.Contains(m.text, "Fixed the authentication") {
+			sawAssistant = true
+		}
+	}
+	if !sawUser || !sawAssistant {
+		t.Errorf("missing user/assistant text messages (user=%v assistant=%v)", sawUser, sawAssistant)
+	}
+
+	// tool_use: shell with JSON args, and apply_patch with text input.
+	var shell, patch *parsedMessage
+	for i := range byType["tool_use"] {
+		m := &byType["tool_use"][i]
+		switch m.toolName {
+		case "shell":
+			shell = m
+		case "apply_patch":
+			patch = m
+		}
+	}
+	if shell == nil || shell.toolUseID != "call_1" || !json.Valid(shell.toolInput) ||
+		!strings.Contains(string(shell.toolInput), "command") {
+		t.Errorf("shell tool_use malformed: %+v", shell)
+	}
+	if patch == nil || patch.toolUseID != "call_2" || patch.toolInput != nil ||
+		!strings.Contains(patch.text, "Begin Patch") {
+		t.Errorf("apply_patch tool_use malformed: %+v", patch)
+	}
+
+	// tool_result paired to the shell call by call_id.
+	if rs := byType["tool_result"]; len(rs) != 1 || rs[0].toolUseID != "call_1" || rs[0].text != "build succeeded" {
+		t.Errorf("tool_result = %+v, want call_1 / build succeeded", byType["tool_result"])
+	}
+
+	// reasoning: encrypted chain → placeholder.
+	if th := byType["thinking"]; len(th) != 1 || th[0].text != "[encrypted reasoning]" {
+		t.Errorf("thinking = %+v, want [encrypted reasoning]", byType["thinking"])
+	}
+}
+
+func TestCodexIngestEndToEnd(t *testing.T) {
+	codexDir := t.TempDir()
+	cwd := "/Users/dev/work/github.com/acme/webapp"
+	writeCodexRollout(t, codexDir, cwd)
+
+	s := newTestStore(t, t.TempDir()) // empty Claude project dir
+	s.SetCodexRoots([]string{filepath.Join(codexDir, "sessions")})
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Codex content is searchable.
+	results, err := s.Search("authentication", 10, "all", "", 0, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 || results[0].SessionID != codexSessUUID {
+		t.Fatalf("search did not surface the Codex session: %+v", results)
+	}
+
+	// session_meta records the source and repo attribution.
+	var source, repo string
+	if err := s.readDB.QueryRow(
+		`SELECT source, repo FROM session_meta WHERE session_id = ?`, codexSessUUID,
+	).Scan(&source, &repo); err != nil {
+		t.Fatalf("session_meta query: %v", err)
+	}
+	if source != "codex" {
+		t.Errorf("session_meta.source = %q, want codex", source)
+	}
+	if repo != "acme/webapp" {
+		t.Errorf("session_meta.repo = %q, want acme/webapp", repo)
+	}
+
+	entryCount := func() int {
+		var n int
+		if err := s.readDB.QueryRow(`SELECT count(*) FROM entries WHERE session_id = ?`, codexSessUUID).Scan(&n); err != nil {
+			t.Fatalf("count query: %v", err)
+		}
+		return n
+	}
+	if got := entryCount(); got != 6 {
+		t.Fatalf("entries after ingest = %d, want 6", got)
+	}
+
+	// Idempotency: re-ingesting the same rollout from offset 0 must not
+	// duplicate rows — the synthetic (session_id, uuid) dedup holds.
+	s.mu.Lock()
+	for p := range s.offsets {
+		s.offsets[p] = 0
+	}
+	s.mu.Unlock()
+	path := writeCodexRollout(t, codexDir, cwd)
+	if err := s.ingestCodexFile(path); err != nil {
+		t.Fatal(err)
+	}
+	if got := entryCount(); got != 6 {
+		t.Errorf("entries after re-ingest = %d, want 6 (dedup)", got)
+	}
+}

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -476,7 +476,12 @@ CREATE TABLE session_meta (
 			-- over-broad excludeCWD prefix check that wrongly skipped real
 			-- dev sessions sharing the mnemo repo cwd. Additive, defaulted:
 			-- old rows read as 0 (eligible) until re-ingest tags a marker.
-			compactor_internal INTEGER NOT NULL DEFAULT 0
+			compactor_internal INTEGER NOT NULL DEFAULT 0,
+			-- 🎯T99 multi-agent provenance: which coding agent produced
+			-- this session's transcript. 'claude' for ~/.claude/projects
+			-- rollouts (the default, so existing rows read correctly),
+			-- 'codex' for ~/.codex/sessions rollouts. Additive, defaulted.
+			source TEXT NOT NULL DEFAULT 'claude'
 		);
 
 CREATE TABLE session_nonces (

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -99,6 +99,14 @@ type Store struct {
 	// non-repo planning spaces. Mutated only via SetSynthesisRoots.
 	synthesisRoots []string
 
+	// codexRoots are the candidate Codex rollout roots (~/.codex/sessions,
+	// ~/.codex/archived_sessions) ingested alongside the Claude project
+	// dirs (🎯T99). Configured at construction (registry.ForUser) rather
+	// than discovered globally, so New-based tests stay hermetic and
+	// don't pull in the developer's real ~/.codex. Mutated only via
+	// SetCodexRoots; existence is checked lazily in codexDirs.
+	codexRoots []string
+
 	// todoGlobs are extra repo-relative globs that IngestTodos matches
 	// when discovering TODO files, beyond the default TODO.md / todos.md
 	// names (🎯T78). Mutated only via SetTodoGlobs, read under
@@ -188,6 +196,37 @@ func (s *Store) SetExtraProjectDirs(dirs []string) {
 		return
 	}
 	s.extraProjectDirs = append(s.extraProjectDirs[:0:0], dirs...)
+}
+
+// SetCodexRoots configures the Codex rollout roots ingested alongside
+// the Claude project dirs (🎯T99). Pass the candidate directories
+// (CodexRootsFor); existence is checked lazily by codexDirs so roots
+// created after startup (Codex installed later) are still picked up.
+// Call once after Store.New.
+func (s *Store) SetCodexRoots(roots []string) {
+	s.rootsMu.Lock()
+	defer s.rootsMu.Unlock()
+	if len(roots) == 0 {
+		s.codexRoots = nil
+		return
+	}
+	s.codexRoots = append(s.codexRoots[:0:0], roots...)
+}
+
+// codexDirs returns the configured Codex rollout roots that currently
+// exist on disk. Empty when Codex roots weren't configured (e.g. New-
+// based tests) or ~/.codex isn't present, making the feature a no-op.
+func (s *Store) codexDirs() []string {
+	s.rootsMu.RLock()
+	roots := append([]string(nil), s.codexRoots...)
+	s.rootsMu.RUnlock()
+	var out []string
+	for _, d := range roots {
+		if info, err := os.Stat(d); err == nil && info.IsDir() {
+			out = append(out, d)
+		}
+	}
+	return out
 }
 
 // SetSynthesisRoots configures the filesystem roots walked by
@@ -2711,6 +2750,9 @@ type parsedFile struct {
 	branch    string
 	topic     string
 	newOffset int64
+	// source is the producing agent ('claude' or 'codex'). Empty means
+	// 'claude' (the default for ~/.claude/projects transcripts).
+	source string
 }
 
 // IngestAll scans the project directory and ingests all JSONL files
@@ -2729,7 +2771,10 @@ func (s *Store) IngestAll() error {
 		offset int64 // already-ingested offset
 	}
 	var files []fileEntry
-	for _, dir := range s.projectDirs() {
+	// Codex rollout roots (~/.codex/sessions, archived_sessions) are
+	// walked alongside the Claude project dirs; the worker routes each
+	// file to the right parser by path (🎯T99).
+	for _, dir := range append(s.projectDirs(), s.codexDirs()...) {
 		if _, err := os.Stat(dir); err != nil {
 			if os.IsNotExist(err) {
 				slog.Warn("project dir unavailable, skipping", "dir", dir)
@@ -2781,7 +2826,11 @@ func (s *Store) IngestAll() error {
 		go func() {
 			defer wg.Done()
 			for fe := range pathCh {
-				if pf, err := parseFile(fe.path, fe.offset); err == nil {
+				parse := parseFile
+				if isCodexRollout(fe.path) {
+					parse = parseCodexFile
+				}
+				if pf, err := parse(fe.path, fe.offset); err == nil {
 					parsedCh <- pf
 				} else {
 					slog.Warn("parse failed", "file", filepath.Base(fe.path), "err", err)
@@ -2921,78 +2970,7 @@ func (s *Store) runWriter(parsedCh <-chan parsedFile, totalFiles int) error {
 				"rate", fmt.Sprintf("%.1f files/s", rate),
 				"eta", eta.Round(time.Second))
 		}
-		// Insert all raw entries and build entryIdx→entryID map.
-		// INSERT OR IGNORE skips duplicate (session_id, uuid) pairs, so
-		// only record the entry ID when a row was actually inserted.
-		entryIDs := make(map[int]int64, len(pf.entries))
-		for i, e := range pf.entries {
-			result, err := ws.entryStmt.Exec(pf.sessionID, pf.project, e.entryType, e.timestamp, string(e.raw))
-			if err != nil {
-				slog.Warn("entry insert failed", "session", pf.sessionID, "err", err)
-				continue
-			}
-			n, _ := result.RowsAffected()
-			if n > 0 {
-				if id, err := result.LastInsertId(); err == nil {
-					entryIDs[i] = id
-				}
-			}
-		}
-
-		// Insert content block messages linked to their entries.
-		// Skip messages whose entry was a duplicate (INSERT OR IGNORE, entryID == 0).
-		compactorInternal := 0
-		for _, m := range pf.messages {
-			entryID := entryIDs[m.entryIdx]
-			if entryID == 0 {
-				continue // entry was duplicate — skip associated messages
-			}
-			var toolInput any
-			if m.toolInput != nil {
-				toolInput = string(m.toolInput)
-			}
-			ws.msgStmt.Exec(entryID, pf.sessionID, pf.project, m.role, m.text, m.timestamp, m.typ, m.isNoise,
-				m.contentType, m.toolName, m.toolUseID, toolInput, m.isError)
-
-			// Detect self-identification nonces.
-			if m.contentType == "text" && strings.HasPrefix(m.text, NoncePrefix) {
-				ws.tx.Exec("INSERT OR IGNORE INTO session_nonces (nonce, session_id) VALUES (?, ?)",
-					strings.TrimSpace(m.text), pf.sessionID)
-			}
-
-			// 🎯T72 recursion guard: flag claudia-spawned compaction runs
-			// by the marker on their opening prompt.
-			if m.contentType == "text" && IsCompactorMarker(m.text) {
-				compactorInternal = 1
-			}
-		}
-
-		// Upsert session metadata.
-		if pf.cwd != "" || pf.branch != "" || pf.topic != "" || compactorInternal == 1 {
-			repo := extractRepo(pf.cwd)
-			workType := classifyWorkType(pf.branch)
-			ws.tx.Exec(`INSERT INTO session_meta (session_id, repo, cwd, git_branch, work_type, topic, compactor_internal)
-				VALUES (?, ?, ?, ?, ?, ?, ?)
-				ON CONFLICT(session_id) DO UPDATE SET
-					repo = CASE WHEN excluded.repo != '' THEN excluded.repo ELSE session_meta.repo END,
-					cwd = CASE WHEN excluded.cwd != '' THEN excluded.cwd ELSE session_meta.cwd END,
-					git_branch = CASE WHEN excluded.git_branch != '' THEN excluded.git_branch ELSE session_meta.git_branch END,
-					work_type = CASE WHEN excluded.work_type != '' THEN excluded.work_type ELSE session_meta.work_type END,
-					topic = CASE WHEN excluded.topic != '' AND session_meta.topic = '' THEN excluded.topic ELSE session_meta.topic END,
-					compactor_internal = MAX(session_meta.compactor_internal, excluded.compactor_internal)`,
-				pf.sessionID, repo, pf.cwd, pf.branch, workType, pf.topic, compactorInternal)
-		}
-
-		// Update ingest offset + fingerprint (🎯T68.6 same-size
-		// rewrite detection). recordedSize/Mtime is nullable; an
-		// os.Stat error just records NULL — detection falls back to
-		// offset-vs-size on the next pass.
-		recSize, recMtime := statFingerprint(pf.path)
-		ws.tx.Exec(`INSERT OR REPLACE INTO ingest_state (path, offset, recorded_size, recorded_mtime)
-			VALUES (?, ?, ?, ?)`, pf.path, pf.newOffset, recSize, recMtime)
-		s.mu.Lock()
-		s.offsets[pf.path] = pf.newOffset
-		s.mu.Unlock()
+		s.writeParsedFile(ws, pf)
 
 		// Commit periodically.
 		if time.Since(lastCommit) >= commitInterval {
@@ -3005,6 +2983,92 @@ func (s *Store) runWriter(parsedCh <-chan parsedFile, totalFiles int) error {
 	// Final commit.
 	ws.Close()
 	return ws.tx.Commit()
+}
+
+// writeParsedFile inserts one parsed transcript file (entries, content
+// messages, session metadata, and the ingest offset) into the open
+// writer transaction. Shared by the parallel batch writer (runWriter)
+// and the single-file Codex path (ingestCodexFile), so both sources go
+// through identical insert logic. Best-effort: individual insert
+// failures are logged, not propagated, matching the original loop.
+func (s *Store) writeParsedFile(ws *writerState, pf parsedFile) {
+	// Insert all raw entries and build entryIdx→entryID map.
+	// INSERT OR IGNORE skips duplicate (session_id, uuid) pairs, so
+	// only record the entry ID when a row was actually inserted.
+	entryIDs := make(map[int]int64, len(pf.entries))
+	for i, e := range pf.entries {
+		result, err := ws.entryStmt.Exec(pf.sessionID, pf.project, e.entryType, e.timestamp, string(e.raw))
+		if err != nil {
+			slog.Warn("entry insert failed", "session", pf.sessionID, "err", err)
+			continue
+		}
+		n, _ := result.RowsAffected()
+		if n > 0 {
+			if id, err := result.LastInsertId(); err == nil {
+				entryIDs[i] = id
+			}
+		}
+	}
+
+	// Insert content block messages linked to their entries.
+	// Skip messages whose entry was a duplicate (INSERT OR IGNORE, entryID == 0).
+	compactorInternal := 0
+	for _, m := range pf.messages {
+		entryID := entryIDs[m.entryIdx]
+		if entryID == 0 {
+			continue // entry was duplicate — skip associated messages
+		}
+		var toolInput any
+		if m.toolInput != nil {
+			toolInput = string(m.toolInput)
+		}
+		ws.msgStmt.Exec(entryID, pf.sessionID, pf.project, m.role, m.text, m.timestamp, m.typ, m.isNoise,
+			m.contentType, m.toolName, m.toolUseID, toolInput, m.isError)
+
+		// Detect self-identification nonces.
+		if m.contentType == "text" && strings.HasPrefix(m.text, NoncePrefix) {
+			ws.tx.Exec("INSERT OR IGNORE INTO session_nonces (nonce, session_id) VALUES (?, ?)",
+				strings.TrimSpace(m.text), pf.sessionID)
+		}
+
+		// 🎯T72 recursion guard: flag claudia-spawned compaction runs
+		// by the marker on their opening prompt.
+		if m.contentType == "text" && IsCompactorMarker(m.text) {
+			compactorInternal = 1
+		}
+	}
+
+	// Upsert session metadata.
+	if pf.cwd != "" || pf.branch != "" || pf.topic != "" || compactorInternal == 1 || pf.source != "" {
+		repo := extractRepo(pf.cwd)
+		workType := classifyWorkType(pf.branch)
+		source := pf.source
+		if source == "" {
+			source = "claude"
+		}
+		ws.tx.Exec(`INSERT INTO session_meta (session_id, repo, cwd, git_branch, work_type, topic, compactor_internal, source)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(session_id) DO UPDATE SET
+				repo = CASE WHEN excluded.repo != '' THEN excluded.repo ELSE session_meta.repo END,
+				cwd = CASE WHEN excluded.cwd != '' THEN excluded.cwd ELSE session_meta.cwd END,
+				git_branch = CASE WHEN excluded.git_branch != '' THEN excluded.git_branch ELSE session_meta.git_branch END,
+				work_type = CASE WHEN excluded.work_type != '' THEN excluded.work_type ELSE session_meta.work_type END,
+				topic = CASE WHEN excluded.topic != '' AND session_meta.topic = '' THEN excluded.topic ELSE session_meta.topic END,
+				compactor_internal = MAX(session_meta.compactor_internal, excluded.compactor_internal),
+				source = CASE WHEN excluded.source != '' THEN excluded.source ELSE session_meta.source END`,
+			pf.sessionID, repo, pf.cwd, pf.branch, workType, pf.topic, compactorInternal, source)
+	}
+
+	// Update ingest offset + fingerprint (🎯T68.6 same-size
+	// rewrite detection). recordedSize/Mtime is nullable; an
+	// os.Stat error just records NULL — detection falls back to
+	// offset-vs-size on the next pass.
+	recSize, recMtime := statFingerprint(pf.path)
+	ws.tx.Exec(`INSERT OR REPLACE INTO ingest_state (path, offset, recorded_size, recorded_mtime)
+		VALUES (?, ?, ?, ?)`, pf.path, pf.newOffset, recSize, recMtime)
+	s.mu.Lock()
+	s.offsets[pf.path] = pf.newOffset
+	s.mu.Unlock()
 }
 
 // parseFile reads and parses a JSONL transcript file, returning all
@@ -3140,6 +3204,19 @@ func (s *Store) Watch() error {
 		})
 	}
 
+	// Watch Codex rollout roots (🎯T99). Date-nested subdirs created
+	// later are picked up by the fsnotify Create→watcher.Add path below.
+	for _, dir := range s.codexDirs() {
+		filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err == nil && info.IsDir() {
+				if wErr := watcher.Add(path); wErr != nil {
+					slog.Warn("failed to watch codex directory", "path", path, "err", wErr)
+				}
+			}
+			return nil
+		})
+	}
+
 	// Also watch the skills directory for .md changes.
 	if sdir, err := skillsDir(); err == nil {
 		if wErr := watcher.Add(sdir); wErr != nil {
@@ -3199,6 +3276,12 @@ func (s *Store) Watch() error {
 			if strings.HasSuffix(name, ".jsonl") &&
 				(event.Has(fsnotify.Write) || event.Has(fsnotify.Create)) {
 				db.enqueue(name, func() {
+					if isCodexRollout(name) {
+						if err := s.ingestCodexFile(name); err != nil {
+							slog.Error("ingest codex failed", "file", name, "err", err)
+						}
+						return
+					}
 					if err := s.ingestFile(name); err != nil {
 						slog.Error("ingest failed", "file", name, "err", err)
 					}


### PR DESCRIPTION
Adds a second transcript source: OpenAI **Codex CLI** rollout JSONL under `~/.codex/sessions` (and `archived_sessions`), indexed alongside Claude Code transcripts.

## What & why
Codex records the OpenAI Responses API item stream wrapped in a thin `{timestamp, type, payload}` envelope — structurally unlike Claude's schema. A new parser (`internal/store/codex.go`) transforms each rollout into the same `parsedFile` intermediate the Claude path produces, so the existing watcher / ingest-offset / repo-attribution / search / session machinery is reused unchanged.

## How
- **`parseCodexFile`** maps `response_item` records to entries+messages: `message`→text, `function_call`/`custom_tool_call`/`tool_search_call`→`tool_use`, `*_output`→`tool_result` (paired by `call_id`), `reasoning`→placeholder (encrypted chains aren't indexable). `session_meta`/`turn_context`/`event_msg`/developer turns are skipped. Unknown envelope/payload types are tolerated, never fatal.
- **Synthetic id**: Codex records have no `uuid`, so a deterministic `(session_id, line-byte-offset)` uuid is injected into `raw` → `(session_id, uuid)` dedup + idempotent re-ingest.
- **Shared writer**: `runWriter`'s per-file body is factored into `writeParsedFile`, used by both the batch pipeline and the single-file Codex watcher path (`ingestCodexFile`).
- **`session_meta.source`**: additive column (`'claude'` default, `'codex'` for rollouts) discriminates the corpora. Schema change is additive-only (sqlift `AllowNone`-safe).
- **Hermetic config**: Codex roots are a configured `Store` field set by `registry.ForUser` from the user's home — `New`-based tests don't pull in real `~/.codex`.

## Scope (MVP — "capture transcripts, not much else")
Out of scope: the `~/.codex/*.sqlite` DBs, `history.jsonl`, decrypting reasoning, chain/compaction modeling, `event_msg` richness beyond what's needed, Codex-specific tooling.

## Tests
Parser unit test over a representative rollout + end-to-end ingest (search, source tagging, repo attribution, dedup idempotency). Smoke-verified against real `~/.codex` rollouts (445–2555 entries each, healthy text/thinking/tool_use/tool_result split). `go test -tags sqlite_fts5 ./...` green.

Design of record: `docs/design/codex-ingest.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)