### PR TITLE
Release v0.60.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.59.0"
+	version              = "0.60.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 )


### PR DESCRIPTION
## Summary

Bump mnemo from `0.59.0` to `0.60.0` for the release that includes:

- Hardened `mnemo_query` read-only execution against write re-enablement and `ATTACH`/`DETACH`.
- Resilient Claude/Codex transcript ingest for oversized JSONL lines and crash-window offset handling.
- Bounded image sidecar spawn/backpressure at startup.
- Regression tests and bullseye retirements for 🎯T103–T107 plus 🎯T109.

## Verification

- `go test -tags sqlite_fts5 ./...`
- Release notes displayed in the release-driving transcript.

## Release

Planned tag: `v0.60.0`.