### PR TITLE
Integrate macOS Developer ID signing into the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,13 @@ jobs:
             cxx: aarch64-w64-mingw32-clang++
             ar: aarch64-w64-mingw32-ar
     runs-on: ${{ matrix.os }}
+    env:
+      # Developer ID signing secrets (🎯T101). Absent → empty → the Sign
+      # step below is skipped, so this is a no-op until the secrets are
+      # added. Set at job level so the step's `if:` gate can read them.
+      MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
+      MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+      MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
     defaults:
       run:
         shell: bash
@@ -146,10 +153,42 @@ jobs:
           AR: ${{ matrix.ar }}
         working-directory: mnemo
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
           go build -tags "sqlite_fts5" \
             -ldflags "-s -w ${LDFLAGS_EXTRA}" \
             -o "mnemo${{ matrix.ext }}" .
+
+      - name: Sign macOS binary (Developer ID)
+        # Sign with a stable Team ID so macOS TCC grants (Full Disk
+        # Access, "files managed by Google Drive", …) persist across
+        # `brew upgrade` (🎯T101). The default Go binary is only
+        # ad-hoc/linker-signed (no Team ID), so TCC keys grants on the
+        # cdhash and re-prompts on every new build. Apple CLI directly —
+        # fastlane isn't warranted for a single Homebrew-distributed
+        # binary. No-op until the signing secrets exist.
+        if: matrix.goos == 'darwin' && env.MACOS_CERT_P12 != ''
+        working-directory: mnemo
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/signing.keychain-db"
+          KC_PWD="$(uuidgen)"
+          security create-keychain -p "$KC_PWD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KC_PWD" "$KEYCHAIN"
+          printf '%s' "$MACOS_CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -P "$MACOS_CERT_PASSWORD" \
+            -t cert -f pkcs12 -k "$KEYCHAIN" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KC_PWD" "$KEYCHAIN" >/dev/null
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+          codesign --force --options runtime --timestamp \
+            --sign "$MACOS_SIGN_IDENTITY" "mnemo${{ matrix.ext }}"
+          codesign --verify --strict --verbose=2 "mnemo${{ matrix.ext }}"
+          rm -f "$RUNNER_TEMP/cert.p12"
+          security delete-keychain "$KEYCHAIN"
+
+      - name: Package
+        working-directory: mnemo
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
           case "${{ matrix.archive }}" in
             tar.gz)
               tar czf "mnemo-${VERSION}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz" "mnemo${{ matrix.ext }}"


### PR DESCRIPTION
🎯T101 — integrate macOS Developer ID signing into the release pipeline.

## What
Splits the darwin build into **build → sign → package** and adds a Developer ID `codesign` step (hardened runtime, `--timestamp`) using the Apple CLI directly. **Gated on secrets** (`MACOS_CERT_P12`, `MACOS_CERT_PASSWORD`, `MACOS_SIGN_IDENTITY`) — a **no-op until** a Developer ID Application cert is created and the secrets are set, so this merges safely now and activates later.

## Why
The default Go binary is only ad-hoc/linker-signed (no Team ID), so macOS TCC keys privacy grants on the per-build **cdhash** — every `brew upgrade` is a new identity and re-prompts (Full Disk Access, "files managed by Google Drive", etc.). A stable Developer ID Team ID anchors grants to the **Designated Requirement**, so they persist across versions.

## Why not fastlane
fastlane targets Xcode/App-Store pipelines (provisioning profiles, `match`, `gym`, App Store Connect) — none apply to a single Homebrew-distributed Go binary. The whole job is one `codesign` call; the Apple CLI is the right tool. (Notarization isn't needed for the brew bare-binary; the `Mnemo.app` menu-bar shim is a separate optional follow-on.)

## Activation (later, by the maintainer)
1. Create a **Developer ID Application** cert (Xcode → Manage Certificates), export `.p12`.
2. Set the three repo secrets.
The signing step then runs on the next release; verify a TCC grant survives a `brew upgrade` without re-prompting.

Windows validated on the local VM (🎯T100 gate): PASS — release.yml-only change, binary unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
