### PR TITLE
Graceful daemon drain with WAL checkpoint; realtime watcher priority

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2222,9 +2222,10 @@ targets:
     discovered: 2026-07-01
   T64.2:
     name: '`_mnemo/` namespace + vault_layout config'
-    status: identified
+    status: set_aside
     value: 2.0
     cost: 0.0
+    set_aside_reason: 'NOT parked, NOT won''t-fix, NOT an achievement judgement — this is an OWNERSHIP EXCLUSION only. T64.2 is driven externally on open PR #112 (branch t64.2-mnemo-namespace-vault-layout, +1959/−46, both CI checks green at 2026-06-14 but 29 commits behind master; lineage from navnita''s now-closed #105). Excluded from Marcelo''s frontier so /cv stops recommending work that already exists on an open PR. bullseye has no dedicated owner/not-mine disposition (feature filed as bullseye 🎯T43), so set_aside is a stand-in here — the reason carries the nuance the status enum can''t. REVIVE by clearing status back to identified (bullseye_put id=T64.2 status=identified) when ownership returns to Marcelo or #112 lands/closes.'
     acceptance:
     - vault_layout config key accepts "v2", "both", or "v1"; default is "both" for existing vaults, "v2" for new.
     - _mnemo/index.md and _mnemo/README.md exist with the standard fence contract.
@@ -2239,9 +2240,10 @@ targets:
     discovered: 2026-05-22
   T64.3:
     name: Move decisions + memories under _mnemo/
-    status: identified
+    status: set_aside
     value: 2.0
     cost: 0.0
+    set_aside_reason: 'Leak-containment for the T64.2 ownership exclusion. Downstream of 🎯T64.2 (externally-owned, open PR #112). T64.2''s _mnemo/ namespace foundation is NOT on master, so this is not actually actionable — bullseye mechanically unblocked it only because set_aside(T64.2) is treated like achievement. Excluded to keep Marcelo''s frontier honest. REVIVE together with T64.2 (status→identified) when ownership returns / #112 lands.'
     acceptance:
     - decisions/ and memories/ pages render under _mnemo/decisions/ and _mnemo/memories/ with the design's new frontmatter shape and
     - Old v1 decision/memory files still written when vault_layout="both".
@@ -2268,9 +2270,10 @@ targets:
     discovered: 2026-05-22
   T64.5:
     name: PKM profile + auto-detect (mtime-based)
-    status: identified
+    status: set_aside
     value: 2.0
     cost: 0.0
+    set_aside_reason: 'Leak-containment for the T64.2 ownership exclusion. Downstream of 🎯T64.2 (externally-owned, open PR #112). T64.2''s _mnemo/ namespace foundation is NOT on master, so this is not actually actionable — bullseye mechanically unblocked it only because set_aside(T64.2) is treated like achievement. Excluded to keep Marcelo''s frontier honest. REVIVE together with T64.2 (status→identified) when ownership returns / #112 lands.'
     acceptance:
     - vault_profile config key accepts "obsidian", "logseq", "foam", or "generic".
     - 'Per-profile renderer hooks plumbed for link syntax + properties differences (Obsidian alias links, Logseq prop:: syntax, etc.).'
@@ -2283,9 +2286,10 @@ targets:
     discovered: 2026-05-22
   T64.6:
     name: Bridges
-    status: identified
+    status: set_aside
     value: 2.0
     cost: 0.0
+    set_aside_reason: 'Leak-containment for the T64.2 ownership exclusion. Downstream of 🎯T64.2 (externally-owned, open PR #112). T64.2''s _mnemo/ namespace foundation is NOT on master, so this is not actually actionable — bullseye mechanically unblocked it only because set_aside(T64.2) is treated like achievement. Excluded to keep Marcelo''s frontier honest. REVIVE together with T64.2 (status→identified) when ownership returns / #112 lands.'
     acceptance:
     - vault_bridges config maps collection name (themes / patterns / cross-repo / lessons / decisions / memories) to an anchor-file path anywhere in the vault.
     - Whole-file atomic write inserts a fenced block ('<!-- mnemo:bridge:<name> --> ... <!-- /mnemo:bridge:<name> -->') into the named anchor file.
@@ -3637,7 +3641,7 @@ targets:
     discovered: 2026-06-30
   T97.1:
     name: The backend daemon drains gracefully on SIGTERM/SIGINT and leaves a checkpointed WAL
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -3653,6 +3657,7 @@ targets:
     - wal
     origin: manual
     discovered: 2026-06-30
+    achieved: 2026-07-06
   T97.2:
     name: A newer mnemo release is detected and surfaced via the T83 health pipeline
     status: identified

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -215,7 +215,17 @@ func (r *Registry) CompactWatcherFor(username string) *compact.Watcher {
 func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 	logger := slog.Default().With("user", username)
 
-	// Ingest + watcher + image workers + repo-level ingest streams.
+	// Realtime transcript watcher. Start this before the cold catch-up
+	// backlog so new appends are indexed with stack-like priority.
+	e.workers.Add(1)
+	go func() {
+		defer e.workers.Done()
+		if err := e.store.Watch(r.baseCtx); err != nil {
+			logger.Error("watcher failed", "err", err)
+		}
+	}()
+
+	// Ingest + image workers + repo-level ingest streams.
 	e.workers.Add(1)
 	go func() {
 		defer e.workers.Done()
@@ -289,9 +299,6 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 					logger.Warn("vault: initial sync failed", "err", err)
 				}
 			}()
-		}
-		if err := e.store.Watch(r.baseCtx); err != nil {
-			logger.Error("watcher failed", "err", err)
 		}
 	}()
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -290,7 +290,7 @@ func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 				}
 			}()
 		}
-		if err := e.store.Watch(); err != nil {
+		if err := e.store.Watch(r.baseCtx); err != nil {
 			logger.Error("watcher failed", "err", err)
 		}
 	}()

--- a/internal/store/debouncer.go
+++ b/internal/store/debouncer.go
@@ -48,6 +48,19 @@ func (d *debouncer) enqueue(key string, fn func()) {
 	})
 }
 
+// stop cancels every pending timer so no debounced callback fires after the
+// caller has begun shutting down (🎯T97.1). A callback already executing is
+// unaffected; this only prevents not-yet-fired ingest work from racing the
+// store's Close/checkpoint. Safe to call once on the watcher's exit path.
+func (d *debouncer) stop() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for key, t := range d.timers {
+		t.Stop()
+		delete(d.timers, key)
+	}
+}
+
 // invocations returns the number of callbacks that have fired.
 // Intended for testing only.
 func (d *debouncer) invocations() int64 {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -832,12 +832,62 @@ func New(dbPath, projectDir string) (*Store, error) {
 
 // Close closes the store.
 func (s *Store) Close() error {
+	// Drain order matters (🎯T97.1): quiesce the read pool first, then
+	// checkpoint the writer, then close the writer. TRUNCATE only fully
+	// resets the -wal when no other connection holds a WAL read lock, so
+	// closing readDB before checkpointing gives the truncate the best
+	// chance to leave a zero-length -wal behind. A busy or failed
+	// checkpoint is logged but never fails Close — the DB still closes
+	// cleanly and crash-only recovery replays any residual frames.
 	rerr := s.readDB.Close()
+
+	if res, err := s.Checkpoint(); err != nil {
+		slog.Warn("wal checkpoint on close failed", "db", s.dbPath, "err", err)
+	} else if res.Busy != 0 {
+		slog.Warn("wal checkpoint on close busy; -wal left for crash recovery",
+			"db", s.dbPath, "busy", res.Busy, "log", res.Log, "checkpointed", res.Checkpointed)
+	} else {
+		slog.Info("wal checkpoint on close",
+			"db", s.dbPath, "busy", res.Busy, "log", res.Log, "checkpointed", res.Checkpointed)
+	}
+
 	werr := s.writeDB.Close()
 	if rerr != nil {
 		return rerr
 	}
 	return werr
+}
+
+// CheckpointResult holds the three integers PRAGMA wal_checkpoint returns.
+// Busy is 1 when the checkpoint could not run to completion because another
+// connection held a read lock on the WAL; Log is the number of frames in the
+// write-ahead log; Checkpointed is the number of frames moved back into the
+// main database. After a successful TRUNCATE (Busy == 0) the -wal file has
+// been flushed into the db and truncated to zero bytes.
+type CheckpointResult struct {
+	Busy         int
+	Log          int
+	Checkpointed int
+}
+
+// Checkpoint runs PRAGMA wal_checkpoint(TRUNCATE) on the writer connection,
+// flushing the write-ahead log into the main database file and truncating the
+// -wal to zero. It is the durable-shutdown primitive for 🎯T97.1: after a
+// clean drain the next startup replays no WAL. Because TRUNCATE only resets
+// the WAL when no other connection holds a read lock, callers that want a
+// zero-length -wal should quiesce the read pool (close readDB) first; a
+// non-zero Busy signals the reset was blocked and the WAL was left in place
+// for crash recovery.
+func (s *Store) Checkpoint() (CheckpointResult, error) {
+	var r CheckpointResult
+	if s.writeDB == nil {
+		return r, nil
+	}
+	row := s.writeDB.QueryRow("PRAGMA wal_checkpoint(TRUNCATE)")
+	if err := row.Scan(&r.Busy, &r.Log, &r.Checkpointed); err != nil {
+		return r, fmt.Errorf("wal_checkpoint(TRUNCATE): %w", err)
+	}
+	return r, nil
 }
 
 // MemoryInfo holds a single memory record from the index.
@@ -3073,10 +3123,23 @@ func (s *Store) writeParsedFile(ws *writerState, pf parsedFile) {
 	// os.Stat error just records NULL — detection falls back to
 	// offset-vs-size on the next pass.
 	recSize, recMtime := statFingerprint(pf.path)
-	ws.tx.Exec(`INSERT OR REPLACE INTO ingest_state (path, offset, recorded_size, recorded_mtime)
-		VALUES (?, ?, ?, ?)`, pf.path, pf.newOffset, recSize, recMtime)
+	ws.tx.Exec(`INSERT INTO ingest_state (path, offset, recorded_size, recorded_mtime)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(path) DO UPDATE SET
+			offset = MAX(ingest_state.offset, excluded.offset),
+			recorded_size = CASE
+				WHEN excluded.offset >= ingest_state.offset THEN excluded.recorded_size
+				ELSE ingest_state.recorded_size
+			END,
+			recorded_mtime = CASE
+				WHEN excluded.offset >= ingest_state.offset THEN excluded.recorded_mtime
+				ELSE ingest_state.recorded_mtime
+			END`,
+		pf.path, pf.newOffset, recSize, recMtime)
 	s.mu.Lock()
-	s.offsets[pf.path] = pf.newOffset
+	if pf.newOffset > s.offsets[pf.path] {
+		s.offsets[pf.path] = pf.newOffset
+	}
 	s.mu.Unlock()
 }
 
@@ -3217,7 +3280,12 @@ func parseFile(path string, offset int64) (parsedFile, error) {
 }
 
 // Watch watches for new/modified JSONL files and ingests them in realtime.
-func (s *Store) Watch() error {
+// It runs until ctx is cancelled (graceful drain, 🎯T97.1) or the fsnotify
+// backend closes its channels. Returning promptly on cancellation is what
+// lets Registry.Close finish stopping workers and reach the WAL checkpoint;
+// before ctx observance the kqueue/inotify read blocked shutdown until the
+// drain deadline forced a hard exit.
+func (s *Store) Watch(ctx context.Context) error {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return err
@@ -3305,9 +3373,14 @@ func (s *Store) Watch() error {
 	// operations) for the same path into a single re-index after 300ms of quiet.
 	// Heavy ingest work runs in the timer goroutine, not on the event goroutine.
 	db := newDebouncer(300 * time.Millisecond)
+	// On drain, cancel pending debounced ingests so none races the store's
+	// Close/checkpoint (🎯T97.1).
+	defer db.stop()
 
 	for {
 		select {
+		case <-ctx.Done():
+			return nil
 		case event, ok := <-watcher.Events:
 			if !ok {
 				return nil

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -72,6 +72,38 @@ func newTestStore(t *testing.T, projectDir string) *Store {
 	return s
 }
 
+func TestWriteParsedFileDoesNotRegressOffset(t *testing.T) {
+	s := newTestStore(t, t.TempDir())
+	path := filepath.Join(t.TempDir(), "sess.jsonl")
+
+	writeParsed := func(off int64) {
+		t.Helper()
+		ws, err := newWriterState(s.writeDB)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s.writeParsedFile(ws, parsedFile{path: path, sessionID: "sess", project: "proj", newOffset: off})
+		ws.Close()
+		if err := ws.tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeParsed(200)
+	writeParsed(100)
+
+	var got int64
+	if err := s.readDB.QueryRow("SELECT offset FROM ingest_state WHERE path = ?", path).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != 200 {
+		t.Fatalf("ingest_state offset regressed to %d, want 200", got)
+	}
+	if got := s.offsets[path]; got != 200 {
+		t.Fatalf("in-memory offset regressed to %d, want 200", got)
+	}
+}
+
 func TestIngestAndSearch(t *testing.T) {
 	projectDir := t.TempDir()
 
@@ -2556,4 +2588,70 @@ func writeBenchJSONL(b *testing.B, dir, project, sessionID string, entries []map
 		}
 	}
 	return path
+}
+
+// TestCheckpointTruncatesWAL proves Store.Checkpoint runs a TRUNCATE
+// checkpoint (🎯T97.1): after writes grow the -wal, Checkpoint flushes the
+// frames into the main database and truncates the -wal to zero bytes while
+// the store is still open. This is the durability guarantee a clean drain
+// relies on — the default PASSIVE checkpoint on last-connection-close would
+// not reset the -wal mid-life.
+func TestCheckpointTruncatesWAL(t *testing.T) {
+	projectDir := t.TempDir()
+	dbPath := filepath.Join(t.TempDir(), "ckpt.db")
+	s, err := New(dbPath, projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	// Disable autocheckpoint so the seed writes below stay resident in the
+	// WAL until our explicit Checkpoint flushes them — otherwise SQLite's
+	// 1000-page automatic checkpoint may reset the log first, making the
+	// moved-frame count non-deterministic.
+	if _, err := s.writeDB.Exec("PRAGMA wal_autocheckpoint = 0"); err != nil {
+		t.Fatalf("disable autocheckpoint: %v", err)
+	}
+
+	// Grow the write-ahead log with a batch of autocommitted writes.
+	for i := 0; i < 50; i++ {
+		if _, err := s.writeDB.Exec(
+			"INSERT INTO ingest_state(path, offset) VALUES(?, ?)",
+			fmt.Sprintf("/fake/path/%d", i), int64(i),
+		); err != nil {
+			t.Fatalf("seed write %d: %v", i, err)
+		}
+	}
+
+	walPath := dbPath + "-wal"
+	if fi, err := os.Stat(walPath); err != nil {
+		t.Fatalf("stat -wal before checkpoint: %v", err)
+	} else if fi.Size() == 0 {
+		t.Fatal("expected a non-empty -wal before checkpoint, got 0 bytes")
+	}
+
+	res, err := s.Checkpoint()
+	if err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if res.Busy != 0 {
+		t.Errorf("checkpoint busy = %d, want 0 (idle read pool must not block TRUNCATE)", res.Busy)
+	}
+	// NOTE: on a successful TRUNCATE this SQLite build reports the log/
+	// checkpointed frame counters as 0 rather than the frames actually moved,
+	// so the reliable success signal is Busy == 0 plus a -wal reset to zero
+	// bytes below — not res.Checkpointed. (A PASSIVE checkpoint on the same
+	// state reports the true 100-frame count; TRUNCATE flushes those frames
+	// and truncates, then zeroes the counters.)
+
+	// TRUNCATE resets the -wal to zero bytes (a missing file is an equally
+	// valid truncation outcome on some platforms/driver builds). The -wal
+	// was non-empty above, so a zero here proves the flush+truncate ran.
+	if fi, err := os.Stat(walPath); err != nil {
+		if !os.IsNotExist(err) {
+			t.Fatalf("stat -wal after checkpoint: %v", err)
+		}
+	} else if fi.Size() != 0 {
+		t.Errorf("-wal not truncated: size = %d bytes, want 0", fi.Size())
+	}
 }

--- a/main.go
+++ b/main.go
@@ -32,8 +32,10 @@ import (
 	"net/http/pprof"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -72,6 +74,13 @@ const (
 	version              = "0.60.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
+
+	// drainDeadline caps the graceful shutdown sequence (🎯T97.1). Stopping
+	// HTTP intake, stopping workers, quiescing the read pool, and truncating
+	// the WAL should complete well within this; if it overruns we hard-exit,
+	// which is safe under mnemo's crash-only durability (the next start
+	// recovers any un-checkpointed WAL frames).
+	drainDeadline = 10 * time.Second
 )
 
 // summariserWorkDir returns a dedicated, always-present working
@@ -186,7 +195,15 @@ func main() {
 		autoMigrateStdioAndExit(*addr)
 	}
 
-	if err := runServe(context.Background(), *addr, *federatedAddr); err != nil {
+	// Install a signal-driven cancellable context so a foreground
+	// SIGTERM/SIGINT (Ctrl+C, `brew services restart`, systemd stop) drives
+	// the graceful drain in runServe instead of hard-killing the daemon
+	// mid-request (🎯T97.1). The Windows-Service path handled its own
+	// SCM-driven cancellation above and never reaches here.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := runServe(ctx, *addr, *federatedAddr); err != nil {
 		os.Exit(1)
 	}
 }
@@ -829,22 +846,53 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 		slog.Error("HTTP MCP server failed", "err", err)
 		return err
 	case <-ctx.Done():
-		slog.Info("mnemo serve shutting down")
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		// Drain MCP sessions first, then close the TCP listener.
-		if err := httpSrv.Shutdown(shutdownCtx); err != nil {
-			slog.Warn("HTTP shutdown error", "err", err)
-		}
-		if err := httpServer.Shutdown(shutdownCtx); err != nil {
-			slog.Warn("HTTP server shutdown error", "err", err)
-		}
-		if fedSrv != nil {
-			if err := fedSrv.Shutdown(shutdownCtx); err != nil {
-				slog.Warn("federated HTTP shutdown error", "err", err)
+		slog.Info("mnemo serve draining", "deadline", drainDeadline)
+		// Ordered graceful drain (🎯T97.1), bounded by drainDeadline:
+		//   1. stop intake      — refuse new MCP/HTTP/federated requests,
+		//                          let in-flight ones finish
+		//   2. release lease     — seam for 🎯T97.4 (no-op until it exists)
+		//   3. stop workers      — cancel per-user worker contexts
+		//   4. quiesce read pool — close each readDB
+		//   5. checkpoint writer — PRAGMA wal_checkpoint(TRUNCATE)
+		// Steps 3–5 are driven by reg.Close(), which is idempotent, so the
+		// deferred reg.Close() above is a harmless second call. If the whole
+		// sequence overruns drainDeadline we hard-exit — safe under crash-only
+		// durability (residual WAL frames replay on the next start).
+		drainCtx, cancelDrain := context.WithTimeout(context.Background(), drainDeadline)
+		defer cancelDrain()
+		drained := make(chan struct{})
+		go func() {
+			defer close(drained)
+			// 1. Stop intake, draining in-flight requests within the deadline.
+			slog.Info("drain: stopping HTTP MCP intake")
+			if err := httpSrv.Shutdown(drainCtx); err != nil {
+				slog.Warn("HTTP MCP shutdown error", "err", err)
 			}
+			slog.Info("drain: stopping HTTP server intake")
+			if err := httpServer.Shutdown(drainCtx); err != nil {
+				slog.Warn("HTTP server shutdown error", "err", err)
+			}
+			if fedSrv != nil {
+				slog.Info("drain: stopping federated intake")
+				if err := fedSrv.Shutdown(drainCtx); err != nil {
+					slog.Warn("federated HTTP shutdown error", "err", err)
+				}
+			}
+			// 2. (release singleton background lease — 🎯T97.4)
+			// 3–5. Stop workers, quiesce read pools, checkpoint each writer.
+			slog.Info("drain: stopping workers + checkpointing stores")
+			reg.Close()
+		}()
+		select {
+		case <-drained:
+			slog.Info("mnemo serve drained cleanly")
+			return nil
+		case <-drainCtx.Done():
+			slog.Warn("drain exceeded deadline; forcing exit (crash-only recovery on next start)",
+				"deadline", drainDeadline)
+			os.Exit(0)
+			return nil // unreachable; os.Exit does not return
 		}
-		return nil
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.60.0"
+	version              = "0.61.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 


### PR DESCRIPTION
## Summary

Two composable daemon-lifecycle changes, bundled for release:

1. **Graceful drain on SIGTERM/SIGINT (🎯T97.1).** `main()` now installs a
   signal-driven cancellable context, so a foreground `SIGTERM`/`SIGINT`
   (`brew services restart`, systemd stop, Ctrl+C) drives an ordered drain
   instead of hard-killing the daemon mid-request. Order: stop HTTP intake →
   *(lease-release seam for 🎯T97.4)* → stop workers → quiesce read pool →
   `PRAGMA wal_checkpoint(TRUNCATE)` on the writer. Bounded by a 10 s deadline
   with a hard-exit fallback (safe under crash-only durability). Previously the
   drain block in `runServe` was dead code on macOS/Linux — `main()` passed
   `context.Background()`, which never cancels.

2. **Realtime watcher starts before cold catch-up.** The fsnotify watcher moves
   into its own worker goroutine that starts ahead of the initial `IngestAll`
   backlog, so new appends are indexed immediately. *(Work by a concurrent Codex
   CLI session; assembled here alongside T97.1.)*

These compose: codex's relocated watcher call is `Store.Watch(r.baseCtx)`, which
only compiles because T97.1 made `Watch` context-aware — and the ctx is exactly
what lets the watcher drain promptly.

## Supporting changes
- `Store.Checkpoint()` — `PRAGMA wal_checkpoint(TRUNCATE)`; `Store.Close()`
  reordered to quiesce reads → checkpoint → close writer, logging the result
  (`busy != 0` warns).
- `Store.Watch(ctx)` — the fsnotify loop observes cancellation so
  `Registry.Close`'s `workers.Wait()` completes on shutdown (fixing a latent
  hang the drain surfaced). `debouncer.stop()` cancels pending ingests so none
  races the checkpoint.

## Verification
- `go test -tags sqlite_fts5 ./...` — all 22 packages pass.
- Live `SIGTERM` and `SIGINT` drains: clean WAL checkpoint (`busy=0`, `-wal`
  truncated to 0 bytes), rc=0, ~0.1 s; deadline hard-exit fallback exercised.
- Windows: validated on the local Parallels VM (see the `windows-vm-validated`
  gate).

## Target lifecycle (rides this PR)
- 🎯T97.1 **retired** (delivered here).
- 🎯T64.2 **set aside** — ownership exclusion: it's driven on open PR #112, not
  parked. 🎯T64.3/T64.5/T64.6 set aside as leak-containment (set_aside unblocks
  dependents, which had leaked them into the frontier). bullseye lacks a
  first-class owner/not-mine disposition; filed as bullseye 🎯T43.

## Notes
- Internal-only diff: no new CLI flags, no new MCP tools, no user-facing surface.
- `--version` → `0.61.0`.

Co-Authored-By: Codex CLI <codex@openai.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
