### PR TITLE
Validate Windows on the local VM instead of as a required CI gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,27 @@ targets are invisible to it. If you want a cross-project target
 search that includes mnemo, use `bullseye_list(cwd)` directly until
 the indexer is taught to read `bullseye.yaml`.
 
+## Gates
+
+profile: mnemo
+
+The `mnemo` gate profile (`~/.claude/gates/mnemo.yaml`, merged over
+`base.yaml`) adds a **`windows-vm-validated`** pre-merge gate: the
+Windows build + test suite is validated on the local Parallels VM
+(`ssh hms-vm`, Win11 ARM64) by `scripts/win-validate.sh`, not by the
+cloud CI Windows job. Cloud `test (windows-latest …)` still runs on
+every PR but is **non-required** (removed from the master ruleset's
+required checks) — it's the slow ~15-18 min CGO/SQLite long pole, so
+it no longer gates the merge.
+
+Flow is **push-first**: push the branch, then run
+`scripts/win-validate.sh` (it validates the *pushed* commit), which
+builds mnemo + sqldeep with the clang/ARM64 CGO toolchain on the VM
+and runs `go test -tags sqlite_fts5 ./...` — far faster than the cloud
+job (native ARM64, ~1-2 min). One-time VM provisioning: Go, MSYS2
+CLANGARM64 toolchain (`clang`/`llvm-ar`), and
+`mingw-w64-clang-aarch64-sqlite3`.
+
 ## Delivery
 
 Merged to master via squash PR.

--- a/scripts/win-validate.ps1
+++ b/scripts/win-validate.ps1
@@ -1,0 +1,62 @@
+# 🎯T100: Windows build+test of mnemo on the Parallels VM (windows/arm64,
+# clang CGO). Driven by scripts/win-validate.sh; run on the VM via
+# `powershell -File`. Mirrors .github/workflows/ci.yml's Windows job:
+# check out the commit + sqldeep, build libsqldeep.a with clang, then
+# `go test -tags sqlite_fts5`. Prereqs (provisioned once): Go, MSYS2
+# CLANGARM64 toolchain (clang/llvm-ar) + mingw-w64-clang-aarch64-sqlite3.
+param(
+  [string]$Sha = "origin/master",
+  [string]$SqldeepRef = "v0.22.0",
+  [string]$Work = "C:\Users\marcelo\winci"
+)
+
+$ErrorActionPreference = "Continue"  # Go writes progress to stderr; don't treat as fatal.
+$env:Path = "C:\msys64\clangarm64\bin;C:\Program Files\Go\bin;" + $env:Path
+New-Item -ItemType Directory -Force -Path $Work | Out-Null
+Set-Location $Work
+
+# --- mnemo: the commit under test ---
+if (-not (Test-Path mnemo\.git)) { git clone --quiet https://github.com/marcelocantos/mnemo.git mnemo }
+Set-Location mnemo
+git fetch --quiet origin
+git checkout --quiet -f $Sha
+"mnemo_head=$(git rev-parse --short HEAD)" | Write-Host
+Set-Location ..
+
+# --- sqldeep: pinned C/C++ dependency built into libsqldeep.a ---
+if (-not (Test-Path sqldeep\.git)) { git clone --quiet --recurse-submodules https://github.com/marcelocantos/sqldeep.git sqldeep }
+Set-Location sqldeep
+git fetch --quiet --tags
+git checkout --quiet -f $SqldeepRef
+git submodule update --init --recursive --quiet
+
+$CC = "clang"; $CXX = "clang++"; $AR = "llvm-ar"; $DP = "vendor/deepparser/src"
+Remove-Item -Recurse -Force build -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path build\deepparser | Out-Null
+$cflags = @("-Wall","-Wextra","-Wno-unused-parameter","-Wno-sign-compare","-O2","-DNDEBUG","-I$DP")
+foreach ($f in "arena","liteparser","lp_tokenize","lp_unparse","parse") {
+  & $CC @cflags -c "$DP/$f.c" -o "build/deepparser/$f.o"
+  if ($LASTEXITCODE -ne 0) { "win_validate_fail=sqldeep_cc_$f" | Write-Host; exit 11 }
+}
+& $CXX @("-std=c++20","-Idist","-Ivendor/include","-I$DP") -c dist/sqldeep.cpp -o build/sqldeep.o
+if ($LASTEXITCODE -ne 0) { "win_validate_fail=sqldeep_cpp" | Write-Host; exit 12 }
+& $CC @("-w","-Idist","-Ivendor/include") -c dist/sqldeep_xml.c -o build/sqldeep_xml.o
+if ($LASTEXITCODE -ne 0) { "win_validate_fail=sqldeep_xml" | Write-Host; exit 13 }
+& $AR rcs build/libsqldeep.a build/sqldeep.o (Get-ChildItem build/deepparser/*.o | ForEach-Object { $_.FullName })
+if (-not (Test-Path build/libsqldeep.a)) { "win_validate_fail=libsqldeep_missing" | Write-Host; exit 14 }
+Set-Location ..
+
+# --- go test (CGO sqlite + sqldeep) ---
+Set-Location mnemo
+$env:CGO_ENABLED = "1"
+$env:CC = "clang"
+$env:CXX = "clang++"  # sqlift's cgo compiles C++; Go defaults CXX to g++, absent in clangarm64
+$env:CGO_CPPFLAGS = "-IC:/msys64/clangarm64/include"
+go test -tags sqlite_fts5 -timeout=25m ./... 2>&1 | Tee-Object "$Work\gotest.log" | Out-Null
+$code = $LASTEXITCODE
+"go_test_exit=$code" | Write-Host
+if ($code -ne 0) {
+  "--- failing tail ---" | Write-Host
+  Get-Content "$Work\gotest.log" -Tail 50 | Write-Host
+}
+exit $code

--- a/scripts/win-validate.sh
+++ b/scripts/win-validate.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# 🎯T100: "local vm ci" — build + test mnemo on Windows on the Parallels
+# VM, used as the windows-vm-validated pre-merge gate (replacing the slow
+# required Windows cloud-CI check).
+#
+# Validates the *pushed* current commit: push your branch first, then run
+# this. It scp's scripts/win-validate.ps1 to the VM and runs it (clone the
+# commit + sqldeep, build libsqldeep.a with clang, `go test -tags
+# sqlite_fts5` on windows/arm64). Exit 0 = Windows is green.
+#
+# Config: WINCI_VM (default hms-vm), WINCI_SQLDEEP_REF (default v0.22.0).
+set -uo pipefail
+
+VM="${WINCI_VM:-hms-vm}"
+SQLDEEP_REF="${WINCI_SQLDEEP_REF:-v0.22.0}"
+REMOTE_PS="C:/Users/marcelo/win-validate.ps1"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+sha="$(git rev-parse HEAD)"
+
+# The gate validates what will merge, so the commit must be on origin.
+if [ -z "$(git branch -r --contains "$sha" 2>/dev/null)" ]; then
+  echo "win-validate: HEAD ${sha:0:12} is not on any remote branch — push first." >&2
+  exit 2
+fi
+
+echo "win-validate: $VM building + testing ${sha:0:12} (windows/arm64, clang CGO)…"
+
+if ! scp -q "$HERE/win-validate.ps1" "$VM:$REMOTE_PS"; then
+  echo "win-validate: scp to $VM failed (is the VM up / ssh $VM reachable?)" >&2
+  exit 3
+fi
+
+out="$(ssh -o ConnectTimeout=15 "$VM" \
+  "powershell -NoProfile -ExecutionPolicy Bypass -File $REMOTE_PS -Sha $sha -SqldeepRef $SQLDEEP_REF" 2>&1)"
+echo "$out" | grep -vE '^[[:space:]]*$'
+
+# Authoritative pass signal is the script's own go_test_exit marker —
+# robust against any ssh exit-code propagation quirks.
+if printf '%s\n' "$out" | grep -q "go_test_exit=0"; then
+  echo "win-validate: PASS (windows/arm64)"
+  exit 0
+fi
+echo "win-validate: FAIL — Windows build/tests did not pass on $VM" >&2
+exit 1


### PR DESCRIPTION
🎯T100 — replace the slow required Windows CI check with local VM validation.

## Why
The cloud `test (windows-latest …)` job is a ~15-18 min CGO/SQLite + Defender long pole that gated **every** PR merge. This moves Windows validation to the existing Parallels Win11 ARM64 VM (`ssh hms-vm`), where a native-ARM64/clang build runs the full suite in ~1-2 min.

## What
- **`scripts/win-validate.sh`** + **`scripts/win-validate.ps1`** — the "local vm ci". `win-validate.sh` validates the *pushed* commit: scp's the PowerShell recipe to the VM, which checks out the commit + sqldeep, builds `libsqldeep.a` with clang, and runs `go test -tags sqlite_fts5 ./...` (windows/arm64, `CC=clang CXX=clang++`). Exit 0 = Windows green. Push-first by design.
- **`mnemo` gate profile** (`CLAUDE.md` `## Gates: profile: mnemo` + `~/.claude/gates/mnemo.yaml`) — adds a `windows-vm-validated` automated pre-merge gate. `/push` and `/release` already read gate profiles, so no skill-code change.
- **Ruleset**: `test (windows-latest …)` removed from master's required status checks (applied). The cloud Windows job **still runs on PRs** as a non-required amd64/gcc cross-check — so both arches stay covered, but only the fast ubuntu check + the VM gate block merges.

## Validation
`./scripts/win-validate.sh` against this branch's HEAD: **PASS** — 22 packages green on windows/arm64 (`store` in 48s vs ~18 min in cloud). The VM was provisioned one-time: Go + MSYS2 CLANGARM64 toolchain + `mingw-w64-clang-aarch64-sqlite3`.

Note: `~/.claude/gates/mnemo.yaml` is global config (synced separately), not in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
