### PR TITLE
Document Codex CLI ingest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,12 @@ a SQLite FTS5 index, and exposes search/query tools via MCP. Watches
 for new transcripts in realtime. Indexes all content block types:
 text, tool_use, tool_result, and thinking.
 
+Also ingests OpenAI **Codex CLI** rollout transcripts from
+`~/.codex/sessions/` (and `archived_sessions/`) — its OpenAI
+Responses-API records are transformed into the same content model and
+flow through the same search/session machinery, tagged
+`session_meta.source = 'codex'`. See `docs/design/codex-ingest.md`.
+
 ## Build & Run
 
 ```bash

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -3310,3 +3310,25 @@ targets:
     - agent
     origin: manual
     discovered: 2026-06-30
+  T99:
+    name: mnemo ingests Codex CLI session transcripts into the existing searchable index
+    status: achieved
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - mnemo discovers and watches Codex rollout files under ~/.codex/sessions/** and ~/.codex/archived_sessions/ recursively; Codex roots are a configured Store field so New-based tests stay hermetic.
+    - 'A rollout is transformed into mnemo''s content model via parseCodexFile: response_item/message -> role+text, function_call/custom_tool_call/tool_search_call -> tool_use, *_output -> tool_result (paired by call_id), reasoning -> placeholder; session_meta/turn_context/event_msg/developer turns skipped.'
+    - Each Codex record gets a deterministic synthetic (session_id, line-offset) uuid injected into raw so re-ingest is idempotent via INSERT OR IGNORE; ingest resumes from the ingest_state byte offset.
+    - session_meta carries an additive `source` column (default 'claude'); Codex sessions are source='codex' and existing mnemo_search/mnemo_sessions surface them; the batch and watcher paths share one writeParsedFile writer.
+    - The parser tolerates unknown envelope/payload types and junk lines rather than failing, surviving codex-rs format churn.
+    - Unit + end-to-end tests pass (parse, search, source tagging, repo attribution, dedup); shipped in v0.59.0. docs/design/codex-ingest.md is the design of record.
+    context: 'MVP Codex transcript ingest. Codex records OpenAI Responses API items in a {timestamp,type,payload} envelope under ~/.codex/sessions; parseCodexFile (codex.go) transforms each into the shared parsedFile intermediate, reusing the watcher/ingest_state/repo/search spine via a factored writeParsedFile writer. session_meta.source discriminates corpora; Codex roots configured via registry.ForUser for test hermeticity. Merged in PR #135; design in docs/design/codex-ingest.md.'
+    tags:
+    - codex
+    - ingest
+    - multi-agent
+    - parser
+    - mvp
+    origin: manual
+    discovered: 2026-06-30
+    achieved: 2026-06-30

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.58.0"
+	version              = "0.59.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
Release prep for **v0.59.0**, whose headline is Codex CLI transcript ingest (feature landed in #135).

This PR carries:
- **Version bump** to `0.59.0` (`main.go`).
- **Docs**: project `CLAUDE.md` "What it does" now describes Codex rollout ingest (`~/.codex/sessions`, `source='codex'`).
- **Targets**: 🎯T99 retired (achieved) — the feature is merged and tested.

Full local suite green (`go test -tags sqlite_fts5 ./...`, 22 packages); the Codex feature itself was smoke-verified against real `~/.codex` rollouts in #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
