### PR TITLE
Harden mnemo against the Fable-5 audit findings (🎯T109)

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -426,6 +426,47 @@ targets:
     context: 'HIGH data loss. internal/store/store.go:6042: a mid-stream commit persists f.Seek(0,1), which overshoots the last processed line, so a crash between a mid-stream commit and completion permanently skips buffered-but-unwritten lines. Unverified Fable-5 finder-stage candidate; verify before implementing. See docs/audit/fable-2026-07.md.'
     origin: manual
     discovered: 2026-07-02
+  T108:
+    name: The menubar popup and dashboard surface p — the fraction of output requiring Marcelo personally — per repo, decomposed by cost term
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - 'Popup/dashboard show per-repo p over a recent window (e.g. 30 days), decomposed by the four oracle-first cost terms: harness / generation / verification-friction / verification-judgment'
+    - 'The derivation is documented: which transcript signals proxy ''required Marcelo personally'' (interrupts, manual user turns, corrective messages) vs autonomous completion (oracle-green retirements, uninterrupted agent runs)'
+    - 'p trend over time is visible, so the multiplier J-curve prediction (memory: prediction_multiplier_jcurve) can be evaluated from the dashboard'
+    context: 'oracle-first doctrine (~/.claude/skills/oracle-first/): the productivity multiplier ∝ 1/p, and p tracks oracle availability, not difficulty — but p is currently unmeasured. mnemo holds the raw signals. Filed from the 2026-07-03 ~think discussion (session 1cf2248b). [Re-filed 2026-07-05 after local-master reset to origin discarded the original unpushed entry; discovered date was originally 2026-07-03.]'
+    tags:
+    - oracle-first
+    - dashboard
+    origin: manual
+    discovered: 2026-07-05
+  T109:
+    name: The Fable-5 audit's critical/high findings are all resolved — each of T103–T107 is adversarially verified, then fixed-with-regression-test or refuted-and-retired
+    status: identified
+    value: 0.0
+    cost: 0.0
+    acceptance:
+    - 'Each of T103–T107 has been adversarially verified against the real code: a finding that reproduces is fixed with a regression test that fails on the pre-fix code and passes after; a finding that does not reproduce is retired with the refutation recorded in its target.'
+    - 'Query surface (T103, T106): mnemo_query cannot execute writes (no PRAGMA query_only=0 re-enable) and rejects ATTACH DATABASE, on the federation-exposed path too.'
+    - 'Ingest durability (T104, T107): oversized/unreadable JSONL lines are surfaced not silently skipped, and ingest offsets persist only at a true processed-line boundary so a crash never skips buffered content.'
+    - 'Resource safety (T105): image-sidecar work is bounded at spawn time so a startup backlog cannot blow up goroutines or memory.'
+    - All five sub-findings are retired in bullseye (achieved or refuted); this umbrella is achieved only when none remain open.
+    context: 'Umbrella goal for the Fable-5 deep-audit findings filed via #139 (docs/audit/fable-2026-07.md) on 2026-07-02. All five were finder-stage candidates whose adversarial verification was interrupted by an API spend limit, so each must be verified before implementing. Two themed clusters — query-surface hardening (T103 write-guard bypass + T106 ATTACH) and ingest durability (T104 oversized-line offset overshoot + T107 mid-stream Seek(0,1) overshoot) — plus T105 (unbounded image-sidecar goroutines). Set this as the goal to drive the whole batch; the five findings are the parallelisable frontier beneath it.'
+    depends_on:
+    - T103
+    - T104
+    - T105
+    - T106
+    - T107
+    tags:
+    - security
+    - data-loss
+    - audit
+    - fable-5
+    - hardening
+    origin: manual
+    discovered: 2026-07-05
   T11:
     name: Git history indexed cross-repo with FTS and session correlation
     status: achieved

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -371,9 +371,10 @@ targets:
     discovered: 2026-07-01
   T103:
     name: mnemo's read-only query surface cannot execute writes — user SQL cannot turn PRAGMA query_only back off
-    status: identified
+    status: achieved
     value: 13.0
     cost: 3.0
+    actual_cost: 2.0
     acceptance:
     - mnemo_query rejects or neutralizes any attempt to run PRAGMA query_only=0 (or otherwise write) within a submitted statement or batch
     - A submitted 'PRAGMA query_only=0; <write>' does not mutate the database
@@ -381,11 +382,13 @@ targets:
     context: 'CRITICAL. internal/store/store.go:5535: the read-only guard sets PRAGMA query_only=1, but a submitted ''PRAGMA query_only=0; <write>'' turns it back off and executes writes (DB wipe/corruption) — also reachable over federation. Unverified Fable-5 finder-stage candidate (adversarial verification interrupted by an API spend limit); verify before implementing. See docs/audit/fable-2026-07.md.'
     origin: manual
     discovered: 2026-07-02
+    achieved: 2026-07-05
   T104:
     name: mnemo ingest never advances its offset past unread content — an oversized/unreadable JSONL line is surfaced, not silently skipped
-    status: identified
+    status: achieved
     value: 13.0
     cost: 3.0
+    actual_cost: 2.0
     acceptance:
     - scanner.Err() is checked at every ingest site; a token-too-long error aborts without advancing the persisted offset past the unread line
     - Oversized lines are handled (larger buffer or explicit logged skip) rather than silently dropping subsequent content
@@ -393,39 +396,46 @@ targets:
     context: 'CRITICAL data loss. internal/store/store.go:3175: an oversized JSONL line silently aborts ingest and permanently advances the offset past unread content (scanner.Err() is never checked at any ingest site). Unverified Fable-5 finder-stage candidate; verify before implementing. See docs/audit/fable-2026-07.md.'
     origin: manual
     discovered: 2026-07-02
+    achieved: 2026-07-05
   T105:
     name: mnemo bounds image-sidecar work at spawn time so startup cannot blow up goroutines or memory
-    status: identified
+    status: achieved
     value: 8.0
     cost: 3.0
+    actual_cost: 2.0
     acceptance:
     - triggerImageSidecars bounds the number of spawned goroutines (a worker pool), not only concurrent execution
     - A large backlog at startup does not pin full image bytes across thousands of goroutines
     context: 'HIGH. internal/store/images.go:203: triggerImageSidecars spawns unbounded goroutines that each pin full image bytes; the semaphore gates execution, not spawn count, so startup can blow up goroutines/memory. Unverified Fable-5 finder-stage candidate; verify before implementing. See docs/audit/fable-2026-07.md.'
     origin: manual
     discovered: 2026-07-02
+    achieved: 2026-07-05
   T106:
     name: mnemo's read-only query surface forbids ATTACH DATABASE so it cannot read arbitrary files or create files
-    status: identified
+    status: achieved
     value: 8.0
     cost: 3.0
+    actual_cost: 2.0
     acceptance:
     - ATTACH DATABASE is rejected on the mnemo_query path (statement inspection or authorizer)
     - A query attempting ATTACH cannot read arbitrary local SQLite files or create files at chosen paths
     context: 'HIGH. internal/store/store.go:5531: ATTACH DATABASE is permitted under query_only=1, allowing reads of arbitrary local SQLite files (info disclosure) and file creation at attacker-chosen paths. Unverified Fable-5 finder-stage candidate; verify before implementing. See docs/audit/fable-2026-07.md.'
     origin: manual
     discovered: 2026-07-02
+    achieved: 2026-07-05
   T107:
     name: mnemo persists an ingest offset only at a true processed-line boundary so a crash never skips buffered lines
-    status: identified
+    status: achieved
     value: 8.0
     cost: 3.0
+    actual_cost: 2.0
     acceptance:
     - Mid-stream commits persist an offset matching the last fully-processed line, not a Seek(0,1) that overshoots buffered input
     - A crash or kill between a mid-stream commit and completion does not permanently skip lines; regression test covers it
     context: 'HIGH data loss. internal/store/store.go:6042: a mid-stream commit persists f.Seek(0,1), which overshoots the last processed line, so a crash between a mid-stream commit and completion permanently skips buffered-but-unwritten lines. Unverified Fable-5 finder-stage candidate; verify before implementing. See docs/audit/fable-2026-07.md.'
     origin: manual
     discovered: 2026-07-02
+    achieved: 2026-07-05
   T108:
     name: The menubar popup and dashboard surface p — the fraction of output requiring Marcelo personally — per repo, decomposed by cost term
     status: identified
@@ -443,7 +453,7 @@ targets:
     discovered: 2026-07-05
   T109:
     name: The Fable-5 audit's critical/high findings are all resolved — each of T103–T107 is adversarially verified, then fixed-with-regression-test or refuted-and-retired
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -467,6 +477,7 @@ targets:
     - hardening
     origin: manual
     discovered: 2026-07-05
+    achieved: 2026-07-05
   T11:
     name: Git history indexed cross-repo with FTS and session correlation
     status: achieved

--- a/internal/store/audit_fable5_test.go
+++ b/internal/store/audit_fable5_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+// Regression tests for the Fable-5 deep-audit findings (🎯T109):
+//   - 🎯T104 oversized JSONL line silently dropped (and its tail)
+//   - 🎯T105 unbounded image-sidecar goroutine spawn
+//   - 🎯T107 mid-stream ingest commit persists an overshot offset
+// (🎯T103/🎯T106 — the read-only query surface — are covered by
+// TestQuery and TestQueryRejectsAttach in store_test.go.)
+
+package store
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestIngestOversizedLineNotDropped verifies that a JSONL line larger
+// than the old bufio.Scanner token cap (1<<20) is ingested rather than
+// silently skipped, and that content after it is not lost either
+// (🎯T104). Before the fix, bufio.Scanner returned ErrTooLong on the
+// oversized line, the scan loop exited as if at EOF, and the offset was
+// advanced past it.
+func TestIngestOversizedLineNotDropped(t *testing.T) {
+	projectDir := t.TempDir()
+
+	oversized := "giantmarker " + strings.Repeat("x", 1<<20) // > 1 MiB line
+	writeJSONL(t, projectDir, "proj", "sess-oversize", []map[string]any{
+		msg("user", "alpha marker line", "2026-04-01T10:00:00Z"),
+		msg("assistant", oversized, "2026-04-01T10:00:05Z"),
+		msg("user", "omega marker after the giant line", "2026-04-01T10:00:10Z"),
+	})
+
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	countLike := func(pattern string) int64 {
+		rows, err := s.Query("SELECT COUNT(*) AS c FROM messages WHERE text LIKE '%" + pattern + "%'")
+		if err != nil {
+			t.Fatal(err)
+		}
+		c, _ := rows[0]["c"].(int64)
+		return c
+	}
+
+	if countLike("giantmarker") == 0 {
+		t.Error("oversized line was dropped (🎯T104)")
+	}
+	if countLike("omega marker") == 0 {
+		t.Error("content after the oversized line was dropped (🎯T104)")
+	}
+}
+
+// TestRunSidecarBoundsSpawn verifies that runSidecar acquires a semaphore
+// slot before spawning, so the caller back-pressures once the pool is
+// full instead of launching an unbounded number of goroutines that each
+// pin image bytes (🎯T105). Before the fix the semaphore was acquired
+// inside the already-spawned goroutine.
+func TestRunSidecarBoundsSpawn(t *testing.T) {
+	const slots = 2
+	s := &Store{imageSem: make(chan struct{}, slots)}
+
+	release := make(chan struct{})
+	entered := make(chan struct{}, 16)
+	fn := func() {
+		entered <- struct{}{}
+		<-release
+	}
+
+	producerDone := make(chan struct{})
+	go func() {
+		for i := 0; i < slots+3; i++ {
+			s.runSidecar(fn)
+		}
+		close(producerDone)
+	}()
+
+	// Exactly `slots` sidecars start; the next runSidecar call must block
+	// the producer acquiring a slot.
+	for i := 0; i < slots; i++ {
+		select {
+		case <-entered:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("expected %d sidecars to start", slots)
+		}
+	}
+	select {
+	case <-producerDone:
+		t.Fatal("producer finished without back-pressure: spawn is unbounded (🎯T105)")
+	case <-time.After(100 * time.Millisecond):
+		// expected: producer parked acquiring the next slot
+	}
+
+	close(release)
+	select {
+	case <-producerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("producer did not drain after release")
+	}
+}
+
+// TestIngestFileMidStreamOffsetOnBoundary verifies that the offset
+// persisted at a mid-stream commit is a true line boundary, so a crash
+// between that commit and completion cannot skip buffered-but-unwritten
+// lines (🎯T107). Before the fix the offset came from f.Seek(0,1), which
+// reads ahead of the last processed line.
+func TestIngestFileMidStreamOffsetOnBoundary(t *testing.T) {
+	savedLC, savedCI := ingestLineCheckInterval, ingestCommitInterval
+	ingestLineCheckInterval, ingestCommitInterval = 1, 0 // commit after every line
+	var offsets []int64
+	testMidStreamCommitOffset = func(off int64) { offsets = append(offsets, off) }
+	t.Cleanup(func() {
+		ingestLineCheckInterval, ingestCommitInterval = savedLC, savedCI
+		testMidStreamCommitOffset = nil
+	})
+
+	projectDir := t.TempDir()
+	// Lines wide enough that bufio reads ahead of the last processed line,
+	// so the pre-fix f.Seek offset would land mid-line.
+	entries := make([]map[string]any, 0, 20)
+	for i := 0; i < 20; i++ {
+		entries = append(entries,
+			msg("user", fmt.Sprintf("line-%02d ", i)+strings.Repeat("x", 600),
+				fmt.Sprintf("2026-04-01T10:%02d:00Z", i)))
+	}
+	path := writeJSONL(t, projectDir, "proj", "sess-mid", entries)
+
+	s := newTestStore(t, projectDir)
+	if err := s.ingestFile(path); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(offsets) == 0 {
+		t.Fatal("no mid-stream commit fired; cannot validate offset")
+	}
+	for _, off := range offsets {
+		if off <= 0 || off > int64(len(data)) {
+			t.Errorf("mid-stream offset %d out of range [1,%d]", off, len(data))
+			continue
+		}
+		if off < int64(len(data)) && data[off-1] != '\n' {
+			t.Errorf("mid-stream offset %d is not a line boundary (preceding byte %q) (🎯T107)",
+				off, data[off-1])
+		}
+	}
+}

--- a/internal/store/codex.go
+++ b/internal/store/codex.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -138,21 +139,16 @@ func parseCodexFile(path string, offset int64) (parsedFile, error) {
 		source:    "codex",
 	}
 
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 1<<20), 8<<20) // Codex tool outputs can be large
+	reader := bufio.NewReader(f)
 
-	lineStart := offset
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		thisStart := lineStart
-		lineStart += int64(len(line)) + 1 // +1 for the stripped '\n'
-		if len(line) == 0 {
-			continue
-		}
-
+	// handleLine parses one rollout envelope into pf. Guard clauses skip a
+	// line by returning rather than a loop `continue`, so the EOF / read-
+	// error handling in the read loop always runs. thisStart is the line's
+	// starting byte offset — the synthetic-uuid discriminator.
+	handleLine := func(line []byte, thisStart int64) {
 		var cl codexLine
 		if json.Unmarshal(line, &cl) != nil {
-			continue // tolerate junk / unknown lines, never fail the file
+			return // tolerate junk / unknown lines, never fail the file
 		}
 
 		switch cl.Type {
@@ -168,21 +164,21 @@ func parseCodexFile(path string, offset int64) (parsedFile, error) {
 					pf.branch = p.Git.Branch
 				}
 			}
-			continue
+			return
 		case "response_item":
 			// conversation content — handled below
 		default:
-			continue // event_msg, compacted, world_state, inter_agent_* …
+			return // event_msg, compacted, world_state, inter_agent_* …
 		}
 
 		var p codexPayload
 		if json.Unmarshal(cl.Payload, &p) != nil {
-			continue
+			return
 		}
 
 		entryType, msgs, ok := codexRecord(&p)
 		if !ok {
-			continue
+			return
 		}
 
 		ts := cl.Timestamp
@@ -218,7 +214,27 @@ func parseCodexFile(path string, offset int64) (parsedFile, error) {
 		}
 	}
 
-	pf.newOffset, _ = f.Seek(0, 1)
+	// bufio.Reader.ReadBytes has no per-line size cap, so oversized Codex
+	// tool outputs are ingested rather than silently dropped (🎯T104). The
+	// offset is the running count of bytes consumed (a true line boundary),
+	// and a non-EOF read error aborts without advancing it.
+	consumed := offset
+	for {
+		raw, readErr := reader.ReadBytes('\n')
+		if readErr != nil && readErr != io.EOF {
+			return parsedFile{}, fmt.Errorf("read %s: %w", path, readErr)
+		}
+		thisStart := consumed
+		consumed += int64(len(raw))
+		if line := trimLineEnding(raw); len(line) > 0 {
+			handleLine(line, thisStart)
+		}
+		if readErr == io.EOF {
+			break
+		}
+	}
+
+	pf.newOffset = consumed
 	pf.project = codexProject(pf.cwd)
 	return pf, nil
 }

--- a/internal/store/images.go
+++ b/internal/store/images.go
@@ -190,27 +190,35 @@ func ingestImageFromPath(s *Store, path string, entryID int64, messageID int64, 
 	s.triggerImageSidecars(imageID, data, mimeType)
 }
 
-// triggerImageSidecars spawns one goroutine per sidecar pipeline (OCR,
-// description, embedding) for a single image. All three share a single
-// store-wide semaphore (sized at runtime.NumCPU()) so the total amount
-// of image-processing work in flight is bounded regardless of arrival
-// pattern. Each helper is idempotent and a cheap no-op if its backend
-// is unavailable.
+// triggerImageSidecars runs the three sidecar pipelines (OCR,
+// description, embedding) for a single image. runSidecar acquires a slot
+// on the store-wide semaphore (sized at runtime.NumCPU()) BEFORE spawning
+// each goroutine, so both the number of in-flight goroutines and the
+// image bytes their closures pin are bounded no matter how large a
+// backlog backfillImages feeds in (🎯T105); the caller back-pressures
+// rather than launching thousands of parked goroutines. Each helper is
+// idempotent and a cheap no-op if its backend is unavailable.
 func (s *Store) triggerImageSidecars(imageID int64, data []byte, mimeType string) {
 	if s == nil || s.writeDB == nil || s.imageSem == nil {
 		return
 	}
-	go s.runSidecar(func() { ocrOneImage(s.writeDB, imageID, data) })
-	go s.runSidecar(func() { describeOneImage(s.writeDB, imageID, data, mimeType) })
-	go s.runSidecar(func() { embedOneImage(s.writeDB, imageID, data, mimeType) })
+	s.runSidecar(func() { ocrOneImage(s.writeDB, imageID, data) })
+	s.runSidecar(func() { describeOneImage(s.writeDB, imageID, data, mimeType) })
+	s.runSidecar(func() { embedOneImage(s.writeDB, imageID, data, mimeType) })
 }
 
-// runSidecar acquires a slot on the shared image semaphore, runs fn,
-// then releases.
+// runSidecar acquires a slot on the shared image semaphore, then spawns a
+// goroutine that runs fn and releases the slot. Acquiring BEFORE the `go`
+// (rather than as the goroutine's first statement) is what bounds the
+// spawn count and the memory fn's closure pins: the caller blocks here
+// once NumCPU slots are taken instead of queueing unbounded goroutines
+// (🎯T105).
 func (s *Store) runSidecar(fn func()) {
 	s.imageSem <- struct{}{}
-	defer func() { <-s.imageSem }()
-	fn()
+	go func() {
+		defer func() { <-s.imageSem }()
+		fn()
+	}()
 }
 
 // extToMime maps common image extensions to MIME types.

--- a/internal/store/rodriver.go
+++ b/internal/store/rodriver.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"database/sql"
+	"strings"
+
+	sqlite3 "github.com/mattn/go-sqlite3"
+)
+
+// readOnlyDriverName is the SQLite driver mnemo opens its read pool with.
+// It is the stock "sqlite3" driver plus a per-connection authorizer
+// (readOnlyAuthorizer) that hardens the read-only boundary of
+// mnemo_query, which runs arbitrary client SQL (including from mTLS
+// federation peers).
+//
+// PRAGMA query_only=1 alone is not a sufficient boundary:
+//   - a client can submit "PRAGMA query_only=0; <write>" to turn the
+//     guard back off within one submission and execute writes — a full
+//     DB wipe under the append-only/pruned-JSONL policy (🎯T103); and
+//   - query_only never gates ATTACH DATABASE, so a client can read
+//     arbitrary local SQLite files or create files at chosen paths
+//     (🎯T106).
+//
+// The authorizer closes both holes at the connection level, where
+// client SQL cannot undo it.
+const readOnlyDriverName = "sqlite3_mnemo_ro"
+
+func init() {
+	sql.Register(readOnlyDriverName, &sqlite3.SQLiteDriver{
+		ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+			conn.RegisterAuthorizer(readOnlyAuthorizer)
+			return nil
+		},
+	})
+}
+
+// readOnlyAuthorizer is the SQLite authorizer installed on every read-pool
+// connection. Comprehensive write-blocking stays delegated to
+// PRAGMA query_only=1 (set per query in Store.Query); this authorizer only
+// guarantees that guard cannot be bypassed, by denying the two vectors
+// query_only itself does not cover:
+//
+//   - ATTACH/DETACH — reads of arbitrary local SQLite files and file
+//     creation at chosen paths (🎯T106); mnemo never legitimately
+//     attaches a second database on the read path.
+//   - turning query_only off — the client-resettable PRAGMA that makes
+//     "PRAGMA query_only=0; <write>" execute writes (🎯T103).
+//
+// It fails closed: any query_only SET other than the exact "=1" mnemo
+// itself issues is denied, while a bare "PRAGMA query_only" read and all
+// other pragmas (journal_mode, synchronous, … set by openDB) pass.
+func readOnlyAuthorizer(op int, arg1, arg2, arg3 string) int {
+	switch op {
+	case sqlite3.SQLITE_ATTACH, sqlite3.SQLITE_DETACH:
+		return sqlite3.SQLITE_DENY
+	case sqlite3.SQLITE_PRAGMA:
+		if strings.EqualFold(arg1, "query_only") && arg2 != "" && arg2 != "1" {
+			return sqlite3.SQLITE_DENY
+		}
+	}
+	return sqlite3.SQLITE_OK
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -550,7 +551,15 @@ func relaxQuery(q string) string {
 }
 
 func openDB(dbPath string, writer bool) (*sql.DB, error) {
-	db, err := sql.Open("sqlite3", dbPath)
+	// The read pool uses a driver that installs a read-only authorizer
+	// (see rodriver.go): mnemo_query runs arbitrary client SQL, and
+	// PRAGMA query_only=1 alone is bypassable (🎯T103) and does not gate
+	// ATTACH (🎯T106). The writer keeps the stock driver.
+	driver := "sqlite3"
+	if !writer {
+		driver = readOnlyDriverName
+	}
+	db, err := sql.Open(driver, dbPath)
 	if err != nil {
 		return nil, err
 	}
@@ -3071,6 +3080,19 @@ func (s *Store) writeParsedFile(ws *writerState, pf parsedFile) {
 	s.mu.Unlock()
 }
 
+// trimLineEnding strips a single trailing "\n" (and a preceding "\r"),
+// matching bufio.ScanLines semantics for a line read via
+// bufio.Reader.ReadBytes('\n').
+func trimLineEnding(b []byte) []byte {
+	if n := len(b); n > 0 && b[n-1] == '\n' {
+		b = b[:n-1]
+		if n = len(b); n > 0 && b[n-1] == '\r' {
+			b = b[:n-1]
+		}
+	}
+	return b
+}
+
 // parseFile reads and parses a JSONL transcript file, returning all
 // extracted messages and metadata. Pure computation — no DB access.
 func parseFile(path string, offset int64) (parsedFile, error) {
@@ -3087,8 +3109,7 @@ func parseFile(path string, offset int64) (parsedFile, error) {
 	sessionID := strings.TrimSuffix(filepath.Base(path), ".jsonl")
 	project := filepath.Base(filepath.Dir(path))
 
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+	reader := bufio.NewReader(f)
 
 	pf := parsedFile{
 		path:      path,
@@ -3096,15 +3117,13 @@ func parseFile(path string, offset int64) (parsedFile, error) {
 		project:   project,
 	}
 
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
-		}
-
+	// handleLine extracts one JSONL line into pf. Its guard clauses skip a
+	// line by returning, which — unlike a bare loop `continue` — cannot
+	// bypass the read-error / EOF handling in the read loop below.
+	handleLine := func(line []byte) {
 		var entry jsonlEntry
 		if json.Unmarshal(line, &entry) != nil {
-			continue
+			return
 		}
 
 		if entry.Cwd != "" && pf.cwd == "" {
@@ -3131,12 +3150,12 @@ func parseFile(path string, offset int64) (parsedFile, error) {
 
 		// Only extract content blocks for user/assistant messages.
 		if entry.Type != "user" && entry.Type != "assistant" {
-			continue
+			return
 		}
 
 		blocks := extractBlocks(entry.Message)
 		if len(blocks) == 0 {
-			continue
+			return
 		}
 
 		for _, b := range blocks {
@@ -3172,7 +3191,28 @@ func parseFile(path string, offset int64) (parsedFile, error) {
 		}
 	}
 
-	pf.newOffset, _ = f.Seek(0, 1)
+	// bufio.Reader.ReadBytes has no per-line size cap, so oversized lines
+	// (e.g. inline base64 images) are ingested rather than silently
+	// dropped as they were under bufio.Scanner's token limit (🎯T104). The
+	// offset is the running count of bytes consumed — always a true line
+	// boundary — so a resume never overshoots unread content; a non-EOF
+	// read error aborts without advancing it.
+	consumed := offset
+	for {
+		raw, readErr := reader.ReadBytes('\n')
+		if readErr != nil && readErr != io.EOF {
+			return parsedFile{}, fmt.Errorf("read %s: %w", path, readErr)
+		}
+		consumed += int64(len(raw))
+		if line := trimLineEnding(raw); len(line) > 0 {
+			handleLine(line)
+		}
+		if readErr == io.EOF {
+			break
+		}
+	}
+
+	pf.newOffset = consumed
 	return pf, nil
 }
 
@@ -5520,14 +5560,11 @@ func (s *Store) Query(query string, args ...any) ([]map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		// Reset before releasing so the next user of the (single-pool)
-		// connection isn't accidentally read-only. Use a background
-		// context so cancellation of the caller's query doesn't also
-		// cancel the reset.
-		_, _ = conn.ExecContext(context.Background(), "PRAGMA query_only = 0")
-		conn.Close()
-	}()
+	defer conn.Close()
+	// query_only=1 is the write boundary; the read pool's authorizer
+	// (rodriver.go) both prevents this being turned back off and denies
+	// ATTACH, so there is deliberately no reset to query_only=0 on
+	// release — every read-pool connection stays read-only for its life.
 	if _, err := conn.ExecContext(ctx, "PRAGMA query_only = 1"); err != nil {
 		return nil, fmt.Errorf("set query_only: %w", err)
 	}
@@ -5906,6 +5943,18 @@ func isBoilerplate(text string) bool {
 		strings.HasPrefix(text, "<system-reminder>")
 }
 
+// Ingest commit cadence for the realtime watcher path (ingestFile).
+// Vars, not consts, so a test can force a mid-stream commit.
+var (
+	ingestCommitInterval    = 200 * time.Millisecond
+	ingestLineCheckInterval = 50
+)
+
+// testMidStreamCommitOffset, when non-nil, is invoked with the offset
+// persisted at each mid-stream commit — a test seam for asserting that
+// offset lands on a true line boundary (🎯T107).
+var testMidStreamCommitOffset func(int64)
+
 func (s *Store) ingestFile(path string) error {
 	s.mu.Lock()
 	offset := s.offsets[path]
@@ -5927,15 +5976,11 @@ func (s *Store) ingestFile(path string) error {
 	sessionID := strings.TrimSuffix(filepath.Base(path), ".jsonl")
 	project := filepath.Base(filepath.Dir(path))
 
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+	reader := bufio.NewReader(f)
 
 	count := 0
 	var metaCwd, metaBranch, metaTopic string
 	metaCompactorInternal := 0 // 🎯T72: set when a compactor-run marker is seen
-
-	const commitInterval = 200 * time.Millisecond
-	const lineCheckInterval = 50
 
 	ws, err := newWriterState(s.writeDB)
 	if err != nil {
@@ -5944,18 +5989,14 @@ func (s *Store) ingestFile(path string) error {
 	defer func() { ws.tx.Rollback() }()
 	defer ws.Close()
 
-	lastCommit := time.Now()
-	linesSinceLockCheck := 0
-
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
-		}
-
+	// handleLine writes one JSONL line into the current transaction. Its
+	// guard clauses skip a line by returning rather than a loop `continue`,
+	// so the periodic-commit and EOF handling in the read loop always run.
+	// It closes over ws, which is reassigned after each mid-stream commit.
+	handleLine := func(line []byte) {
 		var entry jsonlEntry
 		if err := json.Unmarshal(line, &entry); err != nil {
-			continue
+			return
 		}
 
 		// Extract session metadata from any entry.
@@ -5985,64 +6026,82 @@ func (s *Store) ingestFile(path string) error {
 		// Only extract content blocks for user/assistant messages.
 		// Skip if the entry was a duplicate (INSERT OR IGNORE, entryID == 0).
 		if entry.Type != "user" && entry.Type != "assistant" || entryID == 0 {
-			goto yieldCheck
+			return
 		}
 
-		{
-			blocks := extractBlocks(entry.Message)
-			for _, b := range blocks {
-				noise := 0
-				if b.ContentType == "text" && isNoise(b.Text) {
-					noise = 1
-				}
-				// Capture first substantive user text message as topic.
-				if metaTopic == "" && entry.Type == "user" && b.ContentType == "text" && noise == 0 && len(b.Text) >= 10 && !isBoilerplate(b.Text) {
-					metaTopic = b.Text
-					if len(metaTopic) > 200 {
-						metaTopic = metaTopic[:197] + "..."
-					}
-				}
-
-				// tool_input: pass raw JSON or nil.
-				var toolInput any
-				if b.ToolInput != nil {
-					toolInput = string(b.ToolInput)
-				}
-
-				isErr := 0
-				if b.IsError {
-					isErr = 1
-				}
-
-				ws.msgStmt.Exec(entryID, sessionID, project, entry.Type, b.Text, ts, entry.Type, noise,
-					b.ContentType, b.ToolName, b.ToolUseID, toolInput, isErr)
-				count++
-
-				// Detect self-identification nonces.
-				if b.ContentType == "text" && strings.HasPrefix(b.Text, NoncePrefix) {
-					nonce := strings.TrimSpace(b.Text)
-					ws.tx.Exec("INSERT OR IGNORE INTO session_nonces (nonce, session_id) VALUES (?, ?)", nonce, sessionID)
-				}
-
-				// 🎯T72 recursion guard: flag claudia-spawned compaction
-				// runs by the marker on their opening prompt.
-				if b.ContentType == "text" && IsCompactorMarker(b.Text) {
-					metaCompactorInternal = 1
+		blocks := extractBlocks(entry.Message)
+		for _, b := range blocks {
+			noise := 0
+			if b.ContentType == "text" && isNoise(b.Text) {
+				noise = 1
+			}
+			// Capture first substantive user text message as topic.
+			if metaTopic == "" && entry.Type == "user" && b.ContentType == "text" && noise == 0 && len(b.Text) >= 10 && !isBoilerplate(b.Text) {
+				metaTopic = b.Text
+				if len(metaTopic) > 200 {
+					metaTopic = metaTopic[:197] + "..."
 				}
 			}
+
+			// tool_input: pass raw JSON or nil.
+			var toolInput any
+			if b.ToolInput != nil {
+				toolInput = string(b.ToolInput)
+			}
+
+			isErr := 0
+			if b.IsError {
+				isErr = 1
+			}
+
+			ws.msgStmt.Exec(entryID, sessionID, project, entry.Type, b.Text, ts, entry.Type, noise,
+				b.ContentType, b.ToolName, b.ToolUseID, toolInput, isErr)
+			count++
+
+			// Detect self-identification nonces.
+			if b.ContentType == "text" && strings.HasPrefix(b.Text, NoncePrefix) {
+				nonce := strings.TrimSpace(b.Text)
+				ws.tx.Exec("INSERT OR IGNORE INTO session_nonces (nonce, session_id) VALUES (?, ?)", nonce, sessionID)
+			}
+
+			// 🎯T72 recursion guard: flag claudia-spawned compaction
+			// runs by the marker on their opening prompt.
+			if b.ContentType == "text" && IsCompactorMarker(b.Text) {
+				metaCompactorInternal = 1
+			}
+		}
+	}
+
+	lastCommit := time.Now()
+	linesSinceLockCheck := 0
+
+	// bufio.Reader.ReadBytes has no per-line size cap, so oversized lines
+	// are ingested rather than silently dropped (🎯T104). The committed
+	// offset is the running count of bytes consumed — a true line boundary
+	// — not f.Seek(0,1), which reads ahead of the last processed line and
+	// at a mid-stream commit would persist an offset past not-yet-written
+	// content, so a crash would skip it (🎯T107). A non-EOF read error
+	// aborts without advancing the offset.
+	consumed := offset
+	for {
+		raw, readErr := reader.ReadBytes('\n')
+		if readErr != nil && readErr != io.EOF {
+			return fmt.Errorf("read %s: %w", path, readErr)
+		}
+		consumed += int64(len(raw))
+		if line := trimLineEnding(raw); len(line) > 0 {
+			handleLine(line)
 		}
 
-	yieldCheck:
 		// Periodically commit to avoid long-running transactions.
 		linesSinceLockCheck++
-		if linesSinceLockCheck >= lineCheckInterval {
+		if linesSinceLockCheck >= ingestLineCheckInterval {
 			linesSinceLockCheck = 0
-			if time.Since(lastCommit) >= commitInterval {
+			if time.Since(lastCommit) >= ingestCommitInterval {
 				// Commit current transaction with offset update.
-				curOffset, _ := f.Seek(0, 1)
 				recSize, recMtime := statFingerprint(path)
 				ws.tx.Exec(`INSERT OR REPLACE INTO ingest_state (path, offset, recorded_size, recorded_mtime)
-					VALUES (?, ?, ?, ?)`, path, curOffset, recSize, recMtime)
+					VALUES (?, ?, ?, ?)`, path, consumed, recSize, recMtime)
 
 				ws.Close()
 				if err := ws.tx.Commit(); err != nil {
@@ -6050,8 +6109,12 @@ func (s *Store) ingestFile(path string) error {
 				}
 
 				s.mu.Lock()
-				s.offsets[path] = curOffset
+				s.offsets[path] = consumed
 				s.mu.Unlock()
+
+				if testMidStreamCommitOffset != nil {
+					testMidStreamCommitOffset(consumed)
+				}
 
 				// Start a new transaction.
 				ws, err = newWriterState(s.writeDB)
@@ -6060,6 +6123,10 @@ func (s *Store) ingestFile(path string) error {
 				}
 				lastCommit = time.Now()
 			}
+		}
+
+		if readErr == io.EOF {
+			break
 		}
 	}
 
@@ -6079,10 +6146,9 @@ func (s *Store) ingestFile(path string) error {
 			sessionID, repo, metaCwd, metaBranch, workType, metaTopic, metaCompactorInternal)
 	}
 
-	newOffset, _ := f.Seek(0, 1)
 	recSize, recMtime := statFingerprint(path)
 	ws.tx.Exec(`INSERT OR REPLACE INTO ingest_state (path, offset, recorded_size, recorded_mtime)
-		VALUES (?, ?, ?, ?)`, path, newOffset, recSize, recMtime)
+		VALUES (?, ?, ?, ?)`, path, consumed, recSize, recMtime)
 
 	ws.Close()
 	if err := ws.tx.Commit(); err != nil {
@@ -6090,7 +6156,7 @@ func (s *Store) ingestFile(path string) error {
 	}
 
 	s.mu.Lock()
-	s.offsets[path] = newOffset
+	s.offsets[path] = consumed
 	s.mu.Unlock()
 
 	if count > 0 {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -4,6 +4,7 @@
 package store
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -425,6 +426,10 @@ func TestQuery(t *testing.T) {
 		"DROP TABLE messages",
 		"INSERT INTO messages (session_id, project, role, text) VALUES ('x','y','user','z')",
 		"UPDATE messages SET text = 'x'",
+		// 🎯T103: the guard must not be defeatable by turning
+		// PRAGMA query_only back off within the same submission.
+		"PRAGMA query_only=0; DELETE FROM messages",
+		"PRAGMA query_only=0; DROP TABLE messages",
 	} {
 		if _, err := s.Query(q); err == nil {
 			t.Errorf("expected error for write query %q", q)
@@ -453,6 +458,54 @@ func TestQuery(t *testing.T) {
 	// must still work — query_only must not leak into the shared pool.
 	if _, err := s.writeDB.Exec("CREATE TEMP TABLE _t (x INT)"); err != nil {
 		t.Errorf("query_only leaked into shared connection: %v", err)
+	}
+}
+
+// TestQueryRejectsAttach verifies the read-only query surface cannot
+// ATTACH a database — neither to read an arbitrary local SQLite file
+// (info disclosure) nor to create a file at a chosen path (🎯T106).
+func TestQueryRejectsAttach(t *testing.T) {
+	projectDir := t.TempDir()
+	writeJSONL(t, projectDir, "myproject", "sess-attach", []map[string]any{
+		msg("user", "hello", "2026-04-01T10:00:00Z"),
+		msg("assistant", "hi there", "2026-04-01T10:00:05Z"),
+	})
+	s := newTestStore(t, projectDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	// A victim database holding a secret, distinct from mnemo's own DB.
+	victim := filepath.Join(t.TempDir(), "victim.db")
+	vdb, err := sql.Open("sqlite3", victim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := vdb.Exec("CREATE TABLE secret(v TEXT)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := vdb.Exec("INSERT INTO secret VALUES ('TOPSECRET')"); err != nil {
+		t.Fatal(err)
+	}
+	vdb.Close()
+
+	// ATTACH-for-read must be denied, and nothing must leak even if a
+	// follow-up query tries to read the alias.
+	if _, err := s.Query("ATTACH DATABASE '" + victim + "' AS v"); err == nil {
+		t.Error("expected ATTACH to be rejected")
+	}
+	if rows, err := s.Query("SELECT v FROM v.secret"); err == nil && len(rows) > 0 {
+		t.Errorf("read an arbitrary attached DB through the read-only surface: %v", rows)
+	}
+
+	// ATTACH against a nonexistent path must be denied and must not
+	// create a file.
+	newPath := filepath.Join(t.TempDir(), "created.db")
+	if _, err := s.Query("ATTACH DATABASE '" + newPath + "' AS c"); err == nil {
+		t.Error("expected ATTACH (create) to be rejected")
+	}
+	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+		t.Errorf("ATTACH created a file at %s (stat err=%v)", newPath, err)
 	}
 }
 


### PR DESCRIPTION
Fixes the five verified critical/high findings from the Fable-5 deep audit (`docs/audit/fable-2026-07.md`), tracked under 🎯T109 (T103–T107). Each finding was **adversarially re-verified against the current code** before fixing, and each ships a regression test that distinguishes the fixed behaviour.

## Fixes

**🎯T103 / 🎯T106 — read-only query surface** (`rodriver.go`, new)
`mnemo_query` ran arbitrary client SQL on a read pool guarded only by a client-resettable `PRAGMA query_only=1`. So `PRAGMA query_only=0; <write>` executed writes (a full DB wipe — permanent under the append-only/pruned-JSONL policy), and `ATTACH DATABASE` read arbitrary local SQLite files / created files at chosen paths. Both were reachable over the mTLS federation endpoint. The read pool now opens with a dedicated driver whose `ConnectHook` installs an authorizer denying `ATTACH`/`DETACH` and any attempt to turn `query_only` off. `mode=ro` was rejected as an option because `openDB` runs `PRAGMA journal_mode=WAL` on the read handle.
Tests: `TestQuery` (bypass payloads), `TestQueryRejectsAttach`.

**🎯T104 / 🎯T107 — ingest durability** (`store.go`, `codex.go`)
`parseFile`/`ingestFile`/`parseCodexFile` scanned with `bufio.Scanner` (1–8 MiB token cap) and never checked `scanner.Err()`, so an oversized line (e.g. inline base64 image) was silently dropped with the offset advanced past it (T104). `ingestFile`'s mid-stream commit persisted `f.Seek(0,1)`, which reads ahead of the last processed line, so a crash mid-file skipped buffered content (T107). All three now read via `bufio.Reader.ReadBytes` (no cap) and persist a **consumed-bytes offset** that is always a true line boundary; a non-EOF read error aborts without advancing the offset.
Tests: `TestIngestOversizedLineNotDropped`, `TestIngestFileMidStreamOffsetOnBoundary`.

**🎯T105 — image-sidecar spawn bound** (`images.go`)
`triggerImageSidecars` spawned 3 goroutines per image *before* acquiring the semaphore (which gated execution, not spawn count), so a startup backlog spawned thousands of goroutines each pinning full image bytes (~6.8k on the maintainer's own DB). `runSidecar` now acquires a slot before spawning, so the caller back-pressures.
Test: `TestRunSidecarBoundsSpawn`.

## Verification

`go test -tags sqlite_fts5 ./...` green across all packages. The five regression tests each fail on the pre-fix behaviour and pass after.

## Severity notes (from re-verification)

T103, T106 fully confirmed. T104's "tail lost forever" was refuted (a re-scan guard limits it to the oversized line + a crash-window tail); T107 is a crash-window bug; T105's magnitude was overstated — all three real and fixed, severities calibrated to medium.

Target lifecycle: 🎯T103–T107 and umbrella 🎯T109 are retired in this PR.