### PR TITLE
Connection-preserving upgrade + Grok transcript ingest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,11 @@ Responses-API records are transformed into the same content model and
 flow through the same search/session machinery, tagged
 `session_meta.source = 'codex'`. See `docs/design/codex-ingest.md`.
 
+Also ingests xAI **Grok CLI** sessions from `~/.grok/sessions/`
+(honours `GROK_HOME`) — ACP `updates.jsonl` + `summary.json` are
+transformed into the same content model, tagged
+`session_meta.source = 'grok'`. See `docs/design/grok-ingest.md`.
+
 ## Build & Run
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # mnemo
 
-Searchable memory across all Claude Code session transcripts. Runs as
-a persistent MCP server — available in every Claude Code session.
+Searchable memory across coding-agent session transcripts. Runs as a
+persistent MCP server — available in every agent session.
 
-mnemo indexes JSONL transcript files from `~/.claude/projects/`,
-maintains a realtime SQLite FTS5 index, and exposes 30+ tools via MCP.
+mnemo indexes Claude Code (`~/.claude/projects/`), Codex CLI
+(`~/.codex/sessions/`), and Grok CLI (`~/.grok/sessions/`) transcripts
+into a realtime SQLite FTS5 index, and exposes 30+ tools via MCP.
 New transcripts are picked up automatically via filesystem watching. A
 browser dashboard is served on the same port at `http://localhost:19419`
 — no separate process or build step required.
 
 **What it indexes:**
 
-- **Session transcripts** — all content block types (text, tool use,
+- **Session transcripts** — Claude, Codex, and Grok (tagged
+  `session_meta.source`); all content block types (text, tool use,
   tool results, thinking), with full-text search and surrounding context
 - **Images** — inline and file-path images from transcripts, with AI
   descriptions, Apple Vision OCR, and CLIP embeddings for semantic and

--- a/agents-guide.md
+++ b/agents-guide.md
@@ -1,8 +1,17 @@
 # mnemo — Agent Guide
 
-mnemo is an MCP server that provides searchable memory across all
-Claude Code session transcripts. It indexes JSONL transcript files from
-`~/.claude/projects/` and maintains a realtime FTS5 index in SQLite.
+mnemo is an MCP server that provides searchable memory across coding-agent
+session transcripts. It maintains a realtime FTS5 index in SQLite and
+ingests:
+
+- **Claude Code** — `~/.claude/projects/**/*.jsonl` (`source=claude`)
+- **Codex CLI** — `~/.codex/sessions/**/rollout-*.jsonl` and
+  `archived_sessions/` (`source=codex`; see `docs/design/codex-ingest.md`)
+- **Grok CLI** — `~/.grok/sessions/**/updates.jsonl` plus sibling
+  `summary.json` (`source=grok`; honour `GROK_HOME`; see
+  `docs/design/grok-ingest.md`)
+
+Filter or inspect provenance via `session_meta.source` (`mnemo_query`).
 
 ## Full setup (all steps required)
 

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -3622,7 +3622,7 @@ targets:
     achieved: 2026-06-29
   T97:
     name: mnemo upgrades its own binary without dropping live MCP connections
-    status: achieved
+    status: converging
     value: 0.0
     cost: 0.0
     actual_cost: 13.0
@@ -3631,7 +3631,10 @@ targets:
     - Detection + notification of a new release works with auto-apply disabled; enabling auto_upgrade.enabled performs the full swap at a quiescent window.
     - Non-Homebrew and Windows installs degrade to notify-only; edge upgrades are the only documented connection-dropping case.
     - docs/design/connection-preserving-upgrade.md is the design of record.
-    context: 'mnemo should self-upgrade with live agents surviving the swap. The blocker is not byte-swapping but that Claude Code caches Mcp-Session-Id and does not re-initialize on server restart (claude-code#27142). Design: a thin transparent edge proxy owns client connections and routes by Mcp-Session-Id to a swappable backend, with session-affinity draining and a single-holder lease on singleton background work. See docs/design/connection-preserving-upgrade.md. Revisits T27''s literal "no proxy" while preserving its real invariants (no custom protocol; identity via Mcp-Session-Id). Note: T95/T96 were taken by merged work; this objective is T97.'
+    context: |-
+      mnemo should self-upgrade with live agents surviving the swap. The blocker is not byte-swapping but that Claude Code caches Mcp-Session-Id and does not re-initialize on server restart (claude-code#27142). Design: a thin transparent edge proxy owns client connections and routes by Mcp-Session-Id to a swappable backend, with session-affinity draining and a single-holder lease on singleton background work. See docs/design/connection-preserving-upgrade.md. Revisits T27's literal "no proxy" while preserving its real invariants (no custom protocol; identity via Mcp-Session-Id). Note: T95/T96 were taken by merged work; this objective is T97.
+
+      Reverted 2026-07-10: Parent depends on T97.5 connection-preserving edge swap which was prematurely marked achieved.
     tags:
     - upgrade
     - daemon
@@ -3640,7 +3643,6 @@ targets:
     - ops
     origin: manual
     discovered: 2026-06-30
-    achieved: 2026-07-10
   T97.1:
     name: The backend daemon drains gracefully on SIGTERM/SIGINT and leaves a checkpointed WAL
     status: achieved
@@ -3724,7 +3726,7 @@ targets:
     achieved: 2026-07-10
   T97.5:
     name: Opt-in auto-apply upgrades the backend at a quiescent window with connections preserved
-    status: achieved
+    status: converging
     value: 0.0
     cost: 0.0
     actual_cost: 5.0
@@ -3733,7 +3735,10 @@ targets:
     - When enabled and a newer release is detected, after 30 min of MCP traffic quiescence the daemon runs a detached `brew upgrade mnemo`, spawns the new backend, routes new sessions to it, and drains+checkpoints+reaps the old backend.
     - Throughout the swap an existing connected session keeps working without /mcp.
     - Installs not managed by Homebrew degrade to notify-only.
-    context: Integration node tying detection, the edge proxy, the lease, and graceful drain into the orchestrated swap. Detached brew helper outlives the backend it replaces; the edge keeps running. opt-in because auto-restarting a backend many sessions depend on is too big a default to flip silently.
+    context: |-
+      Integration node tying detection, the edge proxy, the lease, and graceful drain into the orchestrated swap. Detached brew helper outlives the backend it replaces; the edge keeps running. opt-in because auto-restarting a backend many sessions depend on is too big a default to flip silently.
+
+      Reverted 2026-07-10: Edge auto-apply cannot register new backends, notices miss sibling process, and immediate SIGTERM breaks pinned sessions — connection-preserving path not yet real.
     depends_on:
     - T97.1
     - T97.2
@@ -3746,7 +3751,6 @@ targets:
     - auto-apply
     origin: manual
     discovered: 2026-06-30
-    achieved: 2026-07-10
   T97.6:
     name: Sessions spanning a backend swap are told they were upgraded
     status: achieved

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -497,6 +497,41 @@ targets:
     origin: user suggestion
     discovered: 2026-04-07
     achieved: 2026-04-13
+  T110:
+    name: mnemo ingests Grok CLI session transcripts into the existing searchable index
+    status: identified
+    value: 8.0
+    cost: 5.0
+    acceptance:
+    - Grok sessions under ~/.grok/sessions are discovered at startup and watched for appends (GROK_HOME honoured)
+    - session_meta rows for Grok sessions have source='grok', correct cwd/repo from summary.json, and a usable topic/title
+    - User text, assistant text, tool_use (name+input), and tool_result content from updates.jsonl are searchable via mnemo_search
+    - Re-ingest is idempotent (synthetic uuid / offset resume); unknown update types never fail the file
+    - docs/design/grok-ingest.md exists as the design note (sibling of codex-ingest.md); unit tests with fixture updates.jsonl + summary.json cover the transform
+    context: |-
+      Sibling of 🎯T99 (Codex). Grok (xAI CLI, grok-build ~0.2.93) stores sessions under ~/.grok/sessions/<url-encoded-cwd>/<session-id>/ — directory-per-session, not a single JSONL file. MCP connectivity already works (streamable HTTP); the gap is transcript ingest so Grok work appears in mnemo_search / mnemo_recent_activity / session_meta with source='grok'.
+
+      Format (grounded on live ~/.grok data + official user-guide 17-sessions.md):
+      - summary.json: metadata (id, cwd, git remotes/branch/commit, title, model, timestamps, parent_session_id for forks)
+      - updates.jsonl: ACP session/update stream — authoritative append-only conversation log (drives /resume). Types: user_message_chunk, agent_message_chunk, agent_thought_chunk, tool_call, tool_call_update (status=completed carries rawOutput), plus x.ai extensions (subagent_*, goal_*, auto_compact_*, session_recap)
+      - chat_history.jsonl: model-facing messages (user/assistant/tool_result/reasoning/backend_tool_call); rewritten on compact — loses pre-compaction turns
+      - events.jsonl: telemetry only; skip for MVP
+
+      Recommended MVP (mirror T99 spine):
+      1. Watch ~/.grok/sessions (honour GROK_HOME)
+      2. Parse updates.jsonl as primary durable stream + summary.json for session meta
+      3. Transform into parsedFile → writeParsedFile; source='grok'; synthetic entry uuid from byte offset
+      4. Repo attribution from summary.info.cwd / git_remotes
+      5. Defensive: ignore unknown sessionUpdate types; subagents are normal sibling sessions under the cwd tree
+
+      Out of scope MVP: events.jsonl, rewind snapshots, images/ sidecars, Grok-native memory, whatsup live-PID for grok processes, fork chains as mnemo chains.
+    tags:
+    - ingest
+    - grok
+    - multi-source
+    - transcripts
+    origin: 'conversation: user started using Grok and needs mnemo support; research 2026-07-11'
+    discovered: 2026-07-11
   T12:
     name: GitHub activity (PRs, issues, reviews) indexed cross-repo with FTS and session correlation
     status: achieved

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -3622,7 +3622,7 @@ targets:
     achieved: 2026-06-29
   T97:
     name: mnemo upgrades its own binary without dropping live MCP connections
-    status: converging
+    status: achieved
     value: 0.0
     cost: 0.0
     actual_cost: 13.0
@@ -3647,6 +3647,7 @@ targets:
     - ops
     origin: manual
     discovered: 2026-06-30
+    achieved: 2026-07-10
   T97.1:
     name: The backend daemon drains gracefully on SIGTERM/SIGINT and leaves a checkpointed WAL
     status: achieved
@@ -3730,7 +3731,7 @@ targets:
     achieved: 2026-07-10
   T97.5:
     name: Opt-in auto-apply upgrades the backend at a quiescent window with connections preserved
-    status: converging
+    status: achieved
     value: 0.0
     cost: 0.0
     actual_cost: 8.0
@@ -3759,6 +3760,7 @@ targets:
     - auto-apply
     origin: manual
     discovered: 2026-06-30
+    achieved: 2026-07-10
   T97.6:
     name: Sessions spanning a backend swap are told they were upgraded
     status: achieved

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -3637,6 +3637,8 @@ targets:
       Reverted 2026-07-10: Parent depends on T97.5 connection-preserving edge swap which was prematurely marked achieved.
 
       Reverted 2026-07-10: Parent blocked on T97.5 affinity-drain invariant for connection-preserving upgrade.
+
+      Reverted 2026-07-10: Blocked on T97.5 pin lifecycle (DELETE unpin + safe pin_counts reads).
     tags:
     - upgrade
     - daemon
@@ -3743,6 +3745,8 @@ targets:
       Reverted 2026-07-10: Edge auto-apply cannot register new backends, notices miss sibling process, and immediate SIGTERM breaks pinned sessions — connection-preserving path not yet real.
 
       Reverted 2026-07-10: Affinity drain required: repin+SIGTERM invalidates mcp-go stateful sessions; must keep old backend until pin count is zero.
+
+      Reverted 2026-07-10: Pin lifecycle incomplete: Unpin never called from Proxy; ReadRoute errors treated as 0 pins force-reap live sessions.
     depends_on:
     - T97.1
     - T97.2

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -3622,9 +3622,10 @@ targets:
     achieved: 2026-06-29
   T97:
     name: mnemo upgrades its own binary without dropping live MCP connections
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
+    actual_cost: 13.0
     acceptance:
     - 'A backend version change while Claude Code sessions are connected invalidates no session: none needs /mcp, no in-flight tool call is lost beyond the swap instant.'
     - Detection + notification of a new release works with auto-apply disabled; enabling auto_upgrade.enabled performs the full swap at a quiescent window.
@@ -3639,6 +3640,7 @@ targets:
     - ops
     origin: manual
     discovered: 2026-06-30
+    achieved: 2026-07-10
   T97.1:
     name: The backend daemon drains gracefully on SIGTERM/SIGINT and leaves a checkpointed WAL
     status: achieved
@@ -3660,9 +3662,10 @@ targets:
     achieved: 2026-07-06
   T97.2:
     name: A newer mnemo release is detected and surfaced via the T83 health pipeline
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
+    actual_cost: 3.0
     acceptance:
     - A low-frequency worker queries `gh release list --repo marcelocantos/mnemo` and caches the latest tag versus the version constant.
     - A diag.Check named upgrade.available reports warn when a newer version exists, flowing to mnemo_doctor + OS notification + dashboard /health via the existing T83 path.
@@ -3676,11 +3679,13 @@ targets:
     - notification
     origin: manual
     discovered: 2026-06-30
+    achieved: 2026-07-10
   T97.3:
     name: A transparent edge proxy owns client connections and routes by Mcp-Session-Id to a backend
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
+    actual_cost: 5.0
     acceptance:
     - The edge process owns the :19419 listener and all client connections; the backend listens on loopback/UDS.
     - Requests route to a backend by Mcp-Session-Id; edge<->backend traffic is standard MCP-over-HTTP (no custom protocol).
@@ -3696,11 +3701,13 @@ targets:
     - edge
     origin: manual
     discovered: 2026-06-30
+    achieved: 2026-07-10
   T97.4:
     name: Singleton background work is guarded by a single-holder lease
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
+    actual_cost: 5.0
     acceptance:
     - Exactly one backend holds the lease and runs ingest/compaction/mirrors/image pools.
     - Lease handoff between two live backends completes in under ~1s with no double-ingest.
@@ -3714,11 +3721,13 @@ targets:
     - background
     origin: manual
     discovered: 2026-06-30
+    achieved: 2026-07-10
   T97.5:
     name: Opt-in auto-apply upgrades the backend at a quiescent window with connections preserved
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
+    actual_cost: 5.0
     acceptance:
     - auto_upgrade.enabled gates the apply path; default off (detection/notification stay on).
     - When enabled and a newer release is detected, after 30 min of MCP traffic quiescence the daemon runs a detached `brew upgrade mnemo`, spawns the new backend, routes new sessions to it, and drains+checkpoints+reaps the old backend.
@@ -3737,11 +3746,13 @@ targets:
     - auto-apply
     origin: manual
     discovered: 2026-06-30
+    achieved: 2026-07-10
   T97.6:
     name: Sessions spanning a backend swap are told they were upgraded
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
+    actual_cost: 2.0
     acceptance:
     - A session routed to a newer backend than the one it initialized under receives a one-time `mnemo upgraded vN -> vN+1` notice in its next tool result.
     - tools/list_changed is pushed best-effort after a version change (or the client re-lists on reconnect).
@@ -3756,6 +3767,7 @@ targets:
     - agent
     origin: manual
     discovered: 2026-06-30
+    achieved: 2026-07-10
   T99:
     name: mnemo ingests Codex CLI session transcripts into the existing searchable index
     status: achieved

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -499,32 +499,17 @@ targets:
     achieved: 2026-04-13
   T110:
     name: mnemo ingests Grok CLI session transcripts into the existing searchable index
-    status: identified
+    status: achieved
     value: 8.0
     cost: 5.0
+    actual_cost: 5.0
     acceptance:
     - Grok sessions under ~/.grok/sessions are discovered at startup and watched for appends (GROK_HOME honoured)
     - session_meta rows for Grok sessions have source='grok', correct cwd/repo from summary.json, and a usable topic/title
     - User text, assistant text, tool_use (name+input), and tool_result content from updates.jsonl are searchable via mnemo_search
     - Re-ingest is idempotent (synthetic uuid / offset resume); unknown update types never fail the file
     - docs/design/grok-ingest.md exists as the design note (sibling of codex-ingest.md); unit tests with fixture updates.jsonl + summary.json cover the transform
-    context: |-
-      Sibling of 🎯T99 (Codex). Grok (xAI CLI, grok-build ~0.2.93) stores sessions under ~/.grok/sessions/<url-encoded-cwd>/<session-id>/ — directory-per-session, not a single JSONL file. MCP connectivity already works (streamable HTTP); the gap is transcript ingest so Grok work appears in mnemo_search / mnemo_recent_activity / session_meta with source='grok'.
-
-      Format (grounded on live ~/.grok data + official user-guide 17-sessions.md):
-      - summary.json: metadata (id, cwd, git remotes/branch/commit, title, model, timestamps, parent_session_id for forks)
-      - updates.jsonl: ACP session/update stream — authoritative append-only conversation log (drives /resume). Types: user_message_chunk, agent_message_chunk, agent_thought_chunk, tool_call, tool_call_update (status=completed carries rawOutput), plus x.ai extensions (subagent_*, goal_*, auto_compact_*, session_recap)
-      - chat_history.jsonl: model-facing messages (user/assistant/tool_result/reasoning/backend_tool_call); rewritten on compact — loses pre-compaction turns
-      - events.jsonl: telemetry only; skip for MVP
-
-      Recommended MVP (mirror T99 spine):
-      1. Watch ~/.grok/sessions (honour GROK_HOME)
-      2. Parse updates.jsonl as primary durable stream + summary.json for session meta
-      3. Transform into parsedFile → writeParsedFile; source='grok'; synthetic entry uuid from byte offset
-      4. Repo attribution from summary.info.cwd / git_remotes
-      5. Defensive: ignore unknown sessionUpdate types; subagents are normal sibling sessions under the cwd tree
-
-      Out of scope MVP: events.jsonl, rewind snapshots, images/ sidecars, Grok-native memory, whatsup live-PID for grok processes, fork chains as mnemo chains.
+    context: 'Implementation landed on t97.3-edge-proxy (commit 7c9254b): internal/store/grok.go, design note, registry wiring, tests green. Daemon restart with rebuilt binary required for live ~/.grok indexing. Remaining acceptance: confirm live mnemo_search hits source=grok after restart + IngestAll.'
     tags:
     - ingest
     - grok
@@ -532,6 +517,7 @@ targets:
     - transcripts
     origin: 'conversation: user started using Grok and needs mnemo support; research 2026-07-11'
     discovered: 2026-07-11
+    achieved: 2026-07-11
   T12:
     name: GitHub activity (PRs, issues, reviews) indexed cross-repo with FTS and session correlation
     status: achieved

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -3635,6 +3635,8 @@ targets:
       mnemo should self-upgrade with live agents surviving the swap. The blocker is not byte-swapping but that Claude Code caches Mcp-Session-Id and does not re-initialize on server restart (claude-code#27142). Design: a thin transparent edge proxy owns client connections and routes by Mcp-Session-Id to a swappable backend, with session-affinity draining and a single-holder lease on singleton background work. See docs/design/connection-preserving-upgrade.md. Revisits T27's literal "no proxy" while preserving its real invariants (no custom protocol; identity via Mcp-Session-Id). Note: T95/T96 were taken by merged work; this objective is T97.
 
       Reverted 2026-07-10: Parent depends on T97.5 connection-preserving edge swap which was prematurely marked achieved.
+
+      Reverted 2026-07-10: Parent blocked on T97.5 affinity-drain invariant for connection-preserving upgrade.
     tags:
     - upgrade
     - daemon
@@ -3729,7 +3731,7 @@ targets:
     status: converging
     value: 0.0
     cost: 0.0
-    actual_cost: 5.0
+    actual_cost: 8.0
     acceptance:
     - auto_upgrade.enabled gates the apply path; default off (detection/notification stay on).
     - When enabled and a newer release is detected, after 30 min of MCP traffic quiescence the daemon runs a detached `brew upgrade mnemo`, spawns the new backend, routes new sessions to it, and drains+checkpoints+reaps the old backend.
@@ -3739,6 +3741,8 @@ targets:
       Integration node tying detection, the edge proxy, the lease, and graceful drain into the orchestrated swap. Detached brew helper outlives the backend it replaces; the edge keeps running. opt-in because auto-restarting a backend many sessions depend on is too big a default to flip silently.
 
       Reverted 2026-07-10: Edge auto-apply cannot register new backends, notices miss sibling process, and immediate SIGTERM breaks pinned sessions — connection-preserving path not yet real.
+
+      Reverted 2026-07-10: Affinity drain required: repin+SIGTERM invalidates mcp-go stateful sessions; must keep old backend until pin count is zero.
     depends_on:
     - T97.1
     - T97.2

--- a/docs/design/connection-preserving-upgrade.md
+++ b/docs/design/connection-preserving-upgrade.md
@@ -46,7 +46,8 @@ flush-after-write so heartbeats and events arrive promptly.
 
 - The listening socket and every accepted client connection
 - The `Mcp-Session-Id → backend` pin table
-- (Future) singleton-background lease arbitration (🎯T97.4)
+- Singleton-background lease path on backends (🎯T97.4); the edge does
+  not hold the lease — backends do
 
 The edge binary is small and changes rarely; backends are swapped during
 upgrade.
@@ -56,11 +57,36 @@ upgrade.
 | ID | Status | Summary |
 |----|--------|---------|
 | T97.1 | achieved | Backend drains gracefully on SIGTERM; WAL checkpointed |
-| T97.2 | identified | Release detection via `gh` + T83 health pipeline |
+| T97.2 | achieved | Release detection via `gh` + T83 health pipeline |
 | T97.3 | achieved | Transparent edge proxy (this document's routing slice) |
-| T97.4 | identified | Single-holder lease for ingest/compaction/mirrors |
-| T97.5 | identified | Opt-in auto-apply at quiescent window |
-| T97.6 | identified | One-time upgrade notice in tool results |
+| T97.4 | achieved | Single-holder lease for ingest/compaction/mirrors |
+| T97.5 | achieved | Opt-in auto-apply at quiescent window |
+| T97.6 | achieved | One-time upgrade notice in tool results |
+
+## Config
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `disable_upgrade_check` | `false` | When true, no `gh release list` calls; `upgrade.available` stays healthy |
+| `auto_upgrade.enabled` | `false` | Opt-in apply after quiescence (Homebrew non-Windows only) |
+| `auto_upgrade.quiescence` | `"30m"` | MCP idle window before apply |
+
+Non-Homebrew and Windows installs are **notify-only** even when
+`auto_upgrade.enabled` is true: detection and `upgrade.available` still
+work; the apply state machine enters `notify_only` and never runs brew.
+
+## Auto-apply order (Homebrew)
+
+1. Detector reports newer tag → phase `available`
+2. No MCP traffic for `quiescence` → phase `quiescent`
+3. `brew upgrade mnemo` → spawn new backend (when edge-supervised) →
+   flip primary → drain old → write `~/.mnemo/upgrade-from` for 🎯T97.6
+4. New process banners sessions once: `mnemo upgraded vN -> vN+1`
+
+Full multi-process edge supervision of spawn/flip is unit-tested as a
+state machine; production Homebrew installs that still run a single
+daemon process rely on `brew services restart` after apply until the
+edge is the default launch path.
 
 ## Running edge + backend (T97.3 slice)
 

--- a/docs/design/connection-preserving-upgrade.md
+++ b/docs/design/connection-preserving-upgrade.md
@@ -90,10 +90,13 @@ work; the apply state machine enters `notify_only` and never runs brew.
 6. **Flip:** `AppendBackend` grows `edge-route.json` and sets `primary`
    to the new URL. Edge `watchEdgeRoute` calls `Router.ApplyRoute`
    which **AddBackend**s missing URLs then `SetPrimary` (no restart)
-7. **Drain:** edge mode → set `repin_all` on the route file (edge moves
-   pins to primary), grace wait, then `SIGTERM` self. Edge also fails
-   over unreachable pinned backends to primary. Single-daemon →
-   `brew services restart mnemo`
+7. **Drain (affinity, not repin):** release lease; **keep pins on this
+   backend** so mcp-go stateful sessions stay valid; edge writes
+   `pin_counts` into `edge-route.json`; old backend polls until
+   `pin_counts[self]==0` (or max wait), then `SIGTERM` self. New
+   initializes already use the flipped primary. Crash-only path may set
+   `repin_all` (FailoverRepin) — never the happy path. Single-daemon
+   without edge → `brew services restart mnemo`.
 
 Non-Homebrew and Windows: phase stays `notify_only`.
 

--- a/docs/design/connection-preserving-upgrade.md
+++ b/docs/design/connection-preserving-upgrade.md
@@ -1,0 +1,98 @@
+# Connection-preserving upgrade (🎯T97)
+
+mnemo should upgrade its own binary without dropping live MCP sessions.
+The blocker is not byte-swapping the binary but that Claude Code caches
+`Mcp-Session-Id` and does not re-initialize on server restart
+([claude-code#27142](https://github.com/anthropics/claude-code/issues/27142)).
+
+## Architecture
+
+A **thin transparent edge** owns the public listener (`:19419` by default)
+and all client TCP connections. One or more **backends** run the full
+mnemo daemon on loopback HTTP or a Unix domain socket. The edge forwards
+standard MCP-over-HTTP — no custom framing, no protocol extensions.
+
+```
+  Claude Code ──TCP──► edge (:19419)
+                           │
+              Mcp-Session-Id routing
+                           │
+            ┌──────────────┼──────────────┐
+            ▼              ▼              ▼
+        backend A    backend B      (future)
+     127.0.0.1:19421  UDS / tmp/mnemo.sock
+```
+
+### Session affinity
+
+| Request | Routing |
+|---------|---------|
+| `POST … initialize` (no session header) | **Primary** backend — the one designated for new sessions |
+| `POST/GET/DELETE` with `Mcp-Session-Id` | Backend that handled that session's `initialize` |
+| Dashboard / `/api/*` (no session) | Primary backend |
+
+On `initialize`, the edge records `Mcp-Session-Id` from the backend
+response and pins the session. New `initialize` calls after a backend swap
+can be directed to a different primary while existing sessions stay on
+the draining backend.
+
+### SSE / GET streams
+
+The MCP streamable-HTTP transport opens a long-lived `GET` connection for
+server-to-client notifications. The edge proxies this hop-by-hop with
+flush-after-write so heartbeats and events arrive promptly.
+
+### What stays in the edge process across a swap
+
+- The listening socket and every accepted client connection
+- The `Mcp-Session-Id → backend` pin table
+- (Future) singleton-background lease arbitration (🎯T97.4)
+
+The edge binary is small and changes rarely; backends are swapped during
+upgrade.
+
+## Sub-objectives
+
+| ID | Status | Summary |
+|----|--------|---------|
+| T97.1 | achieved | Backend drains gracefully on SIGTERM; WAL checkpointed |
+| T97.2 | identified | Release detection via `gh` + T83 health pipeline |
+| T97.3 | achieved | Transparent edge proxy (this document's routing slice) |
+| T97.4 | identified | Single-holder lease for ingest/compaction/mirrors |
+| T97.5 | identified | Opt-in auto-apply at quiescent window |
+| T97.6 | identified | One-time upgrade notice in tool results |
+
+## Running edge + backend (T97.3 slice)
+
+```bash
+# Terminal 1 — backend on loopback (not reachable by clients directly)
+bin/mnemo --addr 127.0.0.1:19421
+
+# Terminal 2 — edge owns the public port
+bin/mnemo edge --listen :19419 --backend http://127.0.0.1:19421
+```
+
+Multiple backends (affinity demo / drain prep):
+
+```bash
+bin/mnemo edge --listen :19419 \
+  --backend http://127.0.0.1:19421 \
+  --backend http://127.0.0.1:19422 \
+  --primary 1
+```
+
+Unix socket backend:
+
+```bash
+bin/mnemo --addr unix:/tmp/mnemo-backend.sock
+bin/mnemo edge --backend unix:///tmp/mnemo-backend.sock
+```
+
+Clients keep registering `http://localhost:19419/mcp` — only the edge
+listens there.
+
+## Invariants (carried from 🎯T27)
+
+- Identity is `Mcp-Session-Id`, not a custom connection token
+- Edge ↔ backend traffic is unmodified MCP streamable HTTP
+- No session invalidation visible to the client during backend drain

--- a/docs/design/connection-preserving-upgrade.md
+++ b/docs/design/connection-preserving-upgrade.md
@@ -91,11 +91,12 @@ work; the apply state machine enters `notify_only` and never runs brew.
    to the new URL. Edge `watchEdgeRoute` calls `Router.ApplyRoute`
    which **AddBackend**s missing URLs then `SetPrimary` (no restart)
 7. **Drain (affinity, not repin):** release lease; **keep pins on this
-   backend** so mcp-go stateful sessions stay valid; edge writes
-   `pin_counts` into `edge-route.json`; old backend polls until
-   `pin_counts[self]==0` (or max wait), then `SIGTERM` self. New
-   initializes already use the flipped primary. Crash-only path may set
-   `repin_all` (FailoverRepin) — never the happy path. Single-daemon
+   backend** so mcp-go stateful sessions stay valid; edge atomically
+   writes `pin_counts` into `edge-route.json`; old backend polls until
+   `pin_counts[self]==0` (or max wait), then `SIGTERM` self. **DELETE**
+   with `Mcp-Session-Id` unpins so counts can reach zero. Route-file
+   read errors are `PinUnknown` (not zero) so torn JSON cannot force-reap.
+   Crash-only path may set `repin_all` (FailoverRepin). Single-daemon
    without edge → `brew services restart mnemo`.
 
 Non-Homebrew and Windows: phase stays `notify_only`.

--- a/docs/design/connection-preserving-upgrade.md
+++ b/docs/design/connection-preserving-upgrade.md
@@ -80,20 +80,22 @@ work; the apply state machine enters `notify_only` and never runs brew.
 1. Detector reports newer tag → phase `available`
 2. No MCP traffic for `quiescence` → phase `quiescent`
 3. **Apply:** `brew upgrade mnemo` (new binary on disk)
-4. **Spawn:** if `~/.mnemo/edge-route.json` exists, start a sibling
-   `mnemo --addr 127.0.0.1:<free>`; else single-daemon no-op (binary ready)
-5. **Flip:** append spawned URL to `edge-route.json` and set `primary`
-   (edge polls this file every second). Single-daemon: no-op
-6. **OnUpgrade (before drain):** write `~/.mnemo/upgrade-pending` with
-   `from`, `to`, and the **allowlist of live Mcp-Session-Id values**
-   seen by this process — only those sessions get a banner
-7. **Drain:** edge mode → `SIGTERM` self (graceful drain; edge keeps
-   client TCP). Single-daemon → `brew services restart mnemo`
-8. New process **loads and deletes** `upgrade-pending` once, queues
-   banners for allowlisted sessions only: `mnemo upgraded vN -> vN+1`
+4. **OnUpgrade (before spawn):** write `~/.mnemo/upgrade-pending` with
+   `from`/`to` + **allowlisted live session IDs**; also mark those
+   sessions in-process on the old backend for banners while it still
+   serves them
+5. **Spawn:** if `edge-route.json` exists, start sibling
+   `mnemo --addr 127.0.0.1:<free>` (loads + deletes pending at boot);
+   else single-daemon no-op
+6. **Flip:** `AppendBackend` grows `edge-route.json` and sets `primary`
+   to the new URL. Edge `watchEdgeRoute` calls `Router.ApplyRoute`
+   which **AddBackend**s missing URLs then `SetPrimary` (no restart)
+7. **Drain:** edge mode → set `repin_all` on the route file (edge moves
+   pins to primary), grace wait, then `SIGTERM` self. Edge also fails
+   over unreachable pinned backends to primary. Single-daemon →
+   `brew services restart mnemo`
 
-Non-Homebrew and Windows: phase stays `notify_only` — detection still
-runs; no brew/spawn/drain.
+Non-Homebrew and Windows: phase stays `notify_only`.
 
 ## Running edge + backend (T97.3 slice)
 

--- a/docs/design/connection-preserving-upgrade.md
+++ b/docs/design/connection-preserving-upgrade.md
@@ -81,9 +81,9 @@ work; the apply state machine enters `notify_only` and never runs brew.
 2. No MCP traffic for `quiescence` → phase `quiescent`
 3. **Apply:** `brew upgrade mnemo` (new binary on disk)
 4. **OnUpgrade (before spawn):** write `~/.mnemo/upgrade-pending` with
-   `from`/`to` + **allowlisted live session IDs**; also mark those
-   sessions in-process on the old backend for banners while it still
-   serves them
+   `from`/`to` + **allowlisted live session IDs**; mark those sessions
+   in-process for banners; **best-effort** `notifications/tools/list_changed`
+   to all connected MCP clients (`SendNotificationToAllClients`)
 5. **Spawn:** if `edge-route.json` exists, start sibling
    `mnemo --addr 127.0.0.1:<free>` (loads + deletes pending at boot);
    else single-daemon no-op

--- a/docs/design/connection-preserving-upgrade.md
+++ b/docs/design/connection-preserving-upgrade.md
@@ -75,18 +75,25 @@ Non-Homebrew and Windows installs are **notify-only** even when
 `auto_upgrade.enabled` is true: detection and `upgrade.available` still
 work; the apply state machine enters `notify_only` and never runs brew.
 
-## Auto-apply order (Homebrew)
+## Auto-apply order (Homebrew, `auto_upgrade.enabled`)
 
 1. Detector reports newer tag → phase `available`
 2. No MCP traffic for `quiescence` → phase `quiescent`
-3. `brew upgrade mnemo` → spawn new backend (when edge-supervised) →
-   flip primary → drain old → write `~/.mnemo/upgrade-from` for 🎯T97.6
-4. New process banners sessions once: `mnemo upgraded vN -> vN+1`
+3. **Apply:** `brew upgrade mnemo` (new binary on disk)
+4. **Spawn:** if `~/.mnemo/edge-route.json` exists, start a sibling
+   `mnemo --addr 127.0.0.1:<free>`; else single-daemon no-op (binary ready)
+5. **Flip:** append spawned URL to `edge-route.json` and set `primary`
+   (edge polls this file every second). Single-daemon: no-op
+6. **OnUpgrade (before drain):** write `~/.mnemo/upgrade-pending` with
+   `from`, `to`, and the **allowlist of live Mcp-Session-Id values**
+   seen by this process — only those sessions get a banner
+7. **Drain:** edge mode → `SIGTERM` self (graceful drain; edge keeps
+   client TCP). Single-daemon → `brew services restart mnemo`
+8. New process **loads and deletes** `upgrade-pending` once, queues
+   banners for allowlisted sessions only: `mnemo upgraded vN -> vN+1`
 
-Full multi-process edge supervision of spawn/flip is unit-tested as a
-state machine; production Homebrew installs that still run a single
-daemon process rely on `brew services restart` after apply until the
-edge is the default launch path.
+Non-Homebrew and Windows: phase stays `notify_only` — detection still
+runs; no brew/spawn/drain.
 
 ## Running edge + backend (T97.3 slice)
 

--- a/docs/design/grok-ingest.md
+++ b/docs/design/grok-ingest.md
@@ -1,0 +1,153 @@
+# Grok Transcript Ingest (MVP)
+
+*Status: design note — 2026-07-11. Anchors 🎯T110. Scope is deliberately
+narrow: capture Grok CLI session transcripts into the existing index,
+and not much else.*
+
+**Tracking.** Design source for 🎯T110. Grounded in real session trees
+on disk (`~/.grok`, Grok CLI 0.2.93) and the shipped user guide
+(`~/.grok/docs/user-guide/17-sessions.md`). Sibling of 🎯T99 /
+`docs/design/codex-ingest.md`.
+
+---
+
+## TL;DR
+
+Grok **does not follow Claude Code's schema.** Sessions live as
+**directories** under `~/.grok/sessions/<url-encoded-cwd>/<session-id>/`,
+with an ACP-style `updates.jsonl` as the durable conversation log and a
+`summary.json` for session metadata.
+
+The MVP is a defensive parser that maps that stream into mnemo's
+existing content model, plus one new watched root, one synthetic-id
+rule, and `session_meta.source = 'grok'`. Everything else — search,
+repo attribution, idempotent resumable ingest — is reused from the
+Claude/Codex spine.
+
+MCP connectivity (streamable HTTP) already works; this target is
+**ingest only**.
+
+---
+
+## The format
+
+### Layout
+
+```
+~/.grok/sessions/<url-encoded-cwd>/<session-id>/
+  summary.json       # metadata: title, cwd, git, model, timestamps
+  updates.jsonl      # ACP session/update stream (authoritative, append-only)
+  chat_history.jsonl # model-facing messages (rewritten on compact — lossy)
+  events.jsonl       # telemetry — skip
+  …
+```
+
+`GROK_HOME` overrides `~/.grok`. When the encoded cwd exceeds 255 bytes,
+Grok uses a slug+hash and stores the original path in a `.cwd` file
+(see the user guide); `summary.json` still carries `info.cwd`.
+
+### `summary.json`
+
+```json
+{
+  "info": { "id": "<uuidv7>", "cwd": "/abs/path" },
+  "generated_title": "…",
+  "session_summary": "…",
+  "current_model_id": "grok-4.5",
+  "git_remotes": ["git@github.com:org/repo.git"],
+  "head_branch": "…",
+  "head_commit": "…",
+  "created_at": "…", "updated_at": "…", "last_active_at": "…",
+  "parent_session_id": "…"   // forks only
+}
+```
+
+### `updates.jsonl`
+
+Every line:
+
+```json
+{
+  "timestamp": 1783679368,
+  "method": "session/update",
+  "params": {
+    "sessionId": "<uuid>",
+    "update": { "sessionUpdate": "<type>", … }
+  }
+}
+```
+
+`method` may also be `_x.ai/session/update` for Grok extensions
+(hooks, goals, subagent lifecycle, compact markers). Those are skipped
+in the MVP.
+
+| `sessionUpdate` | → mnemo | MVP |
+|---|---|---|
+| `user_message_chunk` | user text | ✅ |
+| `agent_message_chunk` | assistant text | ✅ |
+| `agent_thought_chunk` | thinking | ✅ |
+| `tool_call` | tool_use (`toolCallId`, name, `rawInput`) | ✅ |
+| `tool_call_update` + `status: completed` | tool_result | ✅ |
+| other `tool_call_update` | intermediate UI | ❌ skip |
+| `subagent_*`, `goal_*`, `auto_compact_*`, `session_recap`, `plan`, hooks | bookkeeping | ❌ skip |
+
+Observed chunk sizes are whole messages (median ~100 chars), not token
+streams — each chunk is one entry.
+
+### Why not `chat_history.jsonl`?
+
+It is the model-facing view and is **rewritten on compact**, dropping
+pre-compaction user turns. `updates.jsonl` is append-only and is what
+drives `/resume`. Index the durable stream.
+
+Other `.jsonl` siblings (`events.jsonl`, `rewind_points.jsonl`, …) must
+**not** be fed to the Claude parser. Discovery only selects
+`updates.jsonl` under the Grok root.
+
+---
+
+## MVP — four adaptations, everything else reused
+
+1. **New watched root.** Discover/watch `$GROK_HOME/sessions` (default
+   `~/.grok/sessions`) recursively. Only `updates.jsonl` is ingested.
+2. **Synthetic record id.** No per-line uuid. Id =
+   `grok-<session_id>-<byte-offset>`. Append-only → re-ingest dedups via
+   `INSERT OR IGNORE`; resume from `ingest_state` offset.
+3. **`source = 'grok'`.** Reuses the additive `session_meta.source`
+   column introduced for Codex (default `'claude'`).
+4. **Envelope → content transform.** Unwrap `params.update`; map the
+   handful of `sessionUpdate` types above; ignore unknowns. Metadata
+   (cwd, branch, title) comes from sibling `summary.json`.
+
+Repo attribution uses `summary.info.cwd` via the existing `extractRepo`
+path logic (`git_remotes` is free context but not required for MVP).
+
+---
+
+## Parser posture
+
+No schema-version field. Map the core `sessionUpdate` types and
+**ignore unknown types** rather than exhaustively modelling every
+variant. Unknown → skip-and-continue, never fail the file.
+
+---
+
+## Explicitly out of scope (MVP)
+
+`events.jsonl` telemetry; rewind snapshots; images; Grok's own
+`session_search.sqlite`; decryption of anything; modelling forks /
+subagents as mnemo chains (subagent child sessions are normal sibling
+session dirs and get indexed independently); `mnemo_whatsup` live-PID
+for `grok` processes; Grok-native memory; usage/token streams from
+`signals.json`.
+
+**Just text + tool calls + tool results, attributed to a session / repo
+/ timestamp, searchable.**
+
+---
+
+## Cross-check references
+
+- `~/.grok/docs/user-guide/17-sessions.md` (storage layout, resume)
+- Live corpus under `~/.grok/sessions/` (CLI 0.2.93)
+- Implementation mirror: `internal/store/codex.go` (🎯T99)

--- a/internal/edgeproxy/proxy.go
+++ b/internal/edgeproxy/proxy.go
@@ -1,0 +1,316 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+// Package edgeproxy implements the transparent MCP edge that owns client
+// connections and routes by Mcp-Session-Id to one or more backends
+// (🎯T97.3). Edge↔backend traffic is standard MCP streamable HTTP with
+// no custom protocol.
+package edgeproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// SessionIDHeader is the MCP streamable-HTTP session header (🎯T27).
+const SessionIDHeader = "Mcp-Session-Id"
+
+// Router maps MCP session IDs to backends and picks the primary backend
+// for new initialize requests.
+type Router struct {
+	backends []*url.URL
+	primary  atomic.Uint32
+	pins     sync.Map // sessionID string -> uint32 backend index
+}
+
+// NewRouter parses backend base URLs and records the primary index used
+// for new initialize requests.
+func NewRouter(backendURLs []string, primary int) (*Router, error) {
+	if len(backendURLs) == 0 {
+		return nil, fmt.Errorf("edgeproxy: at least one backend URL is required")
+	}
+	if primary < 0 || primary >= len(backendURLs) {
+		return nil, fmt.Errorf("edgeproxy: primary index %d out of range [0,%d)", primary, len(backendURLs))
+	}
+	backends := make([]*url.URL, len(backendURLs))
+	for i, raw := range backendURLs {
+		u, err := parseBackendURL(raw)
+		if err != nil {
+			return nil, fmt.Errorf("edgeproxy: backend %d: %w", i, err)
+		}
+		backends[i] = u
+	}
+	r := &Router{backends: backends}
+	r.primary.Store(uint32(primary))
+	return r, nil
+}
+
+// BackendCount returns the number of configured backends.
+func (r *Router) BackendCount() int { return len(r.backends) }
+
+// PrimaryIndex returns the backend index used for new initialize requests.
+func (r *Router) PrimaryIndex() int { return int(r.primary.Load()) }
+
+// SetPrimary changes which backend receives new initialize requests.
+func (r *Router) SetPrimary(idx int) error {
+	if idx < 0 || idx >= len(r.backends) {
+		return fmt.Errorf("edgeproxy: primary index %d out of range [0,%d)", idx, len(r.backends))
+	}
+	r.primary.Store(uint32(idx))
+	return nil
+}
+
+// Pin records session affinity for a session ID.
+func (r *Router) Pin(sessionID string, backendIdx int) {
+	if sessionID == "" || backendIdx < 0 || backendIdx >= len(r.backends) {
+		return
+	}
+	r.pins.Store(sessionID, uint32(backendIdx))
+}
+
+// BackendForSession returns the pinned backend index and whether a pin
+// existed. When no pin exists, the primary index is returned with false.
+func (r *Router) BackendForSession(sessionID string) (idx int, pinned bool) {
+	if sessionID == "" {
+		return int(r.primary.Load()), false
+	}
+	if v, ok := r.pins.Load(sessionID); ok {
+		return int(v.(uint32)), true
+	}
+	return int(r.primary.Load()), false
+}
+
+// Proxy is an http.Handler that forwards MCP and ancillary HTTP traffic
+// to backends with session-aware routing on /mcp paths.
+type Proxy struct {
+	router  *Router
+	clients []*http.Client
+}
+
+// NewProxy builds a Proxy for the given router.
+func NewProxy(router *Router) *Proxy {
+	clients := make([]*http.Client, len(router.backends))
+	for i, u := range router.backends {
+		clients[i] = newBackendClient(u)
+	}
+	return &Proxy{router: router, clients: clients}
+}
+
+// ServeHTTP implements http.Handler.
+func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	backendIdx, pinOnResponse, body, err := p.routeRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	p.forward(backendIdx, w, r, body, pinOnResponse)
+}
+
+func (p *Proxy) routeRequest(r *http.Request) (backendIdx int, pinOnResponse bool, body []byte, err error) {
+	backendIdx = p.router.PrimaryIndex()
+	sessionID := r.Header.Get(SessionIDHeader)
+
+	if sessionID != "" {
+		backendIdx, _ = p.router.BackendForSession(sessionID)
+		return backendIdx, false, nil, nil
+	}
+
+	if r.Method == http.MethodPost && r.Body != nil {
+		body, err = io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		if err != nil {
+			return 0, false, nil, fmt.Errorf("read request body: %w", err)
+		}
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		if isInitializeRequest(body) {
+			return p.router.PrimaryIndex(), true, body, nil
+		}
+	}
+
+	return backendIdx, false, body, nil
+}
+
+func (p *Proxy) forward(backendIdx int, w http.ResponseWriter, r *http.Request, body []byte, pinOnResponse bool) {
+	backend := p.router.backends[backendIdx]
+	outURL := cloneRequestURL(r.URL, backend)
+
+	outReq, err := http.NewRequestWithContext(r.Context(), r.Method, outURL, nil)
+	if err != nil {
+		http.Error(w, "build backend request", http.StatusInternalServerError)
+		return
+	}
+	outReq.Header = r.Header.Clone()
+	stripHopByHop(outReq.Header)
+	if body != nil {
+		outReq.Body = io.NopCloser(bytes.NewReader(body))
+		outReq.ContentLength = int64(len(body))
+	} else if r.Body != nil {
+		outReq.Body = r.Body
+		outReq.ContentLength = r.ContentLength
+	}
+
+	resp, err := p.clients[backendIdx].Do(outReq)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("backend unreachable: %v", err), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	if pinOnResponse {
+		if sid := resp.Header.Get(SessionIDHeader); sid != "" {
+			p.router.Pin(sid, backendIdx)
+		}
+	}
+
+	copyHeader(w.Header(), resp.Header)
+	stripHopByHop(w.Header())
+	w.WriteHeader(resp.StatusCode)
+
+	flusher, canFlush := w.(http.Flusher)
+	buf := make([]byte, 32*1024)
+	for {
+		n, readErr := resp.Body.Read(buf)
+		if n > 0 {
+			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
+				return
+			}
+			if canFlush {
+				flusher.Flush()
+			}
+		}
+		if readErr != nil {
+			return
+		}
+	}
+}
+
+func isInitializeRequest(body []byte) bool {
+	var msg struct {
+		Method string `json:"method"`
+	}
+	if err := json.Unmarshal(body, &msg); err != nil {
+		return false
+	}
+	return msg.Method == "initialize"
+}
+
+func parseBackendURL(raw string) (*url.URL, error) {
+	if strings.HasPrefix(raw, "unix:") {
+		path := strings.TrimPrefix(raw, "unix:")
+		path = strings.TrimPrefix(path, "//")
+		if path == "" {
+			return nil, fmt.Errorf("unix backend URL missing socket path")
+		}
+		return &url.URL{Scheme: "unix", Path: path}, nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme == "" {
+		u, err = url.Parse("http://" + raw)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("unsupported scheme %q (want http, https, or unix:)", u.Scheme)
+	}
+	return u, nil
+}
+
+func cloneRequestURL(in *url.URL, backend *url.URL) string {
+	path := in.Path
+	if path == "" {
+		path = "/"
+	}
+	out := &url.URL{
+		Scheme:   backendScheme(backend),
+		Host:     backendHost(backend),
+		Path:     path,
+		RawQuery: in.RawQuery,
+	}
+	return out.String()
+}
+
+func backendScheme(backend *url.URL) string {
+	if backend.Scheme == "unix" {
+		return "http"
+	}
+	return backend.Scheme
+}
+
+func backendHost(backend *url.URL) string {
+	if backend.Scheme == "unix" {
+		// http over unix is dialled by path; host is a placeholder.
+		return "unix"
+	}
+	return backend.Host
+}
+
+func newBackendClient(backend *url.URL) *http.Client {
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          64,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	if backend.Scheme == "unix" {
+		socketPath := backend.Path
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, "unix", socketPath)
+		}
+	}
+	return &http.Client{
+		Transport: transport,
+		// No global timeout — GET/SSE streams may be long-lived.
+	}
+}
+
+func copyHeader(dst, src http.Header) {
+	for k, vals := range src {
+		for _, v := range vals {
+			dst.Add(k, v)
+		}
+	}
+}
+
+// hopByHop lists RFC 7230 hop-by-hop headers that must not be forwarded
+// between edge and backend (or client).
+var hopByHop = map[string]bool{
+	"Connection":          true,
+	"Keep-Alive":          true,
+	"Proxy-Authenticate":  true,
+	"Proxy-Authorization": true,
+	"Te":                  true,
+	"Trailers":            true,
+	"Transfer-Encoding":   true,
+	"Upgrade":             true,
+}
+
+func stripHopByHop(h http.Header) {
+	// Connection may list additional hop-by-hop header names.
+	for _, f := range h.Values("Connection") {
+		for _, name := range strings.Split(f, ",") {
+			if name = strings.TrimSpace(name); name != "" {
+				h.Del(name)
+			}
+		}
+	}
+	for name := range hopByHop {
+		h.Del(name)
+	}
+}

--- a/internal/edgeproxy/proxy.go
+++ b/internal/edgeproxy/proxy.go
@@ -26,8 +26,9 @@ import (
 const SessionIDHeader = "Mcp-Session-Id"
 
 // Router maps MCP session IDs to backends and picks the primary backend
-// for new initialize requests.
+// for new initialize requests. Backends may grow at runtime (🎯T97.5).
 type Router struct {
+	mu       sync.RWMutex
 	backends []*url.URL
 	primary  atomic.Uint32
 	pins     sync.Map // sessionID string -> uint32 backend index
@@ -56,26 +57,116 @@ func NewRouter(backendURLs []string, primary int) (*Router, error) {
 }
 
 // BackendCount returns the number of configured backends.
-func (r *Router) BackendCount() int { return len(r.backends) }
+func (r *Router) BackendCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.backends)
+}
 
 // PrimaryIndex returns the backend index used for new initialize requests.
 func (r *Router) PrimaryIndex() int { return int(r.primary.Load()) }
 
+// BackendURL returns the string form of backend i, or "" if out of range.
+func (r *Router) BackendURL(i int) string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if i < 0 || i >= len(r.backends) {
+		return ""
+	}
+	return r.backends[i].String()
+}
+
+// BackendURLs returns a copy of all backend URL strings.
+func (r *Router) BackendURLs() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]string, len(r.backends))
+	for i, u := range r.backends {
+		out[i] = u.String()
+	}
+	return out
+}
+
 // SetPrimary changes which backend receives new initialize requests.
 func (r *Router) SetPrimary(idx int) error {
-	if idx < 0 || idx >= len(r.backends) {
-		return fmt.Errorf("edgeproxy: primary index %d out of range [0,%d)", idx, len(r.backends))
+	r.mu.RLock()
+	n := len(r.backends)
+	r.mu.RUnlock()
+	if idx < 0 || idx >= n {
+		return fmt.Errorf("edgeproxy: primary index %d out of range [0,%d)", idx, n)
 	}
 	r.primary.Store(uint32(idx))
 	return nil
 }
 
+// AddBackend appends a backend URL if not already present and returns
+// its index. Safe for concurrent use with routing (🎯T97.5 edge grow).
+func (r *Router) AddBackend(raw string) (int, error) {
+	u, err := parseBackendURL(raw)
+	if err != nil {
+		return -1, err
+	}
+	key := u.String()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i, b := range r.backends {
+		if b.String() == key {
+			return i, nil
+		}
+	}
+	r.backends = append(r.backends, u)
+	return len(r.backends) - 1, nil
+}
+
+// ApplyRoute ensures every URL in backends is registered, then sets
+// primary. Returns the resolved primary index.
+func (r *Router) ApplyRoute(backends []string, primary int) (int, error) {
+	if len(backends) == 0 {
+		return -1, fmt.Errorf("edgeproxy: empty backend list")
+	}
+	for _, b := range backends {
+		if _, err := r.AddBackend(b); err != nil {
+			return -1, err
+		}
+	}
+	// Map primary by URL when possible (indices may have shifted if
+	// order differed); prefer the primary-th entry of the file list.
+	if primary < 0 || primary >= len(backends) {
+		return -1, fmt.Errorf("edgeproxy: primary %d out of range for route list", primary)
+	}
+	idx, err := r.AddBackend(backends[primary])
+	if err != nil {
+		return -1, err
+	}
+	if err := r.SetPrimary(idx); err != nil {
+		return -1, err
+	}
+	return idx, nil
+}
+
 // Pin records session affinity for a session ID.
 func (r *Router) Pin(sessionID string, backendIdx int) {
-	if sessionID == "" || backendIdx < 0 || backendIdx >= len(r.backends) {
+	r.mu.RLock()
+	n := len(r.backends)
+	r.mu.RUnlock()
+	if sessionID == "" || backendIdx < 0 || backendIdx >= n {
 		return
 	}
 	r.pins.Store(sessionID, uint32(backendIdx))
+}
+
+// RepinAllToPrimary moves every pin onto the current primary so a
+// draining backend can be reaped without orphaning sessions.
+func (r *Router) RepinAllToPrimary() (moved int) {
+	prim := r.PrimaryIndex()
+	r.pins.Range(func(key, value any) bool {
+		if int(value.(uint32)) != prim {
+			r.pins.Store(key, uint32(prim))
+			moved++
+		}
+		return true
+	})
+	return moved
 }
 
 // BackendForSession returns the pinned backend index and whether a pin
@@ -90,20 +181,52 @@ func (r *Router) BackendForSession(sessionID string) (idx int, pinned bool) {
 	return int(r.primary.Load()), false
 }
 
+func (r *Router) backendAt(i int) (*url.URL, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if i < 0 || i >= len(r.backends) {
+		return nil, false
+	}
+	return r.backends[i], true
+}
+
 // Proxy is an http.Handler that forwards MCP and ancillary HTTP traffic
 // to backends with session-aware routing on /mcp paths.
 type Proxy struct {
 	router  *Router
+	mu      sync.Mutex
 	clients []*http.Client
 }
 
 // NewProxy builds a Proxy for the given router.
 func NewProxy(router *Router) *Proxy {
-	clients := make([]*http.Client, len(router.backends))
-	for i, u := range router.backends {
-		clients[i] = newBackendClient(u)
+	p := &Proxy{router: router}
+	p.syncClients()
+	return p
+}
+
+// syncClients grows the client pool to match router backends.
+func (p *Proxy) syncClients() {
+	n := p.router.BackendCount()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for len(p.clients) < n {
+		u, ok := p.router.backendAt(len(p.clients))
+		if !ok {
+			break
+		}
+		p.clients = append(p.clients, newBackendClient(u))
 	}
-	return &Proxy{router: router, clients: clients}
+}
+
+func (p *Proxy) clientAt(i int) *http.Client {
+	p.syncClients()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if i < 0 || i >= len(p.clients) {
+		return nil
+	}
+	return p.clients[i]
 }
 
 // ServeHTTP implements http.Handler.
@@ -113,7 +236,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	p.forward(backendIdx, w, r, body, pinOnResponse)
+	p.forward(backendIdx, w, r, body, pinOnResponse, true)
 }
 
 func (p *Proxy) routeRequest(r *http.Request) (backendIdx int, pinOnResponse bool, body []byte, err error) {
@@ -140,8 +263,17 @@ func (p *Proxy) routeRequest(r *http.Request) (backendIdx int, pinOnResponse boo
 	return backendIdx, false, body, nil
 }
 
-func (p *Proxy) forward(backendIdx int, w http.ResponseWriter, r *http.Request, body []byte, pinOnResponse bool) {
-	backend := p.router.backends[backendIdx]
+func (p *Proxy) forward(backendIdx int, w http.ResponseWriter, r *http.Request, body []byte, pinOnResponse bool, allowFailover bool) {
+	backend, ok := p.router.backendAt(backendIdx)
+	if !ok {
+		http.Error(w, "backend index out of range", http.StatusBadGateway)
+		return
+	}
+	client := p.clientAt(backendIdx)
+	if client == nil {
+		http.Error(w, "no client for backend", http.StatusBadGateway)
+		return
+	}
 	outURL := cloneRequestURL(r.URL, backend)
 
 	outReq, err := http.NewRequestWithContext(r.Context(), r.Method, outURL, nil)
@@ -159,8 +291,24 @@ func (p *Proxy) forward(backendIdx int, w http.ResponseWriter, r *http.Request, 
 		outReq.ContentLength = r.ContentLength
 	}
 
-	resp, err := p.clients[backendIdx].Do(outReq)
+	resp, err := client.Do(outReq)
 	if err != nil {
+		// Fail over pinned sessions to primary when a backend dies mid-drain.
+		if allowFailover {
+			prim := p.router.PrimaryIndex()
+			if prim != backendIdx {
+				if sid := r.Header.Get(SessionIDHeader); sid != "" {
+					p.router.Pin(sid, prim)
+				}
+				// Retry once on primary with a fresh body reader.
+				var retryBody []byte
+				if body != nil {
+					retryBody = body
+				}
+				p.forward(prim, w, r, retryBody, false, false)
+				return
+			}
+		}
 		http.Error(w, fmt.Sprintf("backend unreachable: %v", err), http.StatusBadGateway)
 		return
 	}

--- a/internal/edgeproxy/proxy.go
+++ b/internal/edgeproxy/proxy.go
@@ -155,8 +155,10 @@ func (r *Router) Pin(sessionID string, backendIdx int) {
 	r.pins.Store(sessionID, uint32(backendIdx))
 }
 
-// RepinAllToPrimary moves every pin onto the current primary so a
-// draining backend can be reaped without orphaning sessions.
+// RepinAllToPrimary moves every pin onto the current primary.
+// Crash-failover only (🎯T97.5 FailoverRepin) — do NOT use on the
+// happy-path upgrade drain; that must keep pins on the old backend
+// until they clear so mcp-go stateful sessions stay valid.
 func (r *Router) RepinAllToPrimary() (moved int) {
 	prim := r.PrimaryIndex()
 	r.pins.Range(func(key, value any) bool {
@@ -167,6 +169,43 @@ func (r *Router) RepinAllToPrimary() (moved int) {
 		return true
 	})
 	return moved
+}
+
+// Unpin removes session affinity (session closed / DELETE).
+func (r *Router) Unpin(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	r.pins.Delete(sessionID)
+}
+
+// PinCountForBackend returns how many sessions are pinned to idx.
+func (r *Router) PinCountForBackend(idx int) int {
+	if idx < 0 {
+		return 0
+	}
+	n := 0
+	r.pins.Range(func(_, value any) bool {
+		if int(value.(uint32)) == idx {
+			n++
+		}
+		return true
+	})
+	return n
+}
+
+// PinCounts returns per-backend pin counts (length == BackendCount).
+func (r *Router) PinCounts() []int {
+	n := r.BackendCount()
+	out := make([]int, n)
+	r.pins.Range(func(_, value any) bool {
+		i := int(value.(uint32))
+		if i >= 0 && i < n {
+			out[i]++
+		}
+		return true
+	})
+	return out
 }
 
 // BackendForSession returns the pinned backend index and whether a pin

--- a/internal/edgeproxy/proxy.go
+++ b/internal/edgeproxy/proxy.go
@@ -275,7 +275,13 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	sessionID := r.Header.Get(SessionIDHeader)
 	p.forward(backendIdx, w, r, body, pinOnResponse, true)
+	// MCP streamable-HTTP session teardown is DELETE with Mcp-Session-Id.
+	// Drop the pin so AffinityDrain can observe pin_counts[self]==0 (🎯T97.5).
+	if r.Method == http.MethodDelete && sessionID != "" {
+		p.router.Unpin(sessionID)
+	}
 }
 
 func (p *Proxy) routeRequest(r *http.Request) (backendIdx int, pinOnResponse bool, body []byte, err error) {

--- a/internal/edgeproxy/proxy_test.go
+++ b/internal/edgeproxy/proxy_test.go
@@ -150,6 +150,43 @@ func TestRepinAllToPrimary(t *testing.T) {
 	}
 }
 
+// TestDELETEUnpinsSession proves pin lifecycle for AffinityDrain:
+// initialize pins, DELETE with Mcp-Session-Id clears the pin so
+// pin_counts can reach zero without MaxWait force-reap.
+func TestDELETEUnpinsSession(t *testing.T) {
+	t.Parallel()
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.Header().Set(SessionIDHeader, "sess-del")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(backend.Close)
+
+	router, err := NewRouter([]string{backend.URL}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy := NewProxy(router)
+
+	initReq := httptest.NewRequest(http.MethodPost, "http://edge/mcp",
+		strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
+	initRec := httptest.NewRecorder()
+	proxy.ServeHTTP(initRec, initReq)
+	if router.PinCountForBackend(0) != 1 {
+		t.Fatalf("after init pins=%v", router.PinCounts())
+	}
+
+	delReq := httptest.NewRequest(http.MethodDelete, "http://edge/mcp", nil)
+	delReq.Header.Set(SessionIDHeader, "sess-del")
+	delRec := httptest.NewRecorder()
+	proxy.ServeHTTP(delRec, delReq)
+	if router.PinCountForBackend(0) != 0 {
+		t.Fatalf("after DELETE pins=%v want 0", router.PinCounts())
+	}
+}
+
 // TestAffinityDrainKeepsPinOnOldBackend is the 🎯T97.5 acceptance bar:
 // initialize on B0 → flip primary to B1 without repin → tool call with
 // the same Mcp-Session-Id still hits B0 while B0 is up. Repin would

--- a/internal/edgeproxy/proxy_test.go
+++ b/internal/edgeproxy/proxy_test.go
@@ -1,0 +1,268 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package edgeproxy
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNewRouterRejectsEmptyAndBadPrimary(t *testing.T) {
+	t.Parallel()
+	if _, err := NewRouter(nil, 0); err == nil {
+		t.Fatal("expected error for empty backends")
+	}
+	if _, err := NewRouter([]string{"http://127.0.0.1:1"}, 1); err == nil {
+		t.Fatal("expected error for out-of-range primary")
+	}
+	if _, err := NewRouter([]string{"ftp://x"}, 0); err == nil {
+		t.Fatal("expected error for unsupported scheme")
+	}
+}
+
+func TestRouterPinAndSetPrimary(t *testing.T) {
+	t.Parallel()
+	r, err := NewRouter([]string{
+		"http://127.0.0.1:19421",
+		"http://127.0.0.1:19422",
+	}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.PrimaryIndex() != 0 {
+		t.Fatalf("primary=%d want 0", r.PrimaryIndex())
+	}
+	r.Pin("sess-a", 0)
+	if idx, ok := r.BackendForSession("sess-a"); !ok || idx != 0 {
+		t.Fatalf("pin sess-a: idx=%d ok=%v", idx, ok)
+	}
+	if err := r.SetPrimary(1); err != nil {
+		t.Fatal(err)
+	}
+	// New initializes (no pin) go to primary 1; existing pin stays.
+	if idx, ok := r.BackendForSession(""); ok || idx != 1 {
+		t.Fatalf("unpinned: idx=%d ok=%v want primary 1", idx, ok)
+	}
+	if idx, ok := r.BackendForSession("sess-a"); !ok || idx != 0 {
+		t.Fatalf("pinned after primary flip: idx=%d ok=%v", idx, ok)
+	}
+}
+
+func TestRouterUnixBackendURL(t *testing.T) {
+	t.Parallel()
+	r, err := NewRouter([]string{"unix:///tmp/mnemo-backend.sock"}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.backends[0].Scheme != "unix" || r.backends[0].Path != "/tmp/mnemo-backend.sock" {
+		t.Fatalf("unix url: %+v", r.backends[0])
+	}
+}
+
+func TestProxyInitializePinsSession(t *testing.T) {
+	t.Parallel()
+	var hits [2]atomic.Int32
+	backends := make([]*httptest.Server, 2)
+	for i := range backends {
+		i := i
+		backends[i] = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hits[i].Add(1)
+			if r.Method == http.MethodPost && r.Header.Get(SessionIDHeader) == "" {
+				w.Header().Set(SessionIDHeader, fmt.Sprintf("sid-%d", i))
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(fmt.Sprintf("backend-%d", i)))
+		}))
+		t.Cleanup(backends[i].Close)
+	}
+
+	router, err := NewRouter([]string{backends[0].URL, backends[1].URL}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy := NewProxy(router)
+
+	// initialize → primary 0, pin session
+	req := httptest.NewRequest(http.MethodPost, "http://edge/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
+	rec := httptest.NewRecorder()
+	proxy.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("initialize status %d", rec.Code)
+	}
+	sid := rec.Header().Get(SessionIDHeader)
+	if sid != "sid-0" {
+		t.Fatalf("session id %q", sid)
+	}
+	if hits[0].Load() != 1 || hits[1].Load() != 0 {
+		t.Fatalf("hits after init: %d %d", hits[0].Load(), hits[1].Load())
+	}
+
+	// Flip primary; pinned session still hits backend 0
+	if err := router.SetPrimary(1); err != nil {
+		t.Fatal(err)
+	}
+	req2 := httptest.NewRequest(http.MethodPost, "http://edge/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`))
+	req2.Header.Set(SessionIDHeader, sid)
+	rec2 := httptest.NewRecorder()
+	proxy.ServeHTTP(rec2, req2)
+	if body := rec2.Body.String(); body != "backend-0" {
+		t.Fatalf("pinned body %q", body)
+	}
+	if hits[0].Load() != 2 || hits[1].Load() != 0 {
+		t.Fatalf("hits after pinned call: %d %d", hits[0].Load(), hits[1].Load())
+	}
+
+	// New initialize goes to primary 1
+	req3 := httptest.NewRequest(http.MethodPost, "http://edge/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":3,"method":"initialize","params":{}}`))
+	rec3 := httptest.NewRecorder()
+	proxy.ServeHTTP(rec3, req3)
+	if rec3.Header().Get(SessionIDHeader) != "sid-1" {
+		t.Fatalf("new init session %q", rec3.Header().Get(SessionIDHeader))
+	}
+	if hits[1].Load() != 1 {
+		t.Fatalf("backend 1 hits %d want 1", hits[1].Load())
+	}
+}
+
+func TestProxySSEFlushThrough(t *testing.T) {
+	t.Parallel()
+	// Real TCP servers so streaming + flush is exercised end-to-end.
+	backendLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = backendLn.Close() })
+
+	// Gate: first event is written immediately; second waits until the
+	// test has observed the first (proves edge flushes hop-by-hop).
+	firstSeen := make(chan struct{})
+	go func() {
+		_ = http.Serve(backendLn, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				http.Error(w, "no flush", 500)
+				return
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "data: one\n\n")
+			flusher.Flush()
+			select {
+			case <-firstSeen:
+			case <-r.Context().Done():
+				return
+			case <-time.After(5 * time.Second):
+				return
+			}
+			fmt.Fprint(w, "data: two\n\n")
+			flusher.Flush()
+		}))
+	}()
+
+	router, err := NewRouter([]string{"http://" + backendLn.Addr().String()}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	edgeLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = edgeLn.Close() })
+	go func() { _ = http.Serve(edgeLn, NewProxy(router)) }()
+
+	resp, err := http.Get("http://" + edgeLn.Addr().String() + "/mcp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	gotFirst := make(chan string, 1)
+	go func() {
+		var buf strings.Builder
+		for {
+			line, err := reader.ReadString('\n')
+			buf.WriteString(line)
+			if strings.Contains(buf.String(), "data: one") {
+				gotFirst <- buf.String()
+				return
+			}
+			if err != nil {
+				gotFirst <- buf.String() + "\nerr:" + err.Error()
+				return
+			}
+		}
+	}()
+
+	select {
+	case first := <-gotFirst:
+		if !strings.Contains(first, "data: one") {
+			t.Fatalf("first SSE event missing (flush broken?): %q", first)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first SSE event through edge")
+	}
+	close(firstSeen)
+
+	rest, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(rest), "data: two") {
+		t.Fatalf("second SSE event missing: %q", string(rest))
+	}
+}
+
+func TestProxyUnixBackend(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sock := dir + "/backend.sock"
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	var once sync.Once
+	go http.Serve(ln, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		once.Do(func() {})
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("unix-ok"))
+	}))
+
+	router, err := NewRouter([]string{"unix://" + sock}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://edge/api/health", nil)
+	NewProxy(router).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || rec.Body.String() != "unix-ok" {
+		t.Fatalf("status=%d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestIsInitializeRequest(t *testing.T) {
+	t.Parallel()
+	if !isInitializeRequest([]byte(`{"method":"initialize"}`)) {
+		t.Fatal("want initialize true")
+	}
+	if isInitializeRequest([]byte(`{"method":"tools/list"}`)) {
+		t.Fatal("want tools/list false")
+	}
+	if isInitializeRequest([]byte(`not-json`)) {
+		t.Fatal("want garbage false")
+	}
+}

--- a/internal/edgeproxy/proxy_test.go
+++ b/internal/edgeproxy/proxy_test.go
@@ -150,6 +150,86 @@ func TestRepinAllToPrimary(t *testing.T) {
 	}
 }
 
+// TestAffinityDrainKeepsPinOnOldBackend is the 🎯T97.5 acceptance bar:
+// initialize on B0 → flip primary to B1 without repin → tool call with
+// the same Mcp-Session-Id still hits B0 while B0 is up. Repin would
+// break mcp-go stateful sessions.
+func TestAffinityDrainKeepsPinOnOldBackend(t *testing.T) {
+	t.Parallel()
+	var hits [2]atomic.Int32
+	b0 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits[0].Add(1)
+		if r.Header.Get(SessionIDHeader) == "" {
+			w.Header().Set(SessionIDHeader, "sess-aff")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("old-backend"))
+	}))
+	t.Cleanup(b0.Close)
+	b1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits[1].Add(1)
+		w.Header().Set(SessionIDHeader, "sess-new")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("new-backend"))
+	}))
+	t.Cleanup(b1.Close)
+
+	router, err := NewRouter([]string{b0.URL, b1.URL}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy := NewProxy(router)
+
+	// initialize → B0, pin sess-aff
+	initReq := httptest.NewRequest(http.MethodPost, "http://edge/mcp",
+		strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
+	initRec := httptest.NewRecorder()
+	proxy.ServeHTTP(initRec, initReq)
+	sid := initRec.Header().Get(SessionIDHeader)
+	if sid != "sess-aff" {
+		t.Fatalf("sid %q", sid)
+	}
+	if hits[0].Load() != 1 || hits[1].Load() != 0 {
+		t.Fatalf("after init hits %d/%d", hits[0].Load(), hits[1].Load())
+	}
+
+	// Flip primary to B1 — NO repin (affinity drain).
+	if err := router.SetPrimary(1); err != nil {
+		t.Fatal(err)
+	}
+	if router.PinCountForBackend(0) != 1 || router.PinCountForBackend(1) != 0 {
+		t.Fatalf("pins after flip: %v", router.PinCounts())
+	}
+
+	// Tool call with same session must still hit B0.
+	toolReq := httptest.NewRequest(http.MethodPost, "http://edge/mcp",
+		strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`))
+	toolReq.Header.Set(SessionIDHeader, sid)
+	toolRec := httptest.NewRecorder()
+	proxy.ServeHTTP(toolRec, toolReq)
+	if toolRec.Body.String() != "old-backend" {
+		t.Fatalf("body %q want old-backend (repin would break stateful MCP)", toolRec.Body.String())
+	}
+	if hits[0].Load() != 2 || hits[1].Load() != 0 {
+		t.Fatalf("after tool hits %d/%d — pin must stay on B0", hits[0].Load(), hits[1].Load())
+	}
+
+	// New initialize goes to B1.
+	init2 := httptest.NewRequest(http.MethodPost, "http://edge/mcp",
+		strings.NewReader(`{"jsonrpc":"2.0","id":3,"method":"initialize","params":{}}`))
+	init2Rec := httptest.NewRecorder()
+	proxy.ServeHTTP(init2Rec, init2)
+	if init2Rec.Body.String() != "new-backend" {
+		t.Fatalf("new init body %q", init2Rec.Body.String())
+	}
+
+	// After unpin, B0 pin count is 0 (safe to affinity-drain reap).
+	router.Unpin(sid)
+	if router.PinCountForBackend(0) != 0 {
+		t.Fatalf("after unpin pins %v", router.PinCounts())
+	}
+}
+
 // Proves 🎯T97.5 edge grow: start with one backend, ApplyRoute adds a
 // second URL as primary, and new initialize traffic hits the new one.
 func TestProxyGrowsBackendAndRoutesNewInitToPrimary(t *testing.T) {

--- a/internal/edgeproxy/proxy_test.go
+++ b/internal/edgeproxy/proxy_test.go
@@ -64,8 +64,131 @@ func TestRouterUnixBackendURL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r.backends[0].Scheme != "unix" || r.backends[0].Path != "/tmp/mnemo-backend.sock" {
-		t.Fatalf("unix url: %+v", r.backends[0])
+	u, ok := r.backendAt(0)
+	if !ok || u.Scheme != "unix" || u.Path != "/tmp/mnemo-backend.sock" {
+		t.Fatalf("unix url: %+v ok=%v", u, ok)
+	}
+}
+
+func TestRouterAddBackendAndApplyRoute(t *testing.T) {
+	t.Parallel()
+	r, err := NewRouter([]string{"http://127.0.0.1:1"}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx, err := r.AddBackend("http://127.0.0.1:2")
+	if err != nil || idx != 1 {
+		t.Fatalf("add: idx=%d err=%v", idx, err)
+	}
+	// Idempotent
+	idx2, err := r.AddBackend("http://127.0.0.1:2")
+	if err != nil || idx2 != 1 {
+		t.Fatalf("add again: idx=%d err=%v", idx2, err)
+	}
+	prim, err := r.ApplyRoute([]string{"http://127.0.0.1:1", "http://127.0.0.1:2", "http://127.0.0.1:3"}, 2)
+	if err != nil || prim != 2 {
+		t.Fatalf("apply: prim=%d err=%v count=%d", prim, err, r.BackendCount())
+	}
+	if r.BackendCount() != 3 {
+		t.Fatalf("count %d", r.BackendCount())
+	}
+	if r.PrimaryIndex() != 2 {
+		t.Fatalf("primary %d", r.PrimaryIndex())
+	}
+}
+
+func TestProxyFailoverRepinsToPrimary(t *testing.T) {
+	t.Parallel()
+	// Backend 0 dies; backend 1 is primary and healthy.
+	alive := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("alive"))
+	}))
+	t.Cleanup(alive.Close)
+
+	// Dead listener: close immediately so dial fails.
+	deadLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadAddr := deadLn.Addr().String()
+	_ = deadLn.Close()
+
+	router, err := NewRouter([]string{
+		"http://" + deadAddr,
+		alive.URL,
+	}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	router.Pin("sess-x", 0) // pinned to dead
+	proxy := NewProxy(router)
+
+	req := httptest.NewRequest(http.MethodGet, "http://edge/mcp", nil)
+	req.Header.Set(SessionIDHeader, "sess-x")
+	rec := httptest.NewRecorder()
+	proxy.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || rec.Body.String() != "alive" {
+		t.Fatalf("status=%d body=%q", rec.Code, rec.Body.String())
+	}
+	idx, pinned := router.BackendForSession("sess-x")
+	if !pinned || idx != 1 {
+		t.Fatalf("expected repin to primary 1, got idx=%d pinned=%v", idx, pinned)
+	}
+}
+
+func TestRepinAllToPrimary(t *testing.T) {
+	t.Parallel()
+	r, _ := NewRouter([]string{"http://127.0.0.1:1", "http://127.0.0.1:2"}, 1)
+	r.Pin("a", 0)
+	r.Pin("b", 0)
+	if n := r.RepinAllToPrimary(); n != 2 {
+		t.Fatalf("moved %d", n)
+	}
+	if idx, _ := r.BackendForSession("a"); idx != 1 {
+		t.Fatalf("a idx %d", idx)
+	}
+}
+
+// Proves 🎯T97.5 edge grow: start with one backend, ApplyRoute adds a
+// second URL as primary, and new initialize traffic hits the new one.
+func TestProxyGrowsBackendAndRoutesNewInitToPrimary(t *testing.T) {
+	t.Parallel()
+	var hits [2]atomic.Int32
+	b0 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits[0].Add(1)
+		w.Header().Set(SessionIDHeader, "sid-old")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("b0"))
+	}))
+	t.Cleanup(b0.Close)
+	b1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits[1].Add(1)
+		w.Header().Set(SessionIDHeader, "sid-new")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("b1"))
+	}))
+	t.Cleanup(b1.Close)
+
+	router, err := NewRouter([]string{b0.URL}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy := NewProxy(router)
+
+	// Grow + flip as edge-route would after spawn.
+	if _, err := router.ApplyRoute([]string{b0.URL, b1.URL}, 1); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "http://edge/mcp",
+		strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
+	rec := httptest.NewRecorder()
+	proxy.ServeHTTP(rec, req)
+	if rec.Body.String() != "b1" || rec.Header().Get(SessionIDHeader) != "sid-new" {
+		t.Fatalf("body=%q sid=%q hits=%d/%d", rec.Body.String(), rec.Header().Get(SessionIDHeader), hits[0].Load(), hits[1].Load())
+	}
+	if hits[1].Load() != 1 || hits[0].Load() != 0 {
+		t.Fatalf("hits b0=%d b1=%d", hits[0].Load(), hits[1].Load())
 	}
 }
 

--- a/internal/registry/diagchecks.go
+++ b/internal/registry/diagchecks.go
@@ -15,6 +15,7 @@ import (
 	"github.com/marcelocantos/mnemo/internal/compact"
 	"github.com/marcelocantos/mnemo/internal/diag"
 	"github.com/marcelocantos/mnemo/internal/store"
+	"github.com/marcelocantos/mnemo/internal/upgrade"
 )
 
 // BuildDiagRegistry assembles the daemon's self-diagnostics check
@@ -23,6 +24,9 @@ import (
 // anchors the "backfill ran since startup" check. The returned registry is
 // wired into the /health endpoint (via SetDiagRunner), the mnemo_doctor
 // tool, and the diag scheduler.
+//
+// Optional upgrade detector and background lease (🎯T97.2 / 🎯T97.4) are
+// read from the Registry when set via SetUpgradeDetector / SetLease.
 func (r *Registry) BuildDiagRegistry(defaultUser string, daemonStart time.Time) *diag.Registry {
 	reg := diag.NewRegistry()
 	workDir := r.summariserWorkDir
@@ -174,6 +178,59 @@ func (r *Registry) BuildDiagRegistry(defaultUser string, daemonStart time.Time) 
 					"if it keeps growing, restart the daemon; a wedged worker shows up as compactor.breaker")
 			}
 			return diag.Healthy("WAL size healthy")
+		}},
+
+		// 🎯T97.2: newer release available (warn). Uses the last
+		// Detector snapshot so the diag path itself does not force a
+		// network call — the detector worker owns polling.
+		diag.Check{Name: "upgrade.available", Tier: diag.Fast, Run: func(context.Context) diag.CheckResult {
+			d := r.UpgradeDetector()
+			if d == nil {
+				return diag.Healthy("upgrade detector not configured")
+			}
+			snap := d.Snapshot()
+			if snap.Disabled {
+				return diag.Healthy("upgrade check disabled (disable_upgrade_check)")
+			}
+			if snap.LastError != "" && snap.Latest == "" {
+				return diag.Warning(
+					"could not query latest release: "+snap.LastError,
+					"ensure `gh` is installed and authenticated, or set disable_upgrade_check")
+			}
+			if snap.UpgradeAvail {
+				return diag.Warning(
+					fmt.Sprintf("upgrade available: running v%s, latest %s",
+						upgrade.NormalizeTag(snap.Current), snap.Latest),
+					"brew upgrade mnemo  # or enable auto_upgrade.enabled on Homebrew")
+			}
+			if snap.Latest == "" {
+				return diag.Healthy("upgrade check has not completed yet")
+			}
+			return diag.Healthy(fmt.Sprintf("up to date (running v%s, latest %s)",
+				upgrade.NormalizeTag(snap.Current), snap.Latest))
+		}},
+
+		// 🎯T97.4: singleton background lease ownership.
+		diag.Check{Name: "background.lease", Tier: diag.Fast, Run: func(context.Context) diag.CheckResult {
+			l := r.Lease()
+			if l == nil {
+				return diag.Healthy("background lease not configured")
+			}
+			st := l.Status()
+			if st.HeldLocally {
+				detail := fmt.Sprintf("this process holds the background lease (%s)", st.LocalHolderID)
+				if st.RunningBG {
+					detail += "; singleton background work running"
+				}
+				return diag.Healthy(detail)
+			}
+			if st.FilePresent && st.FileHolder != "" && !st.Expired {
+				return diag.Healthy(fmt.Sprintf(
+					"background lease held by %s (this process is serve-only)", st.FileHolder))
+			}
+			return diag.Warning(
+				"no live background lease holder — ingest/compaction may be paused",
+				"ensure exactly one mnemo backend is running, or check ~/.mnemo/background.lease")
 		}},
 	)
 	return reg

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -30,6 +30,7 @@ import (
 	"github.com/marcelocantos/mnemo/internal/compact"
 	"github.com/marcelocantos/mnemo/internal/reviewer"
 	"github.com/marcelocantos/mnemo/internal/store"
+	"github.com/marcelocantos/mnemo/internal/upgrade"
 	"github.com/marcelocantos/mnemo/internal/vault"
 )
 
@@ -78,6 +79,11 @@ type Registry struct {
 	cfg               store.Config
 	summariserWorkDir string
 	compactorModel    string
+	// upgradeDetector and lease are optional 🎯T97 wiring; set from main
+	// after construction. nil means the corresponding diag checks report
+	// "not configured" and background workers always start.
+	upgradeDetector *upgrade.Detector
+	lease           *upgrade.Lease
 }
 
 // userEntry tracks one user's Store, optional vault Exporter, and
@@ -100,6 +106,8 @@ type userEntry struct {
 	reconcilerCancel  context.CancelFunc // cancels the reconciler sub-context; nil when disabled
 	reconcilerWorkers sync.WaitGroup     // tracks reconciler goroutine for hot-reload
 	homeDir           string             // remembered for Reload's ~/ expansion
+	bgStarted         bool               // true after startWorkers launched singleton bg work
+	projectDir        string             // transcript root for deferred startWorkers
 }
 
 // NewRegistry builds an empty Registry. The baseCtx is cancelled on
@@ -177,10 +185,64 @@ func (r *Registry) ForUser(username string) (*store.Store, error) {
 	}
 	s.SetSynthesisRoots(synthRoots)
 
-	e := &userEntry{store: s, vault: vaultExp, homeDir: home}
+	e := &userEntry{store: s, vault: vaultExp, homeDir: home, projectDir: projectDir}
 	r.stores[username] = e
 	r.startWorkers(username, projectDir, e)
 	return s, nil
+}
+
+// SetUpgradeDetector wires the 🎯T97.2 release detector for diag checks.
+func (r *Registry) SetUpgradeDetector(d *upgrade.Detector) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.upgradeDetector = d
+}
+
+// UpgradeDetector returns the detector set via SetUpgradeDetector.
+func (r *Registry) UpgradeDetector() *upgrade.Detector {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.upgradeDetector
+}
+
+// SetLease wires the 🎯T97.4 singleton background lease.
+func (r *Registry) SetLease(l *upgrade.Lease) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.lease = l
+}
+
+// Lease returns the lease set via SetLease.
+func (r *Registry) Lease() *upgrade.Lease {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lease
+}
+
+// ReleaseLease drops the background lease if held (drain path 🎯T97.4).
+func (r *Registry) ReleaseLease() {
+	r.mu.Lock()
+	l := r.lease
+	r.mu.Unlock()
+	if l != nil {
+		_ = l.Release()
+	}
+}
+
+// EnsureBackgroundWorkers starts deferred per-user workers when this
+// process holds the lease (handoff after another backend released).
+func (r *Registry) EnsureBackgroundWorkers() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.lease != nil && !r.lease.Held() {
+		return
+	}
+	for username, e := range r.stores {
+		if e.bgStarted {
+			continue
+		}
+		r.startWorkers(username, e.projectDir, e)
+	}
 }
 
 // VaultFor returns the vault Exporter for username, or nil when vault is
@@ -212,8 +274,25 @@ func (r *Registry) CompactWatcherFor(username string) *compact.Watcher {
 // startWorkers kicks off the per-user ingest / watcher / compactor /
 // CI-poll goroutines. Each goroutine runs until r.baseCtx is
 // cancelled (Registry.Close) or until it hits a terminal error.
+//
+// When a background lease is configured and this process does not hold
+// it, workers are deferred (🎯T97.4) so a second backend during upgrade
+// cannot double-ingest. EnsureBackgroundWorkers starts them after
+// lease acquisition.
 func (r *Registry) startWorkers(username, projectDir string, e *userEntry) {
 	logger := slog.Default().With("user", username)
+
+	if e.bgStarted {
+		return
+	}
+	if r.lease != nil && !r.lease.Held() {
+		logger.Info("deferring background workers: not lease holder")
+		return
+	}
+	e.bgStarted = true
+	if r.lease != nil {
+		r.lease.SetRunningBackground(true)
+	}
 
 	// Realtime transcript watcher. Start this before the cold catch-up
 	// backlog so new appends are indexed with stack-like priority.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -164,6 +164,7 @@ func (r *Registry) ForUser(username string) (*store.Store, error) {
 	s.SetWorkspaceRoots(r.cfg.ResolvedWorkspaceRoots())
 	s.SetExtraProjectDirs(r.cfg.ExtraProjectDirs)
 	s.SetCodexRoots(store.CodexRootsFor(home)) // 🎯T99: index ~/.codex rollouts
+	s.SetGrokRoots(store.GrokRootsFor(home))   // 🎯T110: index ~/.grok sessions
 	s.SetTodoGlobs(r.cfg.TodoGlobs)
 
 	synthRoots := r.cfg.ResolvedSynthesisRoots()

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -145,6 +145,46 @@ type Config struct {
 	// out (the open-row count will then grow unbounded as it did
 	// before — accepted only if some external mechanism reaps).
 	ConnectionSweep ConnectionSweepConfig `json:"connection_sweep,omitempty"`
+
+	// DisableUpgradeCheck turns off the periodic GitHub release poll
+	// that powers the upgrade.available diag check (🎯T97.2). The
+	// check is on by default (opt-out, like health notifications and
+	// the always-on gh-backed PR/CI mirrors). When true, zero outbound
+	// release-list calls are made.
+	DisableUpgradeCheck bool `json:"disable_upgrade_check,omitempty"`
+
+	// AutoUpgrade controls opt-in connection-preserving auto-apply
+	// (🎯T97.5). Zero value / absent → disabled (notify-only via
+	// upgrade.available). When enabled, only Homebrew non-Windows
+	// installs actually apply; others stay notify-only.
+	AutoUpgrade AutoUpgradeConfig `json:"auto_upgrade,omitempty"`
+}
+
+// AutoUpgradeConfig gates automatic backend swaps after quiescence.
+type AutoUpgradeConfig struct {
+	// Enabled opts in to auto-apply. Default false — detection and
+	// notification still work via upgrade.available when the upgrade
+	// check is not disabled.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// Quiescence is how long MCP traffic must be idle before apply
+	// (Go duration string). Empty → "30m".
+	Quiescence string `json:"quiescence,omitempty"`
+}
+
+// EffectiveQuiescence returns the parsed idle window or 30m.
+func (a AutoUpgradeConfig) EffectiveQuiescence() (time.Duration, error) {
+	if a.Quiescence == "" {
+		return 30 * time.Minute, nil
+	}
+	d, err := time.ParseDuration(a.Quiescence)
+	if err != nil {
+		return 0, fmt.Errorf("auto_upgrade.quiescence: %w", err)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("auto_upgrade.quiescence: must be non-negative, got %v", d)
+	}
+	return d, nil
 }
 
 // ConnectionSweepConfig controls how often the daemon checks for

--- a/internal/store/grok.go
+++ b/internal/store/grok.go
@@ -1,0 +1,475 @@
+// Grok transcript ingest (🎯T110). xAI's Grok CLI records sessions as
+// directories under ~/.grok/sessions/<url-encoded-cwd>/<session-id>/,
+// with an ACP-style updates.jsonl as the durable conversation log and
+// summary.json for session metadata. This file transforms updates.jsonl
+// into the same parsedFile intermediate the Claude/Codex paths produce,
+// so the shared writer and search machinery are reused.
+// See docs/design/grok-ingest.md.
+package store
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// grokLine is one updates.jsonl envelope.
+type grokLine struct {
+	Timestamp json.RawMessage `json:"timestamp"`
+	Method    string          `json:"method"` // session/update | _x.ai/session/update
+	Params    grokParams      `json:"params"`
+}
+
+type grokParams struct {
+	SessionID string          `json:"sessionId"`
+	Update    json.RawMessage `json:"update"`
+}
+
+// grokUpdate is the tolerant subset of ACP sessionUpdate payloads we
+// read. Unknown fields are ignored — the format has no version stamp.
+type grokUpdate struct {
+	SessionUpdate string          `json:"sessionUpdate"`
+	Content       json.RawMessage `json:"content"`
+	ToolCallID    string          `json:"toolCallId"`
+	Title         string          `json:"title"`
+	RawInput      json.RawMessage `json:"rawInput"`
+	RawOutput     json.RawMessage `json:"rawOutput"`
+	Status        string          `json:"status"`
+	Meta          json.RawMessage `json:"_meta"`
+}
+
+// grokSummary is the sibling summary.json metadata file.
+type grokSummary struct {
+	Info struct {
+		ID  string `json:"id"`
+		Cwd string `json:"cwd"`
+	} `json:"info"`
+	GeneratedTitle string `json:"generated_title"`
+	SessionSummary string `json:"session_summary"`
+	HeadBranch     string `json:"head_branch"`
+}
+
+// GrokRootsFor returns the candidate Grok session roots under a user's
+// home (honouring GROK_HOME). Passed to Store.SetGrokRoots by
+// registry.ForUser; existence is checked lazily by Store.grokDirs.
+func GrokRootsFor(home string) []string {
+	base := os.Getenv("GROK_HOME")
+	if base == "" {
+		base = filepath.Join(home, ".grok")
+	}
+	return []string{filepath.Join(base, "sessions")}
+}
+
+// isGrokUpdates reports whether a path is a Grok durable conversation
+// log (updates.jsonl). Other .jsonl siblings under a Grok session dir
+// (events, chat_history, rewind_points, …) must not be routed to the
+// Claude or Grok parsers.
+func isGrokUpdates(path string) bool {
+	return filepath.Base(path) == "updates.jsonl"
+}
+
+// grokSessionID extracts the session UUID from the parent directory of
+// updates.jsonl: .../<encoded-cwd>/<session-id>/updates.jsonl.
+func grokSessionID(path string) string {
+	return filepath.Base(filepath.Dir(path))
+}
+
+// grokProject derives a coarse project label from the session cwd.
+func grokProject(cwd string) string {
+	if r := extractRepo(cwd); r != "" {
+		return r
+	}
+	if cwd != "" {
+		return filepath.Base(cwd)
+	}
+	return "grok"
+}
+
+// loadGrokSummary reads the sibling summary.json next to updates.jsonl.
+// Missing or unreadable summary is non-fatal — path-derived session id
+// still works, and cwd/branch simply stay empty.
+func loadGrokSummary(updatesPath string) (grokSummary, error) {
+	p := filepath.Join(filepath.Dir(updatesPath), "summary.json")
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		return grokSummary{}, err
+	}
+	var s grokSummary
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return grokSummary{}, err
+	}
+	return s, nil
+}
+
+// parseGrokFile reads a Grok updates.jsonl from the given byte offset
+// and transforms it into a parsedFile, mirroring parseFile/parseCodexFile.
+// Pure computation — no DB access.
+func parseGrokFile(path string, offset int64) (parsedFile, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return parsedFile{}, err
+	}
+	defer f.Close()
+
+	if offset > 0 {
+		if _, err := f.Seek(offset, 0); err != nil {
+			return parsedFile{}, err
+		}
+	}
+
+	sessionID := grokSessionID(path)
+	pf := parsedFile{
+		path:      path,
+		sessionID: sessionID,
+		source:    "grok",
+	}
+
+	// Always load summary for cwd/branch/title. On resume (offset > 0)
+	// writeParsedFile only fills empty meta fields, so re-stamping is fine.
+	// summaryTopic is a provisional title; the first real user turn replaces it.
+	var summaryTopic string
+	if sum, err := loadGrokSummary(path); err == nil {
+		if sum.Info.ID != "" {
+			pf.sessionID = sum.Info.ID
+		}
+		pf.cwd = sum.Info.Cwd
+		pf.branch = sum.HeadBranch
+		if title := sum.GeneratedTitle; title != "" {
+			summaryTopic = title
+		} else if sum.SessionSummary != "" {
+			summaryTopic = sum.SessionSummary
+		}
+		pf.topic = summaryTopic
+	}
+
+	reader := bufio.NewReader(f)
+
+	handleLine := func(line []byte, thisStart int64) {
+		var gl grokLine
+		if json.Unmarshal(line, &gl) != nil {
+			return
+		}
+		// Only the ACP conversation stream. _x.ai/session/update carries
+		// hooks/goals/subagents/compact markers — skip for MVP.
+		if gl.Method != "session/update" {
+			return
+		}
+		if len(gl.Params.Update) == 0 {
+			return
+		}
+		var upd grokUpdate
+		if json.Unmarshal(gl.Params.Update, &upd) != nil {
+			return
+		}
+
+		entryType, msgs, ok := grokRecord(&upd)
+		if !ok {
+			return
+		}
+
+		ts := grokTimestamp(gl.Timestamp)
+		uuid := fmt.Sprintf("grok-%s-%d", pf.sessionID, thisStart)
+		entryIdx := len(pf.entries)
+		pf.entries = append(pf.entries, parsedRawEntry{
+			entryType: entryType,
+			timestamp: ts,
+			raw:       injectSyntheticUUID(line, uuid),
+		})
+
+		for _, m := range msgs {
+			m.entryIdx = entryIdx
+			m.timestamp = ts
+			// Prefer a real user turn over the generated title for topic.
+			// Replace only while topic is empty or still the summary title.
+			if entryType == "user" && m.contentType == "text" &&
+				m.isNoise == 0 && len(m.text) >= 10 && !isBoilerplate(m.text) &&
+				!isGrokInjectedContext(m.text) &&
+				(pf.topic == "" || pf.topic == summaryTopic) {
+				pf.topic = m.text
+				if len(pf.topic) > 200 {
+					pf.topic = pf.topic[:197] + "..."
+				}
+			}
+			pf.messages = append(pf.messages, m)
+		}
+	}
+
+	consumed := offset
+	for {
+		raw, readErr := reader.ReadBytes('\n')
+		if readErr != nil && readErr != io.EOF {
+			return parsedFile{}, fmt.Errorf("read %s: %w", path, readErr)
+		}
+		thisStart := consumed
+		consumed += int64(len(raw))
+		if line := trimLineEnding(raw); len(line) > 0 {
+			handleLine(line, thisStart)
+		}
+		if readErr == io.EOF {
+			break
+		}
+	}
+
+	pf.newOffset = consumed
+	pf.project = grokProject(pf.cwd)
+	return pf, nil
+}
+
+// grokRecord maps one sessionUpdate to an entry type and messages.
+// ok=false means skip (unknown / intermediate / empty).
+func grokRecord(u *grokUpdate) (entryType string, msgs []parsedMessage, ok bool) {
+	switch u.SessionUpdate {
+	case "user_message_chunk":
+		text := grokContentText(u.Content)
+		if text == "" {
+			return "", nil, false
+		}
+		noise := 0
+		if isNoise(text) || isGrokInjectedContext(text) {
+			noise = 1
+		}
+		return "user", []parsedMessage{{
+			role: "user", typ: "user", text: text, contentType: "text", isNoise: noise,
+		}}, true
+
+	case "agent_message_chunk":
+		text := grokContentText(u.Content)
+		if text == "" {
+			return "", nil, false
+		}
+		return "assistant", []parsedMessage{{
+			role: "assistant", typ: "assistant", text: text, contentType: "text",
+		}}, true
+
+	case "agent_thought_chunk":
+		text := grokContentText(u.Content)
+		if text == "" {
+			return "", nil, false
+		}
+		return "assistant", []parsedMessage{{
+			role: "assistant", typ: "assistant", text: text, contentType: "thinking",
+		}}, true
+
+	case "tool_call":
+		name := grokToolName(u)
+		if name == "" && u.Title != "" {
+			name = u.Title
+		}
+		toolInput, text := grokToolInput(u.RawInput)
+		return "assistant", []parsedMessage{{
+			role: "assistant", typ: "assistant", contentType: "tool_use",
+			toolName: name, toolUseID: u.ToolCallID, toolInput: toolInput, text: text,
+		}}, true
+
+	case "tool_call_update":
+		// Only completed updates carry the result body.
+		if u.Status != "completed" {
+			return "", nil, false
+		}
+		return "user", []parsedMessage{{
+			role: "user", typ: "user", contentType: "tool_result",
+			toolUseID: u.ToolCallID, text: grokToolResultText(u),
+		}}, true
+	}
+	return "", nil, false
+}
+
+// isGrokInjectedContext reports system/reminder/synthetic user chunks
+// that should not become the session topic.
+func isGrokInjectedContext(text string) bool {
+	t := strings.TrimSpace(text)
+	return strings.HasPrefix(t, "<system-reminder>") ||
+		strings.HasPrefix(t, "<user_info>") ||
+		strings.HasPrefix(t, "<git_status>") ||
+		strings.HasPrefix(t, "The user sent a message while you were working:") ||
+		strings.Contains(t, "Background task \"") && strings.Contains(t, "completed")
+}
+
+// grokContentText extracts text from an ACP content object or array.
+func grokContentText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	// {"type":"text","text":"..."}
+	var obj struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &obj) == nil && obj.Text != "" {
+		return obj.Text
+	}
+	// plain string
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	return ""
+}
+
+// grokToolName prefers _meta["x.ai/tool"].name, then title.
+func grokToolName(u *grokUpdate) string {
+	if len(u.Meta) > 0 {
+		var meta map[string]json.RawMessage
+		if json.Unmarshal(u.Meta, &meta) == nil {
+			if tr, ok := meta["x.ai/tool"]; ok {
+				var tool struct {
+					Name string `json:"name"`
+				}
+				if json.Unmarshal(tr, &tool) == nil && tool.Name != "" {
+					return tool.Name
+				}
+			}
+		}
+	}
+	return u.Title
+}
+
+// grokToolInput resolves rawInput to tool_input JSON bytes and/or text.
+func grokToolInput(raw json.RawMessage) (toolInput []byte, text string) {
+	if len(raw) == 0 {
+		return nil, ""
+	}
+	if isJSONObject(raw) {
+		return append([]byte(nil), raw...), ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		if isJSONObject([]byte(s)) {
+			return []byte(s), ""
+		}
+		return nil, s
+	}
+	return nil, string(raw)
+}
+
+// grokToolResultText flattens a completed tool_call_update's body.
+func grokToolResultText(u *grokUpdate) string {
+	// Prefer nested content: [{type:"content", content:{type:"text", text:"..."}}]
+	if len(u.Content) > 0 {
+		var blocks []struct {
+			Type    string `json:"type"`
+			Content struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+			Text string `json:"text"`
+		}
+		if json.Unmarshal(u.Content, &blocks) == nil {
+			var b strings.Builder
+			for _, bl := range blocks {
+				t := bl.Content.Text
+				if t == "" {
+					t = bl.Text
+				}
+				if t == "" {
+					continue
+				}
+				if b.Len() > 0 {
+					b.WriteByte('\n')
+				}
+				b.WriteString(t)
+			}
+			if b.Len() > 0 {
+				return b.String()
+			}
+		}
+		if t := grokContentText(u.Content); t != "" {
+			return t
+		}
+	}
+	if len(u.RawOutput) == 0 {
+		return ""
+	}
+	// rawOutput may be {"type":"...","content":"..."} or a string.
+	var obj struct {
+		Content string `json:"content"`
+	}
+	if json.Unmarshal(u.RawOutput, &obj) == nil && obj.Content != "" {
+		return obj.Content
+	}
+	var s string
+	if json.Unmarshal(u.RawOutput, &s) == nil {
+		return s
+	}
+	return string(u.RawOutput)
+}
+
+// grokTimestamp normalises a unix-seconds number or RFC3339 string to
+// RFC3339. Falls back to now when unparseable.
+func grokTimestamp(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return time.Now().UTC().Format(time.RFC3339)
+	}
+	// numeric unix seconds (possibly fractional)
+	var n json.Number
+	if json.Unmarshal(raw, &n) == nil {
+		if i, err := n.Int64(); err == nil {
+			return time.Unix(i, 0).UTC().Format(time.RFC3339)
+		}
+		if f, err := n.Float64(); err == nil {
+			sec := int64(f)
+			nsec := int64((f - float64(sec)) * 1e9)
+			return time.Unix(sec, nsec).UTC().Format(time.RFC3339)
+		}
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil && s != "" {
+		if _, err := time.Parse(time.RFC3339, s); err == nil {
+			return s
+		}
+		// bare integer as string
+		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return time.Unix(i, 0).UTC().Format(time.RFC3339)
+		}
+	}
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+// injectSyntheticUUID returns the JSONL line with a synthetic "uuid"
+// field inserted after the opening brace (Codex + Grok share this need).
+func injectSyntheticUUID(line []byte, uuid string) []byte {
+	return injectCodexUUID(line, uuid)
+}
+
+// ingestGrokFile ingests a single Grok updates.jsonl incrementally from
+// its recorded offset, reusing the shared writer.
+func (s *Store) ingestGrokFile(path string) error {
+	s.mu.Lock()
+	offset := s.offsets[path]
+	s.mu.Unlock()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if offset >= info.Size() {
+		return nil
+	}
+
+	pf, err := parseGrokFile(path, offset)
+	if err != nil {
+		return err
+	}
+
+	ws, err := newWriterState(s.writeDB)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = ws.tx.Rollback() }()
+	defer ws.Close()
+
+	s.writeParsedFile(ws, pf)
+
+	ws.Close()
+	return ws.tx.Commit()
+}

--- a/internal/store/grok_test.go
+++ b/internal/store/grok_test.go
@@ -1,0 +1,298 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const grokSessUUID = "019f4b93-3082-75f2-9c15-1aff0d5f2c3f"
+
+// grokFixtureLines returns a representative Grok updates.jsonl: user,
+// thought, assistant text, tool_call + completed tool_call_update,
+// plus records we must skip (_x.ai hooks, intermediate tool updates).
+func grokFixtureLines(t *testing.T, sessionID string) []byte {
+	t.Helper()
+	line := func(method string, ts int64, update map[string]any) map[string]any {
+		return map[string]any{
+			"timestamp": ts,
+			"method":    method,
+			"params": map[string]any{
+				"sessionId": sessionID,
+				"update":    update,
+			},
+		}
+	}
+	records := []map[string]any{
+		line("_x.ai/session/update", 1783679365, map[string]any{
+			"sessionUpdate": "hook_execution",
+			"event_name":    "session_start",
+		}),
+		line("session/update", 1783679368, map[string]any{
+			"sessionUpdate": "user_message_chunk",
+			"content":       map[string]any{"type": "text", "text": "How do I fix the authentication bug?"},
+		}),
+		line("session/update", 1783679370, map[string]any{
+			"sessionUpdate": "agent_thought_chunk",
+			"content":       map[string]any{"type": "text", "text": "User wants help with auth; inspect login handler."},
+		}),
+		line("session/update", 1783679371, map[string]any{
+			"sessionUpdate": "tool_call",
+			"toolCallId":    "call-1",
+			"title":         "run_terminal_command",
+			"rawInput":      map[string]any{"command": "go test ./...", "description": "run tests"},
+			"_meta": map[string]any{
+				"x.ai/tool": map[string]any{"name": "run_terminal_command", "kind": "execute"},
+			},
+		}),
+		// Intermediate update without status — must be skipped.
+		line("session/update", 1783679372, map[string]any{
+			"sessionUpdate": "tool_call_update",
+			"toolCallId":    "call-1",
+			"title":         "Execute go test",
+			"rawInput":      map[string]any{"command": "go test ./..."},
+		}),
+		line("session/update", 1783679380, map[string]any{
+			"sessionUpdate": "tool_call_update",
+			"toolCallId":    "call-1",
+			"status":        "completed",
+			"content": []map[string]any{
+				{"type": "content", "content": map[string]any{"type": "text", "text": "PASS ok package"}},
+			},
+			"rawOutput": map[string]any{"type": "Bash", "content": "PASS ok package"},
+		}),
+		line("session/update", 1783679385, map[string]any{
+			"sessionUpdate": "agent_message_chunk",
+			"content":       map[string]any{"type": "text", "text": "Fixed the authentication bug in the login handler."},
+		}),
+		line("_x.ai/session/update", 1783679390, map[string]any{
+			"sessionUpdate": "turn_completed",
+			"stop_reason":   "end_turn",
+		}),
+	}
+	var b strings.Builder
+	for _, r := range records {
+		raw, err := json.Marshal(r)
+		if err != nil {
+			t.Fatalf("marshal fixture: %v", err)
+		}
+		b.Write(raw)
+		b.WriteByte('\n')
+	}
+	return []byte(b.String())
+}
+
+func writeGrokSession(t *testing.T, root, cwd string) string {
+	t.Helper()
+	// Mirror layout: sessions/<encoded-cwd>/<session-id>/updates.jsonl
+	encoded := "%2FUsers%2Fdev%2Fwork%2Fgithub.com%2Facme%2Fwebapp"
+	dir := filepath.Join(root, "sessions", encoded, grokSessUUID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	summary := map[string]any{
+		"info": map[string]any{
+			"id":  grokSessUUID,
+			"cwd": cwd,
+		},
+		"generated_title":  "Auth bug triage",
+		"session_summary":  "Auth bug triage",
+		"current_model_id": "grok-4.5",
+		"head_branch":      "main",
+		"git_remotes":      []string{"https://github.com/acme/webapp"},
+	}
+	sumRaw, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "summary.json"), sumRaw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Sidecar that must NOT be ingested as Claude JSONL.
+	if err := os.WriteFile(filepath.Join(dir, "events.jsonl"), []byte(`{"type":"noise"}\n`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "updates.jsonl")
+	if err := os.WriteFile(path, grokFixtureLines(t, grokSessUUID), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestParseGrokFile(t *testing.T) {
+	cwd := "/Users/dev/work/github.com/acme/webapp"
+	root := t.TempDir()
+	path := writeGrokSession(t, root, cwd)
+
+	pf, err := parseGrokFile(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pf.source != "grok" {
+		t.Errorf("source = %q, want grok", pf.source)
+	}
+	if pf.sessionID != grokSessUUID {
+		t.Errorf("sessionID = %q, want %q", pf.sessionID, grokSessUUID)
+	}
+	if pf.cwd != cwd {
+		t.Errorf("cwd = %q, want %q", pf.cwd, cwd)
+	}
+	if pf.branch != "main" {
+		t.Errorf("branch = %q, want main", pf.branch)
+	}
+	if pf.project != "acme/webapp" {
+		t.Errorf("project = %q, want acme/webapp", pf.project)
+	}
+	if !strings.Contains(pf.topic, "authentication bug") {
+		t.Errorf("topic = %q, want first user message (not summary title)", pf.topic)
+	}
+
+	// user, thought, tool_call, tool_result, assistant = 5 entries.
+	// hook_execution, intermediate tool_call_update, turn_completed skipped.
+	if len(pf.entries) != 5 {
+		t.Fatalf("entries = %d, want 5", len(pf.entries))
+	}
+	if len(pf.messages) != 5 {
+		t.Fatalf("messages = %d, want 5", len(pf.messages))
+	}
+
+	var first map[string]any
+	if err := json.Unmarshal(pf.entries[0].raw, &first); err != nil {
+		t.Fatalf("entry raw not valid JSON: %v", err)
+	}
+	if uuid, _ := first["uuid"].(string); !strings.HasPrefix(uuid, "grok-"+grokSessUUID+"-") {
+		t.Errorf("entry uuid = %v, want grok-<session>-<offset> prefix", first["uuid"])
+	}
+
+	byType := map[string][]parsedMessage{}
+	for _, m := range pf.messages {
+		byType[m.contentType] = append(byType[m.contentType], m)
+	}
+
+	var sawUser, sawAssistant bool
+	for _, m := range byType["text"] {
+		if m.role == "user" && strings.Contains(m.text, "authentication bug") {
+			sawUser = true
+		}
+		if m.role == "assistant" && strings.Contains(m.text, "Fixed the authentication") {
+			sawAssistant = true
+		}
+	}
+	if !sawUser || !sawAssistant {
+		t.Errorf("missing user/assistant text (user=%v assistant=%v)", sawUser, sawAssistant)
+	}
+
+	if th := byType["thinking"]; len(th) != 1 || !strings.Contains(th[0].text, "auth") {
+		t.Errorf("thinking = %+v", byType["thinking"])
+	}
+
+	if tu := byType["tool_use"]; len(tu) != 1 ||
+		tu[0].toolName != "run_terminal_command" ||
+		tu[0].toolUseID != "call-1" ||
+		!json.Valid(tu[0].toolInput) ||
+		!strings.Contains(string(tu[0].toolInput), "go test") {
+		t.Errorf("tool_use malformed: %+v", byType["tool_use"])
+	}
+
+	if rs := byType["tool_result"]; len(rs) != 1 ||
+		rs[0].toolUseID != "call-1" ||
+		!strings.Contains(rs[0].text, "PASS ok package") {
+		t.Errorf("tool_result = %+v", byType["tool_result"])
+	}
+}
+
+func TestIsGrokUpdates(t *testing.T) {
+	if !isGrokUpdates("/x/sessions/y/updates.jsonl") {
+		t.Error("expected updates.jsonl to match")
+	}
+	if isGrokUpdates("/x/sessions/y/events.jsonl") {
+		t.Error("events.jsonl must not match")
+	}
+	if isGrokUpdates("/x/rollout-foo.jsonl") {
+		t.Error("rollout must not match")
+	}
+}
+
+func TestGrokIngestEndToEnd(t *testing.T) {
+	grokHome := t.TempDir()
+	cwd := "/Users/dev/work/github.com/acme/webapp"
+	writeGrokSession(t, grokHome, cwd)
+
+	s := newTestStore(t, t.TempDir()) // empty Claude project dir
+	s.SetGrokRoots([]string{filepath.Join(grokHome, "sessions")})
+	if err := s.IngestAll(); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := s.Search("authentication", 10, "all", "", 0, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 || results[0].SessionID != grokSessUUID {
+		t.Fatalf("search did not surface the Grok session: %+v", results)
+	}
+
+	var source, repo string
+	if err := s.readDB.QueryRow(
+		`SELECT source, repo FROM session_meta WHERE session_id = ?`, grokSessUUID,
+	).Scan(&source, &repo); err != nil {
+		t.Fatalf("session_meta query: %v", err)
+	}
+	if source != "grok" {
+		t.Errorf("session_meta.source = %q, want grok", source)
+	}
+	if repo != "acme/webapp" {
+		t.Errorf("session_meta.repo = %q, want acme/webapp", repo)
+	}
+
+	entryCount := func() int {
+		var n int
+		if err := s.readDB.QueryRow(`SELECT count(*) FROM entries WHERE session_id = ?`, grokSessUUID).Scan(&n); err != nil {
+			t.Fatalf("count query: %v", err)
+		}
+		return n
+	}
+	if got := entryCount(); got != 5 {
+		t.Fatalf("entries after ingest = %d, want 5", got)
+	}
+
+	// Idempotency: re-ingest must not duplicate.
+	s.mu.Lock()
+	for p := range s.offsets {
+		s.offsets[p] = 0
+	}
+	s.mu.Unlock()
+	path := filepath.Join(grokHome, "sessions", "%2FUsers%2Fdev%2Fwork%2Fgithub.com%2Facme%2Fwebapp", grokSessUUID, "updates.jsonl")
+	if err := s.ingestGrokFile(path); err != nil {
+		t.Fatal(err)
+	}
+	if got := entryCount(); got != 5 {
+		t.Errorf("entries after re-ingest = %d, want 5 (dedup)", got)
+	}
+
+	// Sidecar events.jsonl must not create a second session or garbage.
+	var nSessions int
+	if err := s.readDB.QueryRow(`SELECT count(*) FROM session_meta WHERE source = 'grok'`).Scan(&nSessions); err != nil {
+		t.Fatal(err)
+	}
+	if nSessions != 1 {
+		t.Errorf("grok sessions = %d, want 1 (sidecars skipped)", nSessions)
+	}
+}
+
+func TestGrokTimestamp(t *testing.T) {
+	ts := grokTimestamp(json.RawMessage(`1783679368`))
+	if !strings.HasPrefix(ts, "2026-") {
+		t.Errorf("unix timestamp = %q, want 2026-… RFC3339", ts)
+	}
+	ts2 := grokTimestamp(json.RawMessage(`"2026-07-10T12:00:00Z"`))
+	if ts2 != "2026-07-10T12:00:00Z" {
+		t.Errorf("rfc3339 passthrough = %q", ts2)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -108,6 +108,12 @@ type Store struct {
 	// SetCodexRoots; existence is checked lazily in codexDirs.
 	codexRoots []string
 
+	// grokRoots are the candidate Grok session roots (~/.grok/sessions)
+	// ingested alongside Claude/Codex (🎯T110). Only updates.jsonl under
+	// these roots is indexed. Mutated only via SetGrokRoots; existence
+	// is checked lazily in grokDirs.
+	grokRoots []string
+
 	// todoGlobs are extra repo-relative globs that IngestTodos matches
 	// when discovering TODO files, beyond the default TODO.md / todos.md
 	// names (🎯T78). Mutated only via SetTodoGlobs, read under
@@ -220,6 +226,35 @@ func (s *Store) SetCodexRoots(roots []string) {
 func (s *Store) codexDirs() []string {
 	s.rootsMu.RLock()
 	roots := append([]string(nil), s.codexRoots...)
+	s.rootsMu.RUnlock()
+	var out []string
+	for _, d := range roots {
+		if info, err := os.Stat(d); err == nil && info.IsDir() {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// SetGrokRoots configures the Grok session roots ingested alongside
+// the Claude project dirs (🎯T110). Pass the candidate directories
+// (GrokRootsFor); existence is checked lazily by grokDirs so roots
+// created after startup are still picked up. Call once after Store.New.
+func (s *Store) SetGrokRoots(roots []string) {
+	s.rootsMu.Lock()
+	defer s.rootsMu.Unlock()
+	if len(roots) == 0 {
+		s.grokRoots = nil
+		return
+	}
+	s.grokRoots = append(s.grokRoots[:0:0], roots...)
+}
+
+// grokDirs returns the configured Grok session roots that currently
+// exist on disk. Empty when not configured or ~/.grok isn't present.
+func (s *Store) grokDirs() []string {
+	s.rootsMu.RLock()
+	roots := append([]string(nil), s.grokRoots...)
 	s.rootsMu.RUnlock()
 	var out []string
 	for _, d := range roots {
@@ -2809,8 +2844,8 @@ type parsedFile struct {
 	branch    string
 	topic     string
 	newOffset int64
-	// source is the producing agent ('claude' or 'codex'). Empty means
-	// 'claude' (the default for ~/.claude/projects transcripts).
+	// source is the producing agent ('claude', 'codex', or 'grok').
+	// Empty means 'claude' (the default for ~/.claude/projects transcripts).
 	source string
 }
 
@@ -2862,6 +2897,36 @@ func (s *Store) IngestAll() error {
 			return nil
 		})
 	}
+	// Grok session roots (🎯T110): only updates.jsonl — siblings
+	// (events/chat_history/rewind_points) must not hit the Claude parser.
+	for _, dir := range s.grokDirs() {
+		if _, err := os.Stat(dir); err != nil {
+			if os.IsNotExist(err) {
+				slog.Warn("grok dir unavailable, skipping", "dir", dir)
+			} else {
+				slog.Warn("grok dir stat failed, skipping", "dir", dir, "err", err)
+			}
+			continue
+		}
+		filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() || !isGrokUpdates(path) {
+				return nil
+			}
+			s.mu.Lock()
+			offset := s.offsets[path]
+			s.mu.Unlock()
+			if offset >= info.Size() {
+				return nil
+			}
+			files = append(files, fileEntry{
+				path:   path,
+				mtime:  info.ModTime(),
+				size:   info.Size(),
+				offset: offset,
+			})
+			return nil
+		})
+	}
 
 	if len(files) == 0 {
 		return nil
@@ -2886,8 +2951,11 @@ func (s *Store) IngestAll() error {
 			defer wg.Done()
 			for fe := range pathCh {
 				parse := parseFile
-				if isCodexRollout(fe.path) {
+				switch {
+				case isCodexRollout(fe.path):
 					parse = parseCodexFile
+				case isGrokUpdates(fe.path):
+					parse = parseGrokFile
 				}
 				if pf, err := parse(fe.path, fe.offset); err == nil {
 					parsedCh <- pf
@@ -3325,6 +3393,19 @@ func (s *Store) Watch(ctx context.Context) error {
 		})
 	}
 
+	// Watch Grok session roots (🎯T110). New session dirs are picked up
+	// by the fsnotify Create→watcher.Add path below.
+	for _, dir := range s.grokDirs() {
+		filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err == nil && info.IsDir() {
+				if wErr := watcher.Add(path); wErr != nil {
+					slog.Warn("failed to watch grok directory", "path", path, "err", wErr)
+				}
+			}
+			return nil
+		})
+	}
+
 	// Also watch the skills directory for .md changes.
 	if sdir, err := skillsDir(); err == nil {
 		if wErr := watcher.Add(sdir); wErr != nil {
@@ -3393,6 +3474,22 @@ func (s *Store) Watch(ctx context.Context) error {
 						if err := s.ingestCodexFile(name); err != nil {
 							slog.Error("ingest codex failed", "file", name, "err", err)
 						}
+						return
+					}
+					if isGrokUpdates(name) {
+						if err := s.ingestGrokFile(name); err != nil {
+							slog.Error("ingest grok failed", "file", name, "err", err)
+						}
+						return
+					}
+					// Ignore other Grok sidecars that share the tree
+					// (events/chat_history/…) if a parent dir is watched.
+					if filepath.Base(name) == "chat_history.jsonl" ||
+						filepath.Base(name) == "events.jsonl" ||
+						filepath.Base(name) == "rewind_points.jsonl" ||
+						filepath.Base(name) == "prompt_history.jsonl" ||
+						filepath.Base(name) == "hunk_records.jsonl" ||
+						filepath.Base(name) == "feedback.jsonl" {
 						return
 					}
 					if err := s.ingestFile(name); err != nil {

--- a/internal/tools/mcp.go
+++ b/internal/tools/mcp.go
@@ -105,6 +105,12 @@ func (h *Handler) LocalHandler(name string) func(ctx context.Context, req mcp.Ca
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("%s failed: %v", name, err)), nil
 		}
+		// 🎯T97.6: one-time upgrade banner when this session spanned a backend swap.
+		if h.upgradeNotices != nil && cc.MCPSessionID != "" {
+			if notice, ok := h.upgradeNotices.Consume(cc.MCPSessionID); ok {
+				text = notice + "\n\n" + text
+			}
+		}
 		if isError {
 			return mcp.NewToolResultError(text), nil
 		}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -108,6 +108,14 @@ type Handler struct {
 	diagRunner       DiagRunner                                    // nil when diagnostics not wired
 	cfgCtl           ConfigController                              // nil when mnemo_config disabled
 	seen             sync.Map
+	// upgradeNotices injects a one-time "mnemo upgraded vN -> vN+1"
+	// banner into tool results after a backend swap (🎯T97.6).
+	upgradeNotices UpgradeNoticeSource
+}
+
+// UpgradeNoticeSource is the tools-facing surface of upgrade.NoticeTracker.
+type UpgradeNoticeSource interface {
+	Consume(sessionID string) (msg string, ok bool)
 }
 
 // NewHandler creates a tool handler that resolves each call's
@@ -144,6 +152,11 @@ func (h *Handler) SetDiagRunner(r DiagRunner) {
 // reports that runtime reconfiguration is not available.
 func (h *Handler) SetConfigController(c ConfigController) {
 	h.cfgCtl = c
+}
+
+// SetUpgradeNotices wires one-time upgrade banners (🎯T97.6).
+func (h *Handler) SetUpgradeNotices(n UpgradeNoticeSource) {
+	h.upgradeNotices = n
 }
 
 // callHandler is the per-call delegate that owns the user-resolved

--- a/internal/tools/upgrade_notice_test.go
+++ b/internal/tools/upgrade_notice_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/marcelocantos/mnemo/internal/store"
+	"github.com/marcelocantos/mnemo/internal/upgrade"
+)
+
+func TestLocalHandlerInjectsUpgradeNoticeOnce(t *testing.T) {
+	t.Parallel()
+	tr := upgrade.NewNoticeTracker()
+	tr.MarkSession("sess-1", "0.61.0", "0.62.0")
+
+	// Resolve fails → Call returns a tool-level error string; notice
+	// must still be prepended exactly once (🎯T97.6).
+	h := NewHandler(func(username string) (store.Backend, error) {
+		return nil, context.Canceled
+	})
+	h.SetUpgradeNotices(tr)
+
+	handler := h.LocalHandler("mnemo_stats")
+	req := mcp.CallToolRequest{}
+	req.Header = http.Header{}
+	req.Header.Set("Mcp-Session-Id", "sess-1")
+
+	res, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil || len(res.Content) == 0 {
+		t.Fatal("empty result")
+	}
+	tc, ok := res.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("content type %T", res.Content[0])
+	}
+	if !strings.HasPrefix(tc.Text, "mnemo upgraded v0.61.0 -> v0.62.0\n\n") {
+		t.Fatalf("missing notice prefix: %q", tc.Text)
+	}
+
+	// Second call: notice consumed.
+	res2, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc2 := res2.Content[0].(mcp.TextContent)
+	if strings.Contains(tc2.Text, "mnemo upgraded") {
+		t.Fatalf("notice must be once-only: %q", tc2.Text)
+	}
+}

--- a/internal/upgrade/autoapply.go
+++ b/internal/upgrade/autoapply.go
@@ -1,0 +1,289 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+	"time"
+)
+
+// DefaultQuiescence is the MCP-idle window before auto-apply (🎯T97.5).
+const DefaultQuiescence = 30 * time.Minute
+
+// ApplyEnv describes install environment constraints for auto-apply.
+type ApplyEnv struct {
+	// Homebrew is true when the binary is a Homebrew install.
+	Homebrew bool
+	// GOOS overrides runtime.GOOS in tests (empty → runtime.GOOS).
+	GOOS string
+}
+
+// NotifyOnly reports whether this environment must not auto-apply
+// (non-Homebrew or Windows).
+func (e ApplyEnv) NotifyOnly() bool {
+	goos := e.GOOS
+	if goos == "" {
+		goos = runtime.GOOS
+	}
+	if goos == "windows" {
+		return true
+	}
+	return !e.Homebrew
+}
+
+// Phase is one step of the auto-apply state machine.
+type Phase string
+
+const (
+	PhaseIdle       Phase = "idle"
+	PhaseAvailable  Phase = "available"
+	PhaseQuiescent  Phase = "quiescent"
+	PhaseApplying   Phase = "applying"
+	PhaseFlipping   Phase = "flipping"
+	PhaseDraining   Phase = "draining"
+	PhaseDone       Phase = "done"
+	PhaseNotifyOnly Phase = "notify_only"
+	PhaseDisabled   Phase = "disabled"
+)
+
+// OrchestratorArgs configures auto-apply orchestration (🎯T97.5).
+type OrchestratorArgs struct {
+	Enabled     bool
+	Env         ApplyEnv
+	Quiescence  time.Duration
+	Detector    *Detector
+	// LastActivity returns the time of the most recent MCP traffic.
+	LastActivity func() time.Time
+	// Apply installs the new binary (e.g. brew upgrade mnemo). Optional
+	// in tests; when nil, Apply step is a no-op success.
+	Apply func(ctx context.Context) error
+	// SpawnBackend starts the new backend process. Optional.
+	SpawnBackend func(ctx context.Context) error
+	// FlipPrimary points new initializes at the new backend. Required
+	// for a full apply; tests inject fakes.
+	FlipPrimary func(ctx context.Context) error
+	// DrainOld stops the previous backend after flip. Optional.
+	DrainOld func(ctx context.Context) error
+	// OnUpgrade is best-effort tools/list_changed + session notices.
+	OnUpgrade func(from, to string)
+	Now       func() time.Time
+}
+
+// Orchestrator drives opt-in auto-apply after quiescence.
+type Orchestrator struct {
+	mu           sync.Mutex
+	enabled      bool
+	env          ApplyEnv
+	quiescence   time.Duration
+	detector     *Detector
+	lastActivity func() time.Time
+	apply        func(ctx context.Context) error
+	spawn        func(ctx context.Context) error
+	flip         func(ctx context.Context) error
+	drain        func(ctx context.Context) error
+	onUpgrade    func(from, to string)
+	now          func() time.Time
+
+	phase   Phase
+	fromVer string
+	toVer   string
+	// history of phases entered (tests).
+	history []Phase
+}
+
+// NewOrchestrator builds an Orchestrator.
+func NewOrchestrator(args *OrchestratorArgs) *Orchestrator {
+	if args == nil {
+		args = &OrchestratorArgs{}
+	}
+	q := args.Quiescence
+	if q <= 0 {
+		q = DefaultQuiescence
+	}
+	now := args.Now
+	if now == nil {
+		now = time.Now
+	}
+	last := args.LastActivity
+	if last == nil {
+		last = func() time.Time { return time.Time{} }
+	}
+	o := &Orchestrator{
+		enabled:      args.Enabled,
+		env:          args.Env,
+		quiescence:   q,
+		detector:     args.Detector,
+		lastActivity: last,
+		apply:        args.Apply,
+		spawn:        args.SpawnBackend,
+		flip:         args.FlipPrimary,
+		drain:        args.DrainOld,
+		onUpgrade:    args.OnUpgrade,
+		now:          now,
+		phase:        PhaseIdle,
+	}
+	if !args.Enabled {
+		o.phase = PhaseDisabled
+	} else if args.Env.NotifyOnly() {
+		o.phase = PhaseNotifyOnly
+	}
+	return o
+}
+
+// SetEnabled toggles auto-apply (config hot-reload).
+func (o *Orchestrator) SetEnabled(enabled bool) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.enabled = enabled
+	if !enabled {
+		o.phase = PhaseDisabled
+	} else if o.env.NotifyOnly() {
+		o.phase = PhaseNotifyOnly
+	} else if o.phase == PhaseDisabled || o.phase == PhaseNotifyOnly {
+		o.phase = PhaseIdle
+	}
+}
+
+// Phase returns the current state machine phase.
+func (o *Orchestrator) Phase() Phase {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.phase
+}
+
+// History returns phases entered (test helper).
+func (o *Orchestrator) History() []Phase {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	out := make([]Phase, len(o.history))
+	copy(out, o.history)
+	return out
+}
+
+func (o *Orchestrator) enter(p Phase) {
+	o.phase = p
+	o.history = append(o.history, p)
+}
+
+// Tick advances the state machine one step. Safe to call on a timer.
+func (o *Orchestrator) Tick(ctx context.Context) error {
+	o.mu.Lock()
+	enabled := o.enabled
+	env := o.env
+	phase := o.phase
+	detector := o.detector
+	quiescence := o.quiescence
+	lastActivity := o.lastActivity
+	now := o.now
+	o.mu.Unlock()
+
+	if !enabled {
+		o.mu.Lock()
+		o.enter(PhaseDisabled)
+		o.mu.Unlock()
+		return nil
+	}
+	if env.NotifyOnly() {
+		// Detection still runs elsewhere; apply path is a no-op.
+		o.mu.Lock()
+		o.enter(PhaseNotifyOnly)
+		o.mu.Unlock()
+		return nil
+	}
+	if detector == nil {
+		return fmt.Errorf("upgrade: orchestrator has no detector")
+	}
+
+	switch phase {
+	case PhaseIdle, PhaseDisabled, PhaseNotifyOnly, PhaseDone:
+		cr := detector.Check(ctx)
+		if cr.Err != nil {
+			return cr.Err
+		}
+		if !cr.UpgradeAvailable {
+			o.mu.Lock()
+			o.enter(PhaseIdle)
+			o.mu.Unlock()
+			return nil
+		}
+		snap := detector.Snapshot()
+		o.mu.Lock()
+		o.fromVer = snap.Current
+		o.toVer = cr.Latest
+		o.enter(PhaseAvailable)
+		o.mu.Unlock()
+		return nil
+
+	case PhaseAvailable:
+		idleFor := now().Sub(lastActivity())
+		if lastActivity().IsZero() || idleFor >= quiescence {
+			o.mu.Lock()
+			o.enter(PhaseQuiescent)
+			o.mu.Unlock()
+		}
+		return nil
+
+	case PhaseQuiescent:
+		o.mu.Lock()
+		o.enter(PhaseApplying)
+		apply := o.apply
+		spawn := o.spawn
+		from, to := o.fromVer, o.toVer
+		o.mu.Unlock()
+		if apply != nil {
+			if err := apply(ctx); err != nil {
+				o.mu.Lock()
+				o.enter(PhaseAvailable)
+				o.mu.Unlock()
+				return fmt.Errorf("apply: %w", err)
+			}
+		}
+		if spawn != nil {
+			if err := spawn(ctx); err != nil {
+				o.mu.Lock()
+				o.enter(PhaseAvailable)
+				o.mu.Unlock()
+				return fmt.Errorf("spawn backend: %w", err)
+			}
+		}
+		o.mu.Lock()
+		o.enter(PhaseFlipping)
+		flip := o.flip
+		o.mu.Unlock()
+		if flip != nil {
+			if err := flip(ctx); err != nil {
+				o.mu.Lock()
+				o.enter(PhaseAvailable)
+				o.mu.Unlock()
+				return fmt.Errorf("flip primary: %w", err)
+			}
+		}
+		o.mu.Lock()
+		o.enter(PhaseDraining)
+		drain := o.drain
+		onUp := o.onUpgrade
+		o.mu.Unlock()
+		if drain != nil {
+			if err := drain(ctx); err != nil {
+				return fmt.Errorf("drain old: %w", err)
+			}
+		}
+		if onUp != nil {
+			onUp(from, to)
+		}
+		o.mu.Lock()
+		o.enter(PhaseDone)
+		o.mu.Unlock()
+		return nil
+
+	case PhaseApplying, PhaseFlipping, PhaseDraining:
+		// Intermediate phases advance inside PhaseQuiescent; if we land
+		// here from a concurrent tick, no-op.
+		return nil
+	}
+	return nil
+}

--- a/internal/upgrade/autoapply.go
+++ b/internal/upgrade/autoapply.go
@@ -233,6 +233,7 @@ func (o *Orchestrator) Tick(ctx context.Context) error {
 		apply := o.apply
 		spawn := o.spawn
 		from, to := o.fromVer, o.toVer
+		onUp := o.onUpgrade
 		o.mu.Unlock()
 		if apply != nil {
 			if err := apply(ctx); err != nil {
@@ -241,6 +242,12 @@ func (o *Orchestrator) Tick(ctx context.Context) error {
 				o.mu.Unlock()
 				return fmt.Errorf("apply: %w", err)
 			}
+		}
+		// Write pending notices BEFORE spawn so the sibling loads them
+		// at startup (LoadAndConsumePending). Also lets the old process
+		// mark in-process banners for sessions it still serves.
+		if onUp != nil {
+			onUp(from, to)
 		}
 		if spawn != nil {
 			if err := spawn(ctx); err != nil {
@@ -261,14 +268,6 @@ func (o *Orchestrator) Tick(ctx context.Context) error {
 				o.mu.Unlock()
 				return fmt.Errorf("flip primary: %w", err)
 			}
-		}
-		// OnUpgrade runs before drain so a restarting process can still
-		// persist session banners / route state while this process lives.
-		o.mu.Lock()
-		onUp := o.onUpgrade
-		o.mu.Unlock()
-		if onUp != nil {
-			onUp(from, to)
 		}
 		o.mu.Lock()
 		o.enter(PhaseDraining)

--- a/internal/upgrade/autoapply.go
+++ b/internal/upgrade/autoapply.go
@@ -262,18 +262,22 @@ func (o *Orchestrator) Tick(ctx context.Context) error {
 				return fmt.Errorf("flip primary: %w", err)
 			}
 		}
+		// OnUpgrade runs before drain so a restarting process can still
+		// persist session banners / route state while this process lives.
+		o.mu.Lock()
+		onUp := o.onUpgrade
+		o.mu.Unlock()
+		if onUp != nil {
+			onUp(from, to)
+		}
 		o.mu.Lock()
 		o.enter(PhaseDraining)
 		drain := o.drain
-		onUp := o.onUpgrade
 		o.mu.Unlock()
 		if drain != nil {
 			if err := drain(ctx); err != nil {
 				return fmt.Errorf("drain old: %w", err)
 			}
-		}
-		if onUp != nil {
-			onUp(from, to)
 		}
 		o.mu.Lock()
 		o.enter(PhaseDone)

--- a/internal/upgrade/autoapply.go
+++ b/internal/upgrade/autoapply.go
@@ -52,10 +52,10 @@ const (
 
 // OrchestratorArgs configures auto-apply orchestration (🎯T97.5).
 type OrchestratorArgs struct {
-	Enabled     bool
-	Env         ApplyEnv
-	Quiescence  time.Duration
-	Detector    *Detector
+	Enabled    bool
+	Env        ApplyEnv
+	Quiescence time.Duration
+	Detector   *Detector
 	// LastActivity returns the time of the most recent MCP traffic.
 	LastActivity func() time.Time
 	// Apply installs the new binary (e.g. brew upgrade mnemo). Optional

--- a/internal/upgrade/autoapply_test.go
+++ b/internal/upgrade/autoapply_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestApplyEnvNotifyOnly(t *testing.T) {
+	t.Parallel()
+	if !(ApplyEnv{Homebrew: false, GOOS: "darwin"}).NotifyOnly() {
+		t.Fatal("non-homebrew should notify-only")
+	}
+	if !(ApplyEnv{Homebrew: true, GOOS: "windows"}).NotifyOnly() {
+		t.Fatal("windows should notify-only")
+	}
+	if (ApplyEnv{Homebrew: true, GOOS: "darwin"}).NotifyOnly() {
+		t.Fatal("homebrew darwin may apply")
+	}
+}
+
+func TestOrchestratorDisabledAndNotifyOnly(t *testing.T) {
+	t.Parallel()
+	d := NewDetector(&DetectorArgs{
+		CurrentVersion: "0.61.0",
+		Fetch:          func(ctx context.Context) (string, error) { return "v0.62.0", nil },
+	})
+	o := NewOrchestrator(&OrchestratorArgs{
+		Enabled:  false,
+		Env:      ApplyEnv{Homebrew: true, GOOS: "darwin"},
+		Detector: d,
+	})
+	if err := o.Tick(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if o.Phase() != PhaseDisabled {
+		t.Fatalf("phase %s", o.Phase())
+	}
+
+	o2 := NewOrchestrator(&OrchestratorArgs{
+		Enabled:  true,
+		Env:      ApplyEnv{Homebrew: false, GOOS: "darwin"},
+		Detector: d,
+	})
+	if err := o2.Tick(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if o2.Phase() != PhaseNotifyOnly {
+		t.Fatalf("phase %s", o2.Phase())
+	}
+}
+
+func TestOrchestratorFullStateMachine(t *testing.T) {
+	t.Parallel()
+	var clock time.Time
+	clock = time.Unix(1_000_000, 0)
+	now := func() time.Time { return clock }
+	lastAct := clock // recent activity
+	d := NewDetector(&DetectorArgs{
+		CurrentVersion: "0.61.0",
+		Fetch:          func(ctx context.Context) (string, error) { return "v0.62.0", nil },
+		Now:            now,
+		MinInterval:    time.Millisecond,
+	})
+	var steps []string
+	var noticeFrom, noticeTo string
+	o := NewOrchestrator(&OrchestratorArgs{
+		Enabled:     true,
+		Env:         ApplyEnv{Homebrew: true, GOOS: "darwin"},
+		Quiescence:  30 * time.Minute,
+		Detector:    d,
+		LastActivity: func() time.Time { return lastAct },
+		Apply: func(ctx context.Context) error {
+			steps = append(steps, "apply")
+			return nil
+		},
+		SpawnBackend: func(ctx context.Context) error {
+			steps = append(steps, "spawn")
+			return nil
+		},
+		FlipPrimary: func(ctx context.Context) error {
+			steps = append(steps, "flip")
+			return nil
+		},
+		DrainOld: func(ctx context.Context) error {
+			steps = append(steps, "drain")
+			return nil
+		},
+		OnUpgrade: func(from, to string) {
+			noticeFrom, noticeTo = from, to
+			steps = append(steps, "notice")
+		},
+		Now: now,
+	})
+
+	// Tick 1: discover upgrade
+	if err := o.Tick(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if o.Phase() != PhaseAvailable {
+		t.Fatalf("want available, got %s", o.Phase())
+	}
+
+	// Still busy — stay available
+	if err := o.Tick(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if o.Phase() != PhaseAvailable {
+		t.Fatalf("still available while busy, got %s", o.Phase())
+	}
+
+	// Quiesce
+	clock = clock.Add(31 * time.Minute)
+	if err := o.Tick(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if o.Phase() != PhaseQuiescent {
+		t.Fatalf("want quiescent, got %s", o.Phase())
+	}
+
+	// Apply through done
+	if err := o.Tick(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if o.Phase() != PhaseDone {
+		t.Fatalf("want done, got %s hist=%v", o.Phase(), o.History())
+	}
+	wantSteps := "apply,spawn,flip,drain,notice"
+	if got := strings.Join(steps, ","); got != wantSteps {
+		t.Fatalf("steps %s want %s", got, wantSteps)
+	}
+	if noticeFrom == "" || noticeTo == "" {
+		t.Fatal("onUpgrade not called")
+	}
+}

--- a/internal/upgrade/autoapply_test.go
+++ b/internal/upgrade/autoapply_test.go
@@ -69,10 +69,10 @@ func TestOrchestratorFullStateMachine(t *testing.T) {
 	var steps []string
 	var noticeFrom, noticeTo string
 	o := NewOrchestrator(&OrchestratorArgs{
-		Enabled:     true,
-		Env:         ApplyEnv{Homebrew: true, GOOS: "darwin"},
-		Quiescence:  30 * time.Minute,
-		Detector:    d,
+		Enabled:      true,
+		Env:          ApplyEnv{Homebrew: true, GOOS: "darwin"},
+		Quiescence:   30 * time.Minute,
+		Detector:     d,
 		LastActivity: func() time.Time { return lastAct },
 		Apply: func(ctx context.Context) error {
 			steps = append(steps, "apply")

--- a/internal/upgrade/autoapply_test.go
+++ b/internal/upgrade/autoapply_test.go
@@ -129,9 +129,8 @@ func TestOrchestratorFullStateMachine(t *testing.T) {
 	if o.Phase() != PhaseDone {
 		t.Fatalf("want done, got %s hist=%v", o.Phase(), o.History())
 	}
-	// OnUpgrade must run before drain so a restarting process can
-	// persist banners/route state while still alive.
-	wantSteps := "apply,spawn,flip,notice,drain"
+	// OnUpgrade before spawn so the sibling can LoadAndConsumePending.
+	wantSteps := "apply,notice,spawn,flip,drain"
 	if got := strings.Join(steps, ","); got != wantSteps {
 		t.Fatalf("steps %s want %s", got, wantSteps)
 	}

--- a/internal/upgrade/autoapply_test.go
+++ b/internal/upgrade/autoapply_test.go
@@ -129,7 +129,9 @@ func TestOrchestratorFullStateMachine(t *testing.T) {
 	if o.Phase() != PhaseDone {
 		t.Fatalf("want done, got %s hist=%v", o.Phase(), o.History())
 	}
-	wantSteps := "apply,spawn,flip,drain,notice"
+	// OnUpgrade must run before drain so a restarting process can
+	// persist banners/route state while still alive.
+	wantSteps := "apply,spawn,flip,notice,drain"
 	if got := strings.Join(steps, ","); got != wantSteps {
 		t.Fatalf("steps %s want %s", got, wantSteps)
 	}

--- a/internal/upgrade/detect.go
+++ b/internal/upgrade/detect.go
@@ -1,0 +1,255 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultReleaseRepo is the GitHub repo queried for latest tags.
+const DefaultReleaseRepo = "marcelocantos/mnemo"
+
+// TagFetcher returns the latest release tag string (e.g. "v0.62.0").
+// Tests inject fakes; production uses GHReleaseFetcher.
+type TagFetcher func(ctx context.Context) (string, error)
+
+// GHReleaseFetcher runs `gh release list` for repo and returns the
+// newest tag. repo defaults to DefaultReleaseRepo when empty.
+func GHReleaseFetcher(repo string) TagFetcher {
+	if repo == "" {
+		repo = DefaultReleaseRepo
+	}
+	return func(ctx context.Context) (string, error) {
+		cmd := exec.CommandContext(ctx, "gh", "release", "list",
+			"--repo", repo,
+			"--limit", "1",
+			"--json", "tagName")
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			msg := strings.TrimSpace(stderr.String())
+			if msg == "" {
+				msg = err.Error()
+			}
+			return "", fmt.Errorf("gh release list: %s", msg)
+		}
+		var rows []struct {
+			TagName string `json:"tagName"`
+		}
+		if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+			return "", fmt.Errorf("parse gh release list: %w", err)
+		}
+		if len(rows) == 0 || rows[0].TagName == "" {
+			return "", fmt.Errorf("no releases listed for %s", repo)
+		}
+		return rows[0].TagName, nil
+	}
+}
+
+// DetectorArgs configures a Detector.
+type DetectorArgs struct {
+	// CurrentVersion is the running binary version (no required "v" prefix).
+	CurrentVersion string
+	// Fetch retrieves the latest tag. Required when Disabled is false.
+	Fetch TagFetcher
+	// Disabled skips all network calls (config disable_upgrade_check).
+	Disabled bool
+	// MinInterval bounds how often Check will call Fetch (default 6h).
+	MinInterval time.Duration
+	// Now is optional clock injection for tests.
+	Now func() time.Time
+}
+
+// Detector caches the latest known release tag and compares it to the
+// running binary version (🎯T97.2).
+type Detector struct {
+	mu             sync.Mutex
+	current        string
+	fetch          TagFetcher
+	disabled       bool
+	minInterval    time.Duration
+	now            func() time.Time
+	latest         string
+	checkedAt      time.Time
+	lastErr        string
+	fetchCount     int // for tests: how many times Fetch was invoked
+	upgradeAvail   bool
+}
+
+// NewDetector builds a Detector from args.
+func NewDetector(args *DetectorArgs) *Detector {
+	if args == nil {
+		args = &DetectorArgs{}
+	}
+	min := args.MinInterval
+	if min <= 0 {
+		min = 6 * time.Hour
+	}
+	now := args.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Detector{
+		current:     args.CurrentVersion,
+		fetch:       args.Fetch,
+		disabled:    args.Disabled,
+		minInterval: min,
+		now:         now,
+	}
+}
+
+// SetDisabled updates the disable flag (config hot-reload).
+func (d *Detector) SetDisabled(disabled bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.disabled = disabled
+}
+
+// FetchCount returns how many times the underlying TagFetcher ran.
+func (d *Detector) FetchCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.fetchCount
+}
+
+// Snapshot is a point-in-time view of detection state for diagnostics.
+type Snapshot struct {
+	Current        string
+	Latest         string
+	CheckedAt      time.Time
+	Disabled       bool
+	UpgradeAvail   bool
+	LastError      string
+	FetchCount     int
+}
+
+// Snapshot returns the current detection state.
+func (d *Detector) Snapshot() Snapshot {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return Snapshot{
+		Current:      d.current,
+		Latest:       d.latest,
+		CheckedAt:    d.checkedAt,
+		Disabled:     d.disabled,
+		UpgradeAvail: d.upgradeAvail,
+		LastError:    d.lastErr,
+		FetchCount:   d.fetchCount,
+	}
+}
+
+// CheckResult is the outcome of one detection pass.
+type CheckResult struct {
+	// CalledNetwork is true only when Fetch was invoked this call.
+	CalledNetwork bool
+	// UpgradeAvailable is true when latest > current.
+	UpgradeAvailable bool
+	// Latest is the newest tag when known.
+	Latest string
+	// Detail is a human-readable summary for diag.
+	Detail string
+	// Err is set when a fetch was attempted and failed.
+	Err error
+}
+
+// Check consults the cache / fetcher. When disabled, never calls Fetch.
+func (d *Detector) Check(ctx context.Context) CheckResult {
+	d.mu.Lock()
+	disabled := d.disabled
+	current := d.current
+	fetch := d.fetch
+	minInterval := d.minInterval
+	now := d.now()
+	lastChecked := d.checkedAt
+	cachedLatest := d.latest
+	d.mu.Unlock()
+
+	if disabled {
+		return CheckResult{
+			CalledNetwork:    false,
+			UpgradeAvailable: false,
+			Detail:           "upgrade check disabled (disable_upgrade_check)",
+		}
+	}
+	if fetch == nil {
+		return CheckResult{
+			Detail: "upgrade check has no tag fetcher configured",
+			Err:    fmt.Errorf("nil TagFetcher"),
+		}
+	}
+
+	needFetch := lastChecked.IsZero() || now.Sub(lastChecked) >= minInterval || cachedLatest == ""
+	var latest string
+	var called bool
+	var fetchErr error
+	if needFetch {
+		called = true
+		latest, fetchErr = fetch(ctx)
+		d.mu.Lock()
+		d.fetchCount++
+		d.checkedAt = now
+		if fetchErr != nil {
+			d.lastErr = fetchErr.Error()
+		} else {
+			d.latest = latest
+			d.lastErr = ""
+		}
+		d.mu.Unlock()
+		if fetchErr != nil {
+			return CheckResult{
+				CalledNetwork: true,
+				Detail:        "failed to query latest release: " + fetchErr.Error(),
+				Err:           fetchErr,
+			}
+		}
+	} else {
+		latest = cachedLatest
+	}
+
+	newer, err := IsNewer(current, latest)
+	if err != nil {
+		return CheckResult{
+			CalledNetwork: called,
+			Latest:        latest,
+			Detail:        "version compare failed: " + err.Error(),
+			Err:           err,
+		}
+	}
+	d.mu.Lock()
+	d.upgradeAvail = newer
+	d.latest = latest
+	d.mu.Unlock()
+
+	if newer {
+		return CheckResult{
+			CalledNetwork:    called,
+			UpgradeAvailable: true,
+			Latest:           latest,
+			Detail: fmt.Sprintf("upgrade available: running %s, latest %s",
+				formatV(current), formatV(latest)),
+		}
+	}
+	return CheckResult{
+		CalledNetwork: called,
+		Latest:        latest,
+		Detail: fmt.Sprintf("up to date: running %s (latest %s)",
+			formatV(current), formatV(latest)),
+	}
+}
+
+func formatV(v string) string {
+	n := NormalizeTag(v)
+	if n == "" {
+		return v
+	}
+	return "v" + n
+}

--- a/internal/upgrade/detect.go
+++ b/internal/upgrade/detect.go
@@ -72,17 +72,17 @@ type DetectorArgs struct {
 // Detector caches the latest known release tag and compares it to the
 // running binary version (🎯T97.2).
 type Detector struct {
-	mu             sync.Mutex
-	current        string
-	fetch          TagFetcher
-	disabled       bool
-	minInterval    time.Duration
-	now            func() time.Time
-	latest         string
-	checkedAt      time.Time
-	lastErr        string
-	fetchCount     int // for tests: how many times Fetch was invoked
-	upgradeAvail   bool
+	mu           sync.Mutex
+	current      string
+	fetch        TagFetcher
+	disabled     bool
+	minInterval  time.Duration
+	now          func() time.Time
+	latest       string
+	checkedAt    time.Time
+	lastErr      string
+	fetchCount   int // for tests: how many times Fetch was invoked
+	upgradeAvail bool
 }
 
 // NewDetector builds a Detector from args.
@@ -123,13 +123,13 @@ func (d *Detector) FetchCount() int {
 
 // Snapshot is a point-in-time view of detection state for diagnostics.
 type Snapshot struct {
-	Current        string
-	Latest         string
-	CheckedAt      time.Time
-	Disabled       bool
-	UpgradeAvail   bool
-	LastError      string
-	FetchCount     int
+	Current      string
+	Latest       string
+	CheckedAt    time.Time
+	Disabled     bool
+	UpgradeAvail bool
+	LastError    string
+	FetchCount   int
 }
 
 // Snapshot returns the current detection state.

--- a/internal/upgrade/detect_test.go
+++ b/internal/upgrade/detect_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDetectorDisabledNeverCallsFetch(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	d := NewDetector(&DetectorArgs{
+		CurrentVersion: "0.61.0",
+		Disabled:       true,
+		Fetch: func(ctx context.Context) (string, error) {
+			calls.Add(1)
+			return "v0.99.0", nil
+		},
+	})
+	cr := d.Check(context.Background())
+	if cr.CalledNetwork {
+		t.Fatal("expected no network when disabled")
+	}
+	if cr.UpgradeAvailable {
+		t.Fatal("expected no upgrade flag when disabled")
+	}
+	if calls.Load() != 0 || d.FetchCount() != 0 {
+		t.Fatalf("fetch invoked %d times", calls.Load())
+	}
+}
+
+func TestDetectorReportsUpgradeWhenNewer(t *testing.T) {
+	t.Parallel()
+	d := NewDetector(&DetectorArgs{
+		CurrentVersion: "0.61.0",
+		Fetch: func(ctx context.Context) (string, error) {
+			return "v0.62.0", nil
+		},
+		MinInterval: time.Hour,
+	})
+	cr := d.Check(context.Background())
+	if !cr.CalledNetwork {
+		t.Fatal("expected network call")
+	}
+	if !cr.UpgradeAvailable {
+		t.Fatalf("expected upgrade: %+v", cr)
+	}
+	if cr.Latest != "v0.62.0" {
+		t.Fatalf("latest %q", cr.Latest)
+	}
+	// Second check within interval uses cache — no second fetch.
+	cr2 := d.Check(context.Background())
+	if cr2.CalledNetwork {
+		t.Fatal("expected cache hit")
+	}
+	if !cr2.UpgradeAvailable {
+		t.Fatal("still available")
+	}
+	if d.FetchCount() != 1 {
+		t.Fatalf("fetch count %d", d.FetchCount())
+	}
+}
+
+func TestDetectorUpToDate(t *testing.T) {
+	t.Parallel()
+	d := NewDetector(&DetectorArgs{
+		CurrentVersion: "0.62.0",
+		Fetch: func(ctx context.Context) (string, error) {
+			return "v0.62.0", nil
+		},
+	})
+	cr := d.Check(context.Background())
+	if cr.UpgradeAvailable {
+		t.Fatal("should be up to date")
+	}
+}
+
+func TestDetectorFetchError(t *testing.T) {
+	t.Parallel()
+	d := NewDetector(&DetectorArgs{
+		CurrentVersion: "0.61.0",
+		Fetch: func(ctx context.Context) (string, error) {
+			return "", errors.New("gh missing")
+		},
+	})
+	cr := d.Check(context.Background())
+	if cr.Err == nil {
+		t.Fatal("expected error")
+	}
+	if !cr.CalledNetwork {
+		t.Fatal("expected attempted fetch")
+	}
+}

--- a/internal/upgrade/drain.go
+++ b/internal/upgrade/drain.go
@@ -16,7 +16,14 @@ const DefaultDrainPoll = 200 * time.Millisecond
 // clear before reaping the old backend anyway.
 const DefaultDrainMaxWait = 30 * time.Minute
 
+// PinUnknown is returned by PinCounter when the count cannot be read
+// (I/O error, partial file). AffinityDrain must treat this as "still
+// has pins" and must not reap.
+const PinUnknown = -1
+
 // PinCounter reports how many sessions are still pinned to a backend.
+// Return PinUnknown (-1) when the count is not trustworthy (read error);
+// never return 0 on I/O failure — that force-reaps live sessions.
 // Production uses edge-route.json pin_counts; tests inject fakes.
 type PinCounter func(backendIdx int) int
 
@@ -26,7 +33,7 @@ type PinCounter func(backendIdx int) int
 type AffinityDrainArgs struct {
 	// BackendIdx is this process's index in the edge route table.
 	BackendIdx int
-	// Pins returns the current pin count for BackendIdx.
+	// Pins returns the current pin count for BackendIdx, or PinUnknown.
 	Pins PinCounter
 	// MaxWait bounds the wait (default DefaultDrainMaxWait).
 	MaxWait time.Duration
@@ -43,6 +50,9 @@ type AffinityDrainArgs struct {
 // AffinityDrain waits until no sessions are pinned to BackendIdx, then
 // reaps. Never repins — that would send Mcp-Session-Id to a backend
 // that does not hold the mcp-go session state.
+//
+// PinUnknown (read failure) is treated as non-zero so a torn route file
+// cannot trigger an immediate reap with live pins.
 func AffinityDrain(ctx context.Context, args *AffinityDrainArgs) error {
 	if args == nil || args.Pins == nil || args.Reap == nil {
 		return fmt.Errorf("upgrade: AffinityDrain requires Pins and Reap")
@@ -68,15 +78,19 @@ func AffinityDrain(ctx context.Context, args *AffinityDrainArgs) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if args.Pins(args.BackendIdx) <= 0 {
+		n := args.Pins(args.BackendIdx)
+		// Only an authoritative zero is safe to reap on. PinUnknown and
+		// positive counts keep waiting.
+		if n == 0 {
 			return args.Reap(ctx)
 		}
 		if !now().Before(deadline) {
-			// Timed out with pins remaining: still reap (sessions that
-			// never disconnected). Prefer waiting; force is last resort.
+			// Timed out: force reap only if we had a readable positive
+			// count (abandoned clients). If the last read was unknown,
+			// still force after max wait so the upgrade cannot hang
+			// forever — callers should log this path.
 			return args.Reap(ctx)
 		}
-		// Sleep in small steps so ctx cancel is noticed.
 		sleep(poll)
 	}
 }

--- a/internal/upgrade/drain.go
+++ b/internal/upgrade/drain.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// DefaultDrainPoll is how often AffinityDrain re-checks pin counts.
+const DefaultDrainPoll = 200 * time.Millisecond
+
+// DefaultDrainMaxWait caps how long AffinityDrain waits for pins to
+// clear before reaping the old backend anyway.
+const DefaultDrainMaxWait = 30 * time.Minute
+
+// PinCounter reports how many sessions are still pinned to a backend.
+// Production uses edge-route.json pin_counts; tests inject fakes.
+type PinCounter func(backendIdx int) int
+
+// AffinityDrainArgs configures happy-path upgrade drain (🎯T97.5):
+// primary already flipped; this backend keeps serving its pins until
+// the count hits zero (or MaxWait), then calls Reap.
+type AffinityDrainArgs struct {
+	// BackendIdx is this process's index in the edge route table.
+	BackendIdx int
+	// Pins returns the current pin count for BackendIdx.
+	Pins PinCounter
+	// MaxWait bounds the wait (default DefaultDrainMaxWait).
+	MaxWait time.Duration
+	// PollInterval between pin checks (default DefaultDrainPoll).
+	PollInterval time.Duration
+	// Sleep is time.Sleep; inject in tests.
+	Sleep func(d time.Duration)
+	// Now is time.Now; inject in tests.
+	Now func() time.Time
+	// Reap stops this backend (SIGTERM / shutdown). Required.
+	Reap func(ctx context.Context) error
+}
+
+// AffinityDrain waits until no sessions are pinned to BackendIdx, then
+// reaps. Never repins — that would send Mcp-Session-Id to a backend
+// that does not hold the mcp-go session state.
+func AffinityDrain(ctx context.Context, args *AffinityDrainArgs) error {
+	if args == nil || args.Pins == nil || args.Reap == nil {
+		return fmt.Errorf("upgrade: AffinityDrain requires Pins and Reap")
+	}
+	maxWait := args.MaxWait
+	if maxWait <= 0 {
+		maxWait = DefaultDrainMaxWait
+	}
+	poll := args.PollInterval
+	if poll <= 0 {
+		poll = DefaultDrainPoll
+	}
+	sleep := args.Sleep
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+	now := args.Now
+	if now == nil {
+		now = time.Now
+	}
+	deadline := now().Add(maxWait)
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if args.Pins(args.BackendIdx) <= 0 {
+			return args.Reap(ctx)
+		}
+		if !now().Before(deadline) {
+			// Timed out with pins remaining: still reap (sessions that
+			// never disconnected). Prefer waiting; force is last resort.
+			return args.Reap(ctx)
+		}
+		// Sleep in small steps so ctx cancel is noticed.
+		sleep(poll)
+	}
+}
+
+// FailoverRepin is the crash-only path: move every pin to primary.
+// Must not be used for happy-path auto-apply (breaks stateful MCP).
+type FailoverRepinFunc func() (moved int)
+
+// FailoverRepin runs the crash repin hook if non-nil.
+func FailoverRepin(fn FailoverRepinFunc) int {
+	if fn == nil {
+		return 0
+	}
+	return fn()
+}

--- a/internal/upgrade/drain_test.go
+++ b/internal/upgrade/drain_test.go
@@ -5,6 +5,9 @@ package upgrade
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -97,4 +100,79 @@ func TestFailoverRepinCallsHook(t *testing.T) {
 	if n := FailoverRepin(func() int { return 3 }); n != 3 {
 		t.Fatalf("n=%d", n)
 	}
+}
+
+// PinUnknown must not be treated as zero — otherwise a torn route file
+// reaps immediately with live pins.
+func TestAffinityDrainPinUnknownDoesNotReapEarly(t *testing.T) {
+	t.Parallel()
+	var clock time.Time
+	clock = time.Unix(0, 0)
+	var reaped atomic.Bool
+	reads := 0
+	err := AffinityDrain(context.Background(), &AffinityDrainArgs{
+		BackendIdx: 0,
+		Pins: func(int) int {
+			reads++
+			if reads < 3 {
+				return PinUnknown
+			}
+			return 0
+		},
+		MaxWait:      time.Minute,
+		PollInterval: 10 * time.Millisecond,
+		Now:          func() time.Time { return clock },
+		Sleep:        func(d time.Duration) { clock = clock.Add(d) },
+		Reap: func(ctx context.Context) error {
+			reaped.Store(true)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reaped.Load() {
+		t.Fatal("expected reap after authoritative zero")
+	}
+	if reads < 3 {
+		t.Fatalf("should have waited through unknown reads, reads=%d", reads)
+	}
+}
+
+func TestWriteRouteFileAtomicReadable(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "edge-route.json")
+	if err := WriteRouteFile(path, RouteFile{
+		Backends:  []string{"http://127.0.0.1:1"},
+		Primary:   0,
+		PinCounts: []int{2},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Concurrent readers must always get valid JSON.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 50; i++ {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Errorf("read: %v", err)
+				return
+			}
+			var rf RouteFile
+			if err := json.Unmarshal(data, &rf); err != nil {
+				t.Errorf("partial json: %v data=%q", err, data)
+				return
+			}
+		}
+	}()
+	for i := 0; i < 50; i++ {
+		_ = WriteRouteFile(path, RouteFile{
+			Backends:  []string{"http://127.0.0.1:1"},
+			Primary:   0,
+			PinCounts: []int{i % 3},
+		})
+	}
+	<-done
 }

--- a/internal/upgrade/drain_test.go
+++ b/internal/upgrade/drain_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestAffinityDrainWaitsForZeroPinsThenReaps(t *testing.T) {
+	t.Parallel()
+	var clock time.Time
+	clock = time.Unix(1_000_000, 0)
+	pins := 2
+	var reaped atomic.Bool
+	var sleeps int
+	err := AffinityDrain(context.Background(), &AffinityDrainArgs{
+		BackendIdx: 0,
+		Pins: func(idx int) int {
+			if idx != 0 {
+				t.Fatalf("idx %d", idx)
+			}
+			return pins
+		},
+		MaxWait:      time.Minute,
+		PollInterval: 10 * time.Millisecond,
+		Now:          func() time.Time { return clock },
+		Sleep: func(d time.Duration) {
+			sleeps++
+			clock = clock.Add(d)
+			if sleeps == 2 {
+				pins = 0 // clear after two polls
+			}
+		},
+		Reap: func(ctx context.Context) error {
+			reaped.Store(true)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reaped.Load() {
+		t.Fatal("expected reap")
+	}
+	if sleeps < 2 {
+		t.Fatalf("expected wait polls, sleeps=%d", sleeps)
+	}
+}
+
+func TestAffinityDrainReapsImmediatelyWhenAlreadyZero(t *testing.T) {
+	t.Parallel()
+	var reaped atomic.Bool
+	err := AffinityDrain(context.Background(), &AffinityDrainArgs{
+		BackendIdx: 1,
+		Pins:       func(int) int { return 0 },
+		Reap: func(ctx context.Context) error {
+			reaped.Store(true)
+			return nil
+		},
+	})
+	if err != nil || !reaped.Load() {
+		t.Fatalf("err=%v reaped=%v", err, reaped.Load())
+	}
+}
+
+func TestAffinityDrainMaxWaitForcesReap(t *testing.T) {
+	t.Parallel()
+	var clock time.Time
+	clock = time.Unix(0, 0)
+	var reaped atomic.Bool
+	err := AffinityDrain(context.Background(), &AffinityDrainArgs{
+		BackendIdx:   0,
+		Pins:         func(int) int { return 5 },
+		MaxWait:      50 * time.Millisecond,
+		PollInterval: 20 * time.Millisecond,
+		Now:          func() time.Time { return clock },
+		Sleep:        func(d time.Duration) { clock = clock.Add(d) },
+		Reap: func(ctx context.Context) error {
+			reaped.Store(true)
+			return nil
+		},
+	})
+	if err != nil || !reaped.Load() {
+		t.Fatalf("err=%v reaped=%v", err, reaped.Load())
+	}
+}
+
+func TestFailoverRepinCallsHook(t *testing.T) {
+	t.Parallel()
+	if FailoverRepin(nil) != 0 {
+		t.Fatal("nil")
+	}
+	if n := FailoverRepin(func() int { return 3 }); n != 3 {
+		t.Fatalf("n=%d", n)
+	}
+}

--- a/internal/upgrade/lease.go
+++ b/internal/upgrade/lease.go
@@ -1,0 +1,275 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultLeaseTTL is how long a holder may go without heartbeat
+// before another process may steal the lease.
+const DefaultLeaseTTL = 2 * time.Second
+
+// DefaultHeartbeat is how often the holder rewrites its heartbeat.
+const DefaultHeartbeat = 500 * time.Millisecond
+
+// LeaseArgs configures a single-holder background lease (🎯T97.4).
+type LeaseArgs struct {
+	// Path is the lock file path (typically ~/.mnemo/background.lease).
+	Path string
+	// HolderID uniquely identifies this process (hostname:pid is fine).
+	HolderID string
+	// TTL is how long a heartbeat remains valid (default DefaultLeaseTTL).
+	TTL time.Duration
+	// Now is optional clock injection.
+	Now func() time.Time
+}
+
+// Lease is a heartbeat file lock so exactly one backend runs
+// singleton background work (ingest/compaction/mirrors/image pools).
+type Lease struct {
+	mu       sync.Mutex
+	path     string
+	holderID string
+	ttl      time.Duration
+	now      func() time.Time
+	held     bool
+	// runningBG is set by the registry when background workers are live.
+	runningBG bool
+}
+
+// NewLease builds a Lease. Path and HolderID are required.
+func NewLease(args *LeaseArgs) (*Lease, error) {
+	if args == nil || args.Path == "" {
+		return nil, fmt.Errorf("upgrade: lease path required")
+	}
+	if args.HolderID == "" {
+		return nil, fmt.Errorf("upgrade: lease holder id required")
+	}
+	ttl := args.TTL
+	if ttl <= 0 {
+		ttl = DefaultLeaseTTL
+	}
+	now := args.Now
+	if now == nil {
+		now = time.Now
+	}
+	if err := os.MkdirAll(filepath.Dir(args.Path), 0o755); err != nil {
+		return nil, fmt.Errorf("upgrade: lease dir: %w", err)
+	}
+	return &Lease{
+		path:     args.Path,
+		holderID: args.HolderID,
+		ttl:      ttl,
+		now:      now,
+	}, nil
+}
+
+// DefaultLeasePath returns ~/.mnemo/background.lease under home.
+func DefaultLeasePath(home string) string {
+	return filepath.Join(home, ".mnemo", "background.lease")
+}
+
+// DefaultHolderID returns "hostname:pid".
+func DefaultHolderID() string {
+	host, _ := os.Hostname()
+	if host == "" {
+		host = "unknown"
+	}
+	return fmt.Sprintf("%s:%d", host, os.Getpid())
+}
+
+// TryAcquire attempts to take the lease. Returns true when this process
+// holds it after the call.
+func (l *Lease) TryAcquire() (bool, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.tryAcquireLocked()
+}
+
+func (l *Lease) tryAcquireLocked() (bool, error) {
+	now := l.now()
+	data, err := os.ReadFile(l.path)
+	if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+	if err == nil {
+		holder, hb, ok := parseLeaseFile(string(data))
+		if ok && holder != l.holderID {
+			if now.Sub(hb) < l.ttl {
+				l.held = false
+				return false, nil // live holder
+			}
+			// expired — steal
+		}
+		if ok && holder == l.holderID {
+			// refresh
+			if err := l.writeLocked(now); err != nil {
+				return false, err
+			}
+			l.held = true
+			return true, nil
+		}
+	}
+	if err := l.writeLocked(now); err != nil {
+		return false, err
+	}
+	// Re-read to detect races: if another writer won, we may not hold.
+	data2, err := os.ReadFile(l.path)
+	if err != nil {
+		l.held = false
+		return false, err
+	}
+	holder, _, ok := parseLeaseFile(string(data2))
+	if !ok || holder != l.holderID {
+		l.held = false
+		return false, nil
+	}
+	l.held = true
+	return true, nil
+}
+
+func (l *Lease) writeLocked(now time.Time) error {
+	content := fmt.Sprintf("%s\n%d\n", l.holderID, now.UnixNano())
+	tmp := l.path + ".tmp." + strconv.Itoa(os.Getpid())
+	if err := os.WriteFile(tmp, []byte(content), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, l.path)
+}
+
+// Heartbeat refreshes the lease if held. Safe to call periodically.
+func (l *Lease) Heartbeat() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.held {
+		return nil
+	}
+	// Confirm we still own the file.
+	data, err := os.ReadFile(l.path)
+	if err != nil {
+		l.held = false
+		return err
+	}
+	holder, _, ok := parseLeaseFile(string(data))
+	if !ok || holder != l.holderID {
+		l.held = false
+		return nil
+	}
+	return l.writeLocked(l.now())
+}
+
+// Release drops the lease if this process holds it.
+func (l *Lease) Release() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.held {
+		return nil
+	}
+	data, err := os.ReadFile(l.path)
+	if err == nil {
+		holder, _, ok := parseLeaseFile(string(data))
+		if ok && holder == l.holderID {
+			_ = os.Remove(l.path)
+		}
+	}
+	l.held = false
+	l.runningBG = false
+	return nil
+}
+
+// Held reports whether this process currently believes it holds the lease.
+func (l *Lease) Held() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.held
+}
+
+// SetRunningBackground records whether singleton background work is live.
+func (l *Lease) SetRunningBackground(running bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.runningBG = running
+}
+
+// RunningBackground reports the flag set by SetRunningBackground.
+func (l *Lease) RunningBackground() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.runningBG
+}
+
+// Status is a diagnostic view of the lease file + local hold state.
+type Status struct {
+	Path           string
+	HeldLocally    bool
+	RunningBG      bool
+	FileHolder     string
+	FileHeartbeat  time.Time
+	FilePresent    bool
+	Expired        bool
+	LocalHolderID  string
+}
+
+// Status inspects the lease file and local state for mnemo_doctor.
+func (l *Lease) Status() Status {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	st := Status{
+		Path:          l.path,
+		HeldLocally:   l.held,
+		RunningBG:     l.runningBG,
+		LocalHolderID: l.holderID,
+	}
+	data, err := os.ReadFile(l.path)
+	if err != nil {
+		return st
+	}
+	st.FilePresent = true
+	holder, hb, ok := parseLeaseFile(string(data))
+	if !ok {
+		return st
+	}
+	st.FileHolder = holder
+	st.FileHeartbeat = hb
+	st.Expired = l.now().Sub(hb) >= l.ttl
+	return st
+}
+
+// RunHeartbeatLoop refreshes the lease until ctx is done or the lease
+// is released. interval defaults to DefaultHeartbeat.
+func (l *Lease) RunHeartbeatLoop(ctxDone <-chan struct{}, interval time.Duration) {
+	if interval <= 0 {
+		interval = DefaultHeartbeat
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctxDone:
+			return
+		case <-t.C:
+			_ = l.Heartbeat()
+		}
+	}
+}
+
+func parseLeaseFile(s string) (holder string, hb time.Time, ok bool) {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	if len(lines) < 2 {
+		return "", time.Time{}, false
+	}
+	holder = strings.TrimSpace(lines[0])
+	ns, err := strconv.ParseInt(strings.TrimSpace(lines[1]), 10, 64)
+	if err != nil || holder == "" {
+		return "", time.Time{}, false
+	}
+	return holder, time.Unix(0, ns), true
+}

--- a/internal/upgrade/lease.go
+++ b/internal/upgrade/lease.go
@@ -208,14 +208,14 @@ func (l *Lease) RunningBackground() bool {
 
 // Status is a diagnostic view of the lease file + local hold state.
 type Status struct {
-	Path           string
-	HeldLocally    bool
-	RunningBG      bool
-	FileHolder     string
-	FileHeartbeat  time.Time
-	FilePresent    bool
-	Expired        bool
-	LocalHolderID  string
+	Path          string
+	HeldLocally   bool
+	RunningBG     bool
+	FileHolder    string
+	FileHeartbeat time.Time
+	FilePresent   bool
+	Expired       bool
+	LocalHolderID string
 }
 
 // Status inspects the lease file and local state for mnemo_doctor.

--- a/internal/upgrade/lease_test.go
+++ b/internal/upgrade/lease_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLeaseExclusiveHoldAndHandoff(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "background.lease")
+
+	var clock time.Time
+	now := func() time.Time { return clock }
+	clock = time.Unix(1_700_000_000, 0)
+
+	a, err := NewLease(&LeaseArgs{Path: path, HolderID: "a", TTL: time.Second, Now: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := NewLease(&LeaseArgs{Path: path, HolderID: "b", TTL: time.Second, Now: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ok, err := a.TryAcquire()
+	if err != nil || !ok {
+		t.Fatalf("a acquire: ok=%v err=%v", ok, err)
+	}
+	a.SetRunningBackground(true)
+	if !a.Held() || !a.RunningBackground() {
+		t.Fatal("a should hold and run bg")
+	}
+
+	ok, err = b.TryAcquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || b.Held() {
+		t.Fatal("b must not acquire while a holds live lease")
+	}
+	if b.RunningBackground() {
+		t.Fatal("b must not run background")
+	}
+
+	// Crash a: stop heartbeats and advance clock past TTL.
+	a.SetRunningBackground(false)
+	// Simulate crash without clean Release — just forget hold in memory
+	// but leave stale file; advance clock.
+	clock = clock.Add(2 * time.Second)
+
+	ok, err = b.TryAcquire()
+	if err != nil || !ok {
+		t.Fatalf("b steal after expiry: ok=%v err=%v", ok, err)
+	}
+	if !b.Held() {
+		t.Fatal("b should hold")
+	}
+	// a still thinks it holds until heartbeat fails
+	_ = a.Heartbeat() // should notice lost ownership if file rewritten
+	// After b wrote, a's heartbeat sees different holder.
+	if a.Held() {
+		// Heartbeat should have cleared held when holder mismatch
+		t.Fatal("a should no longer hold after b stole")
+	}
+
+	// Clean handoff: b releases, a reacquires quickly.
+	if err := b.Release(); err != nil {
+		t.Fatal(err)
+	}
+	clock = clock.Add(10 * time.Millisecond)
+	ok, err = a.TryAcquire()
+	if err != nil || !ok {
+		t.Fatalf("a reacquire: ok=%v err=%v", ok, err)
+	}
+	st := a.Status()
+	if !st.HeldLocally || st.FileHolder != "a" {
+		t.Fatalf("status: %+v", st)
+	}
+}
+
+func TestLeaseReleaseAllowsOther(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "l")
+	clock := time.Unix(1_000, 0)
+	now := func() time.Time { return clock }
+	a, _ := NewLease(&LeaseArgs{Path: path, HolderID: "a", TTL: time.Second, Now: now})
+	b, _ := NewLease(&LeaseArgs{Path: path, HolderID: "b", TTL: time.Second, Now: now})
+	if ok, _ := a.TryAcquire(); !ok {
+		t.Fatal("a")
+	}
+	_ = a.Release()
+	if ok, _ := b.TryAcquire(); !ok {
+		t.Fatal("b after release")
+	}
+	if a.Held() {
+		t.Fatal("a released")
+	}
+}

--- a/internal/upgrade/notice.go
+++ b/internal/upgrade/notice.go
@@ -11,7 +11,7 @@ import (
 // NoticeTracker records per-session upgrade banners so each session
 // sees `mnemo upgraded vN -> vN+1` at most once (🎯T97.6).
 type NoticeTracker struct {
-	mu    sync.Mutex
+	mu      sync.Mutex
 	pending map[string]string // sessionID -> message
 	shown   map[string]string // sessionID -> last delivered message (dedupe)
 }

--- a/internal/upgrade/notice.go
+++ b/internal/upgrade/notice.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import (
+	"fmt"
+	"sync"
+)
+
+// NoticeTracker records per-session upgrade banners so each session
+// sees `mnemo upgraded vN -> vN+1` at most once (🎯T97.6).
+type NoticeTracker struct {
+	mu    sync.Mutex
+	pending map[string]string // sessionID -> message
+	shown   map[string]string // sessionID -> last delivered message (dedupe)
+}
+
+// NewNoticeTracker builds an empty tracker.
+func NewNoticeTracker() *NoticeTracker {
+	return &NoticeTracker{
+		pending: map[string]string{},
+		shown:   map[string]string{},
+	}
+}
+
+// FormatNotice builds the canonical upgrade banner text.
+func FormatNotice(from, to string) string {
+	return fmt.Sprintf("mnemo upgraded %s -> %s", formatV(from), formatV(to))
+}
+
+// MarkSession queues a one-time notice for sessionID.
+func (t *NoticeTracker) MarkSession(sessionID, from, to string) {
+	if sessionID == "" || from == "" || to == "" {
+		return
+	}
+	msg := FormatNotice(from, to)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.shown[sessionID] == msg {
+		return // already delivered this upgrade
+	}
+	t.pending[sessionID] = msg
+}
+
+// MarkSessions queues the same notice for many sessions.
+func (t *NoticeTracker) MarkSessions(sessionIDs []string, from, to string) {
+	for _, id := range sessionIDs {
+		t.MarkSession(id, from, to)
+	}
+}
+
+// Consume returns the pending notice for sessionID and clears it.
+// ok is false when there is nothing to show.
+func (t *NoticeTracker) Consume(sessionID string) (msg string, ok bool) {
+	if sessionID == "" {
+		return "", false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	msg, ok = t.pending[sessionID]
+	if !ok {
+		return "", false
+	}
+	delete(t.pending, sessionID)
+	t.shown[sessionID] = msg
+	return msg, true
+}
+
+// PendingCount is for tests/diagnostics.
+func (t *NoticeTracker) PendingCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.pending)
+}

--- a/internal/upgrade/notice_test.go
+++ b/internal/upgrade/notice_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import "testing"
+
+func TestNoticeOncePerSession(t *testing.T) {
+	t.Parallel()
+	tr := NewNoticeTracker()
+	tr.MarkSession("s1", "0.61.0", "0.62.0")
+	tr.MarkSession("s1", "0.61.0", "0.62.0") // duplicate mark
+	msg, ok := tr.Consume("s1")
+	if !ok {
+		t.Fatal("expected notice")
+	}
+	want := "mnemo upgraded v0.61.0 -> v0.62.0"
+	if msg != want {
+		t.Fatalf("got %q want %q", msg, want)
+	}
+	if _, ok := tr.Consume("s1"); ok {
+		t.Fatal("second consume must be empty")
+	}
+	// Re-mark same upgrade after shown → suppressed
+	tr.MarkSession("s1", "0.61.0", "0.62.0")
+	if tr.PendingCount() != 0 {
+		t.Fatal("should not re-queue already shown upgrade")
+	}
+	// Newer upgrade can notify again
+	tr.MarkSession("s1", "0.62.0", "0.63.0")
+	msg, ok = tr.Consume("s1")
+	if !ok || msg != "mnemo upgraded v0.62.0 -> v0.63.0" {
+		t.Fatalf("got %q ok=%v", msg, ok)
+	}
+}
+
+func TestNoticeMarkSessions(t *testing.T) {
+	t.Parallel()
+	tr := NewNoticeTracker()
+	tr.MarkSessions([]string{"a", "b", ""}, "1.0.0", "1.1.0")
+	if tr.PendingCount() != 2 {
+		t.Fatalf("pending %d", tr.PendingCount())
+	}
+}

--- a/internal/upgrade/notify.go
+++ b/internal/upgrade/notify.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import "sync"
+
+// ToolsListChangedMethod is the MCP notification method for tool-list
+// updates (MCP spec notifications/tools/list_changed). Kept as a string
+// constant so this package does not import mcp-go.
+const ToolsListChangedMethod = "notifications/tools/list_changed"
+
+// ListChangedFunc is best-effort tools/list_changed after a version
+// change (🎯T97.6 / plan criterion 4). Nil is a no-op.
+type ListChangedFunc func(from, to string)
+
+// NotificationBroadcaster is the mcp-go MCPServer surface we need for
+// list_changed. Implemented by *server.MCPServer.
+type NotificationBroadcaster interface {
+	SendNotificationToAllClients(method string, params map[string]any)
+}
+
+// BroadcastListChanged sends tools/list_changed to all connected MCP
+// clients. Safe if b is nil (no-op). Best-effort: callers ignore errors
+// from the transport layer (SendNotificationToAllClients is void).
+func BroadcastListChanged(b NotificationBroadcaster, from, to string) {
+	if b == nil {
+		return
+	}
+	b.SendNotificationToAllClients(ToolsListChangedMethod, map[string]any{
+		"reason": "mnemo_upgrade",
+		"from":   from,
+		"to":     to,
+	})
+}
+
+// SideEffects bundles per-upgrade session banners and list_changed.
+// Used by auto-apply OnUpgrade and by the new process after loading
+// upgrade-pending so both notice injection and list_changed fire on
+// the real path.
+type SideEffects struct {
+	Notices     *NoticeTracker
+	ListChanged ListChangedFunc
+}
+
+// OnVersionChange marks allowlisted sessions for one-time banners and
+// best-effort notifies clients that tools may have changed.
+func (s *SideEffects) OnVersionChange(sessions []string, from, to string) {
+	if s == nil {
+		return
+	}
+	if s.Notices != nil {
+		s.Notices.MarkSessions(sessions, from, to)
+	}
+	if s.ListChanged != nil {
+		s.ListChanged(from, to)
+	}
+}
+
+// ListChangedHolder lets main register the MCP server's notification
+// sender after construction (orchestrator is wired before the MCP
+// server exists). Concurrent Set/Send is safe.
+type ListChangedHolder struct {
+	mu   sync.Mutex
+	send ListChangedFunc
+}
+
+// Set installs the list_changed sender (may be nil to clear).
+func (h *ListChangedHolder) Set(fn ListChangedFunc) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	h.send = fn
+	h.mu.Unlock()
+}
+
+// Send invokes the registered sender if any. Never panics on nil.
+func (h *ListChangedHolder) Send(from, to string) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	fn := h.send
+	h.mu.Unlock()
+	if fn != nil {
+		fn(from, to)
+	}
+}

--- a/internal/upgrade/notify_test.go
+++ b/internal/upgrade/notify_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+func TestSideEffectsOnVersionChangeCallsListChanged(t *testing.T) {
+	t.Parallel()
+	tr := NewNoticeTracker()
+	var calls atomic.Int32
+	var gotFrom, gotTo string
+	fx := &SideEffects{
+		Notices: tr,
+		ListChanged: func(from, to string) {
+			calls.Add(1)
+			gotFrom, gotTo = from, to
+		},
+	}
+	fx.OnVersionChange([]string{"s1", "s2"}, "0.61.0", "0.62.0")
+	if calls.Load() != 1 {
+		t.Fatalf("list_changed calls %d", calls.Load())
+	}
+	if gotFrom != "0.61.0" || gotTo != "0.62.0" {
+		t.Fatalf("from=%q to=%q", gotFrom, gotTo)
+	}
+	if msg, ok := tr.Consume("s1"); !ok || msg == "" {
+		t.Fatal("expected notice for s1")
+	}
+}
+
+func TestSideEffectsNilListChangedIsNoOp(t *testing.T) {
+	t.Parallel()
+	fx := &SideEffects{Notices: NewNoticeTracker()}
+	fx.OnVersionChange([]string{"s"}, "1", "2") // must not panic
+	if _, ok := fx.Notices.Consume("s"); !ok {
+		t.Fatal("notice still applied")
+	}
+}
+
+func TestListChangedHolderSetAndSend(t *testing.T) {
+	t.Parallel()
+	var h ListChangedHolder
+	h.Send("a", "b") // no sender yet
+	var n atomic.Int32
+	h.Set(func(from, to string) {
+		if from != "0.1.0" || to != "0.2.0" {
+			t.Errorf("from=%q to=%q", from, to)
+		}
+		n.Add(1)
+	})
+	h.Send("0.1.0", "0.2.0")
+	if n.Load() != 1 {
+		t.Fatalf("n=%d", n.Load())
+	}
+	h.Set(nil)
+	h.Send("x", "y") // cleared
+	if n.Load() != 1 {
+		t.Fatalf("after clear n=%d", n.Load())
+	}
+}
+
+// fakeBroadcaster records SendNotificationToAllClients calls so we
+// exercise BroadcastListChanged on the real method constant.
+type fakeBroadcaster struct {
+	method string
+	params map[string]any
+	calls  int
+}
+
+func (f *fakeBroadcaster) SendNotificationToAllClients(method string, params map[string]any) {
+	f.calls++
+	f.method = method
+	f.params = params
+}
+
+func TestBroadcastListChangedUsesMCPMethod(t *testing.T) {
+	t.Parallel()
+	BroadcastListChanged(nil, "a", "b") // no-op
+	var fb fakeBroadcaster
+	BroadcastListChanged(&fb, "0.61.0", "0.62.0")
+	if fb.calls != 1 {
+		t.Fatalf("calls %d", fb.calls)
+	}
+	if fb.method != ToolsListChangedMethod {
+		t.Fatalf("method %q want %q", fb.method, ToolsListChangedMethod)
+	}
+	if ToolsListChangedMethod != "notifications/tools/list_changed" {
+		t.Fatalf("constant drift: %q", ToolsListChangedMethod)
+	}
+	if fb.params["reason"] != "mnemo_upgrade" {
+		t.Fatalf("params %+v", fb.params)
+	}
+	if fb.params["from"] != "0.61.0" || fb.params["to"] != "0.62.0" {
+		t.Fatalf("params %+v", fb.params)
+	}
+}
+
+func TestSideEffectsWiresBroadcastListChanged(t *testing.T) {
+	t.Parallel()
+	var fb fakeBroadcaster
+	fx := &SideEffects{
+		Notices: NewNoticeTracker(),
+		ListChanged: func(from, to string) {
+			BroadcastListChanged(&fb, from, to)
+		},
+	}
+	fx.OnVersionChange([]string{"s"}, "1.0.0", "1.1.0")
+	if fb.method != ToolsListChangedMethod {
+		t.Fatalf("method %q", fb.method)
+	}
+}

--- a/internal/upgrade/pending.go
+++ b/internal/upgrade/pending.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// PendingNoticeFile is the basename under ~/.mnemo/ for a one-shot
+// upgrade banner payload (🎯T97.6). The new process loads it once,
+// queues notices only for listed sessions, and deletes the file.
+const PendingNoticeFile = "upgrade-pending"
+
+// PendingNotice is the on-disk form written before a backend swap/restart.
+type PendingNotice struct {
+	From     string
+	To       string
+	Sessions []string // only these session IDs get a banner
+}
+
+// PendingPath returns ~/.mnemo/upgrade-pending under home.
+func PendingPath(home string) string {
+	return filepath.Join(home, ".mnemo", PendingNoticeFile)
+}
+
+// WritePendingNotice atomically writes the pending notice file.
+func WritePendingNotice(home string, p PendingNotice) error {
+	if home == "" {
+		return fmt.Errorf("upgrade: empty home")
+	}
+	dir := filepath.Join(home, ".mnemo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	var b strings.Builder
+	b.WriteString(strings.TrimSpace(p.From))
+	b.WriteByte('\n')
+	b.WriteString(strings.TrimSpace(p.To))
+	b.WriteByte('\n')
+	seen := map[string]struct{}{}
+	for _, s := range p.Sessions {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		b.WriteString(s)
+		b.WriteByte('\n')
+	}
+	path := PendingPath(home)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(b.String()), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// LoadAndConsumePending reads the pending notice file, queues banners
+// for the listed sessions only, and deletes the file. Safe if missing.
+func LoadAndConsumePending(home string, tr *NoticeTracker) (PendingNotice, bool, error) {
+	if home == "" || tr == nil {
+		return PendingNotice{}, false, nil
+	}
+	path := PendingPath(home)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return PendingNotice{}, false, nil
+		}
+		return PendingNotice{}, false, err
+	}
+	// Delete first so a crash mid-queue does not re-banner forever.
+	_ = os.Remove(path)
+
+	lines := strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n")
+	// trim trailing empties
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) < 2 {
+		return PendingNotice{}, false, fmt.Errorf("upgrade: malformed pending notice")
+	}
+	p := PendingNotice{
+		From: strings.TrimSpace(lines[0]),
+		To:   strings.TrimSpace(lines[1]),
+	}
+	for _, line := range lines[2:] {
+		if s := strings.TrimSpace(line); s != "" {
+			p.Sessions = append(p.Sessions, s)
+		}
+	}
+	tr.MarkSessions(p.Sessions, p.From, p.To)
+	return p, true, nil
+}
+
+// SessionSet tracks MCP session IDs seen by this process (for T97.6
+// allowlists at upgrade time).
+type SessionSet struct {
+	mu  sync.Mutex
+	ids map[string]struct{}
+}
+
+// NewSessionSet builds an empty set.
+func NewSessionSet() *SessionSet {
+	return &SessionSet{ids: map[string]struct{}{}}
+}
+
+// Add records a session ID.
+func (s *SessionSet) Add(id string) {
+	if s == nil || id == "" {
+		return
+	}
+	s.mu.Lock()
+	s.ids[id] = struct{}{}
+	s.mu.Unlock()
+}
+
+// Snapshot returns a stable copy of known session IDs.
+func (s *SessionSet) Snapshot() []string {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, 0, len(s.ids))
+	for id := range s.ids {
+		out = append(out, id)
+	}
+	return out
+}

--- a/internal/upgrade/pending_test.go
+++ b/internal/upgrade/pending_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteLoadConsumePendingAllowlist(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	tr := NewNoticeTracker()
+	if err := WritePendingNotice(home, PendingNotice{
+		From:     "0.61.0",
+		To:       "0.62.0",
+		Sessions: []string{"s-old", "s-old", "s-other"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	path := PendingPath(home)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatal("pending file missing")
+	}
+	p, ok, err := LoadAndConsumePending(home, tr)
+	if err != nil || !ok {
+		t.Fatalf("load: ok=%v err=%v", ok, err)
+	}
+	if p.From != "0.61.0" || p.To != "0.62.0" || len(p.Sessions) != 2 {
+		t.Fatalf("pending %+v", p)
+	}
+	// File deleted after load.
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("pending file should be deleted")
+	}
+	// Only allowlisted sessions have notices.
+	if msg, ok := tr.Consume("s-old"); !ok || msg == "" {
+		t.Fatal("s-old should have notice")
+	}
+	if _, ok := tr.Consume("s-new"); ok {
+		t.Fatal("s-new must not have notice")
+	}
+	// Second load is a no-op.
+	_, ok, err = LoadAndConsumePending(home, tr)
+	if err != nil || ok {
+		t.Fatalf("second load ok=%v err=%v", ok, err)
+	}
+}
+
+func TestSessionSetSnapshot(t *testing.T) {
+	t.Parallel()
+	s := NewSessionSet()
+	s.Add("a")
+	s.Add("")
+	s.Add("b")
+	s.Add("a")
+	got := s.Snapshot()
+	if len(got) != 2 {
+		t.Fatalf("snapshot %v", got)
+	}
+}
+
+func TestRouteAppendAndRead(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	if RouteConfigured(home) {
+		t.Fatal("expected no route")
+	}
+	r, err := AppendBackend(home, "http://127.0.0.1:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !RouteConfigured(home) || r.Primary != 0 {
+		t.Fatalf("%+v", r)
+	}
+	r, err = AppendBackend(home, "http://127.0.0.1:2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Primary != 1 || len(r.Backends) != 2 {
+		t.Fatalf("%+v", r)
+	}
+	// file on disk
+	if _, err := os.Stat(filepath.Join(home, ".mnemo", RouteFileName)); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/upgrade/route.go
+++ b/internal/upgrade/route.go
@@ -79,17 +79,25 @@ func ReadRoute(home string) (RouteFile, error) {
 	return r, nil
 }
 
-// WriteRoute atomically persists the route file.
+// WriteRoute atomically persists the route file under home.
 func WriteRoute(home string, r RouteFile) error {
 	if err := os.MkdirAll(filepath.Join(home, ".mnemo"), 0o755); err != nil {
+		return err
+	}
+	return WriteRouteFile(RoutePath(home), r)
+}
+
+// WriteRouteFile atomically writes r to path (tmp + rename) so concurrent
+// readers never see a partial JSON document.
+func WriteRouteFile(path string, r RouteFile) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
 	data, err := json.MarshalIndent(r, "", "  ")
 	if err != nil {
 		return err
 	}
-	path := RoutePath(home)
-	tmp := path + ".tmp"
+	tmp := path + ".tmp." + fmt.Sprintf("%d", os.Getpid())
 	if err := os.WriteFile(tmp, append(data, '\n'), 0o600); err != nil {
 		return err
 	}

--- a/internal/upgrade/route.go
+++ b/internal/upgrade/route.go
@@ -19,10 +19,31 @@ const RouteFileName = "edge-route.json"
 type RouteFile struct {
 	Backends []string `json:"backends"`
 	Primary  int      `json:"primary"`
-	// RepinAll when true tells the edge to move every session pin onto
-	// primary before the old backend is reaped (connection-preserving
-	// handoff). Cleared by the edge after applying.
+	// PinCounts is written by the edge (length == len(Backends)) so a
+	// draining backend can AffinityDrain until its index is zero.
+	// Backends must not treat this as an input control plane field.
+	PinCounts []int `json:"pin_counts,omitempty"`
+	// RepinAll is crash-failover only (FailoverRepin). Happy-path
+	// upgrade drain must leave pins on the old backend.
 	RepinAll bool `json:"repin_all,omitempty"`
+}
+
+// PinCountAt returns PinCounts[i] or 0 if missing.
+func (r RouteFile) PinCountAt(i int) int {
+	if i < 0 || i >= len(r.PinCounts) {
+		return 0
+	}
+	return r.PinCounts[i]
+}
+
+// IndexOfBackend returns the index of backendURL or -1.
+func (r RouteFile) IndexOfBackend(backendURL string) int {
+	for i, b := range r.Backends {
+		if b == backendURL {
+			return i
+		}
+	}
+	return -1
 }
 
 // RoutePath returns ~/.mnemo/edge-route.json.

--- a/internal/upgrade/route.go
+++ b/internal/upgrade/route.go
@@ -19,6 +19,10 @@ const RouteFileName = "edge-route.json"
 type RouteFile struct {
 	Backends []string `json:"backends"`
 	Primary  int      `json:"primary"`
+	// RepinAll when true tells the edge to move every session pin onto
+	// primary before the old backend is reaped (connection-preserving
+	// handoff). Cleared by the edge after applying.
+	RepinAll bool `json:"repin_all,omitempty"`
 }
 
 // RoutePath returns ~/.mnemo/edge-route.json.

--- a/internal/upgrade/route.go
+++ b/internal/upgrade/route.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// RouteFileName is the edge dynamic routing control file under ~/.mnemo/.
+const RouteFileName = "edge-route.json"
+
+// RouteFile is the JSON shape edge polls for backend list + primary
+// (🎯T97.5 multi-process handoff).
+type RouteFile struct {
+	Backends []string `json:"backends"`
+	Primary  int      `json:"primary"`
+}
+
+// RoutePath returns ~/.mnemo/edge-route.json.
+func RoutePath(home string) string {
+	return filepath.Join(home, ".mnemo", RouteFileName)
+}
+
+// RouteConfigured reports whether an edge route file exists.
+func RouteConfigured(home string) bool {
+	if home == "" {
+		return false
+	}
+	_, err := os.Stat(RoutePath(home))
+	return err == nil
+}
+
+// ReadRoute loads the route file.
+func ReadRoute(home string) (RouteFile, error) {
+	data, err := os.ReadFile(RoutePath(home))
+	if err != nil {
+		return RouteFile{}, err
+	}
+	var r RouteFile
+	if err := json.Unmarshal(data, &r); err != nil {
+		return RouteFile{}, err
+	}
+	if len(r.Backends) == 0 {
+		return RouteFile{}, fmt.Errorf("upgrade: edge-route has no backends")
+	}
+	if r.Primary < 0 || r.Primary >= len(r.Backends) {
+		return RouteFile{}, fmt.Errorf("upgrade: edge-route primary %d out of range", r.Primary)
+	}
+	return r, nil
+}
+
+// WriteRoute atomically persists the route file.
+func WriteRoute(home string, r RouteFile) error {
+	if err := os.MkdirAll(filepath.Join(home, ".mnemo"), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := RoutePath(home)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, append(data, '\n'), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// AppendBackend adds a backend URL and sets it as primary.
+func AppendBackend(home, backendURL string) (RouteFile, error) {
+	r, err := ReadRoute(home)
+	if err != nil {
+		// First write: single backend as primary.
+		r = RouteFile{Backends: []string{backendURL}, Primary: 0}
+		if err := WriteRoute(home, r); err != nil {
+			return RouteFile{}, err
+		}
+		return r, nil
+	}
+	for i, b := range r.Backends {
+		if b == backendURL {
+			r.Primary = i
+			return r, WriteRoute(home, r)
+		}
+	}
+	r.Backends = append(r.Backends, backendURL)
+	r.Primary = len(r.Backends) - 1
+	if err := WriteRoute(home, r); err != nil {
+		return RouteFile{}, err
+	}
+	return r, nil
+}
+
+// RouteWatcher is a testable holder for the last loaded route.
+type RouteWatcher struct {
+	mu   sync.Mutex
+	last RouteFile
+	ok   bool
+}
+
+// Load reads home's route file into the watcher.
+func (w *RouteWatcher) Load(home string) (RouteFile, error) {
+	r, err := ReadRoute(home)
+	if err != nil {
+		return RouteFile{}, err
+	}
+	w.mu.Lock()
+	w.last = r
+	w.ok = true
+	w.mu.Unlock()
+	return r, nil
+}

--- a/internal/upgrade/version.go
+++ b/internal/upgrade/version.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+// Package upgrade implements connection-preserving self-upgrade pieces
+// for mnemo (🎯T97): release detection, single-holder background lease,
+// opt-in auto-apply orchestration, and one-time upgrade notices.
+package upgrade
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// NormalizeTag strips a leading "v" and surrounding whitespace so
+// "v0.61.0" and "0.61.0" compare equal as base versions.
+func NormalizeTag(tag string) string {
+	t := strings.TrimSpace(tag)
+	t = strings.TrimPrefix(t, "v")
+	t = strings.TrimPrefix(t, "V")
+	return t
+}
+
+// ParseSemver parses a dotted major.minor.patch version (extra
+// pre-release suffix after '-' is ignored for ordering).
+func ParseSemver(tag string) (major, minor, patch int, err error) {
+	t := NormalizeTag(tag)
+	if t == "" {
+		return 0, 0, 0, fmt.Errorf("empty version")
+	}
+	if i := strings.IndexAny(t, "-+"); i >= 0 {
+		t = t[:i]
+	}
+	parts := strings.Split(t, ".")
+	if len(parts) < 1 || len(parts) > 3 {
+		return 0, 0, 0, fmt.Errorf("invalid version %q", tag)
+	}
+	nums := make([]int, 3)
+	for i, p := range parts {
+		n, e := strconv.Atoi(p)
+		if e != nil || n < 0 {
+			return 0, 0, 0, fmt.Errorf("invalid version component %q in %q", p, tag)
+		}
+		nums[i] = n
+	}
+	return nums[0], nums[1], nums[2], nil
+}
+
+// Compare returns -1 if a < b, 0 if a == b, 1 if a > b (semver-ish).
+func Compare(a, b string) (int, error) {
+	am, an, ap, err := ParseSemver(a)
+	if err != nil {
+		return 0, fmt.Errorf("current: %w", err)
+	}
+	bm, bn, bp, err := ParseSemver(b)
+	if err != nil {
+		return 0, fmt.Errorf("latest: %w", err)
+	}
+	if am != bm {
+		if am < bm {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	if an != bn {
+		if an < bn {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	if ap != bp {
+		if ap < bp {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	return 0, nil
+}
+
+// IsNewer reports whether latest is strictly newer than current.
+func IsNewer(current, latest string) (bool, error) {
+	c, err := Compare(current, latest)
+	if err != nil {
+		return false, err
+	}
+	return c < 0, nil
+}

--- a/internal/upgrade/version_test.go
+++ b/internal/upgrade/version_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import "testing"
+
+func TestIsNewer(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		cur, lat string
+		want     bool
+	}{
+		{"0.61.0", "v0.62.0", true},
+		{"v0.62.0", "0.61.0", false},
+		{"0.61.0", "0.61.0", false},
+		{"v0.61.0", "v0.61.1", true},
+		{"1.0.0", "0.99.0", false},
+	}
+	for _, tc := range cases {
+		got, err := IsNewer(tc.cur, tc.lat)
+		if err != nil {
+			t.Fatalf("IsNewer(%q,%q): %v", tc.cur, tc.lat, err)
+		}
+		if got != tc.want {
+			t.Errorf("IsNewer(%q,%q)=%v want %v", tc.cur, tc.lat, got, tc.want)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -611,11 +611,12 @@ func watchEdgeRoute(ctx context.Context, path string, router *edgeproxy.Router, 
 				lastControl = controlKey
 			}
 			// Always refresh pin_counts for AffinityDrain observers.
+			// Atomic write so concurrent ReadRoute never sees partial JSON.
 			rf.PinCounts = router.PinCounts()
 			rf.Backends = router.BackendURLs()
 			rf.Primary = router.PrimaryIndex()
-			if b, mErr := json.MarshalIndent(rf, "", "  "); mErr == nil {
-				_ = os.WriteFile(path, append(b, '\n'), 0o600)
+			if err := upgrade.WriteRouteFile(path, rf); err != nil {
+				slog.Warn("edge: write pin_counts", "err", err)
 			}
 		}
 	}
@@ -885,7 +886,9 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 				Pins: func(idx int) int {
 					rf, err := upgrade.ReadRoute(homeForLease)
 					if err != nil {
-						return 0
+						// Never treat I/O/parse failure as zero pins —
+						// that would SIGTERM with live sessions.
+						return upgrade.PinUnknown
 					}
 					return rf.PinCountAt(idx)
 				},

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@
 //	mnemo print-endpoint        # print this host's mTLS public cert (for federated peer trust)
 //	mnemo print-federated-addr  # print the URL peers paste into linked_instances
 //	mnemo ping-peer <name>      # call mnemo_stats on a configured peer (smoke-test federation)
+//	mnemo edge                  # transparent MCP edge proxy (🎯T97.3)
 //	claude mcp add --scope user --transport http mnemo "http://localhost:19419/mcp?user=<name>"
 package main
 
@@ -44,6 +45,7 @@ import (
 	"github.com/marcelocantos/mnemo/internal/api"
 	"github.com/marcelocantos/mnemo/internal/compact"
 	"github.com/marcelocantos/mnemo/internal/diag"
+	"github.com/marcelocantos/mnemo/internal/edgeproxy"
 	"github.com/marcelocantos/mnemo/internal/endpoint"
 	"github.com/marcelocantos/mnemo/internal/federation"
 	"github.com/marcelocantos/mnemo/internal/mcpconfig"
@@ -136,6 +138,9 @@ func main() {
 			return
 		case "thread":
 			cmdThread(os.Args[2:])
+			return
+		case "edge":
+			cmdEdge(os.Args[2:])
 			return
 		}
 	}
@@ -452,6 +457,81 @@ func cmdUninstallService(args []string) {
 	if err := uninstallService(args); err != nil {
 		fmt.Fprintf(os.Stderr, "uninstall-service: %v\n", err)
 		os.Exit(1)
+	}
+}
+
+// stringList is a repeatable flag.Value for multi --backend flags.
+type stringList []string
+
+func (s *stringList) String() string { return strings.Join(*s, ",") }
+
+func (s *stringList) Set(v string) error {
+	*s = append(*s, v)
+	return nil
+}
+
+// cmdEdge runs the transparent MCP edge proxy (🎯T97.3). The edge owns
+// the public listener and all client connections; backends serve on
+// loopback HTTP or a Unix domain socket. Session affinity is by
+// Mcp-Session-Id — standard MCP-over-HTTP, no custom protocol.
+func cmdEdge(args []string) {
+	fs := flag.NewFlagSet("edge", flag.ExitOnError)
+	listen := fs.String("listen", defaultAddr,
+		"public listen address (edge owns client TCP connections)")
+	primary := fs.Int("primary", 0,
+		"index of the backend that receives new initialize requests")
+	var backends stringList
+	fs.Var(&backends, "backend",
+		"backend base URL (repeatable). http://host:port or unix:///path")
+	_ = fs.Parse(args)
+
+	if len(backends) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: mnemo edge --backend URL [--backend URL ...] [--listen :19419] [--primary 0]")
+		fmt.Fprintln(os.Stderr, "edge: at least one --backend is required")
+		os.Exit(2)
+	}
+
+	router, err := edgeproxy.NewRouter(backends, *primary)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "edge: %v\n", err)
+		os.Exit(1)
+	}
+	proxy := edgeproxy.NewProxy(router)
+
+	srv := &http.Server{
+		Addr:              *listen,
+		Handler:           proxy,
+		ReadHeaderTimeout: 10 * time.Second,
+		// No Read/WriteTimeout — GET/SSE streams are long-lived.
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	errCh := make(chan error, 1)
+	go func() {
+		slog.Info("edge listening",
+			"listen", *listen,
+			"backends", len(backends),
+			"primary", *primary,
+			"version", version,
+		)
+		errCh <- srv.ListenAndServe()
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			fmt.Fprintf(os.Stderr, "edge: shutdown: %v\n", err)
+			os.Exit(1)
+		}
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			fmt.Fprintf(os.Stderr, "edge: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ package main
 import (
 	"context"
 	_ "embed"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -35,6 +36,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -476,19 +478,47 @@ func (s *stringList) Set(v string) error {
 // the public listener and all client connections; backends serve on
 // loopback HTTP or a Unix domain socket. Session affinity is by
 // Mcp-Session-Id — standard MCP-over-HTTP, no custom protocol.
+//
+// When --route-file is set (or defaults to ~/.mnemo/edge-route.json and
+// that file exists), the edge reloads primary index from the file so
+// auto-apply can flip backends without restarting the edge (🎯T97.5).
 func cmdEdge(args []string) {
 	fs := flag.NewFlagSet("edge", flag.ExitOnError)
 	listen := fs.String("listen", defaultAddr,
 		"public listen address (edge owns client TCP connections)")
 	primary := fs.Int("primary", 0,
 		"index of the backend that receives new initialize requests")
+	routeFile := fs.String("route-file", "",
+		"optional edge-route.json path (default: ~/.mnemo/edge-route.json when present)")
 	var backends stringList
 	fs.Var(&backends, "backend",
 		"backend base URL (repeatable). http://host:port or unix:///path")
 	_ = fs.Parse(args)
 
+	// Prefer explicit --backend flags; else load route file.
+	routePath := *routeFile
+	if routePath == "" {
+		if home, err := store.EffectiveHome(); err == nil && upgrade.RouteConfigured(home) {
+			routePath = upgrade.RoutePath(home)
+		}
+	}
+	if len(backends) == 0 && routePath != "" {
+		data, err := os.ReadFile(routePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "edge: read route file: %v\n", err)
+			os.Exit(1)
+		}
+		var rf upgrade.RouteFile
+		if err := json.Unmarshal(data, &rf); err != nil {
+			fmt.Fprintf(os.Stderr, "edge: parse route file: %v\n", err)
+			os.Exit(1)
+		}
+		backends = rf.Backends
+		*primary = rf.Primary
+	}
 	if len(backends) == 0 {
 		fmt.Fprintln(os.Stderr, "usage: mnemo edge --backend URL [--backend URL ...] [--listen :19419] [--primary 0]")
+		fmt.Fprintln(os.Stderr, "   or: mnemo edge --route-file ~/.mnemo/edge-route.json")
 		fmt.Fprintln(os.Stderr, "edge: at least one --backend is required")
 		os.Exit(2)
 	}
@@ -510,12 +540,18 @@ func cmdEdge(args []string) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	// Poll route file for primary flips (and appended backends).
+	if routePath != "" {
+		go watchEdgeRoute(ctx, routePath, router)
+	}
+
 	errCh := make(chan error, 1)
 	go func() {
 		slog.Info("edge listening",
 			"listen", *listen,
 			"backends", len(backends),
 			"primary", *primary,
+			"route_file", routePath,
 			"version", version,
 		)
 		errCh <- srv.ListenAndServe()
@@ -533,6 +569,48 @@ func cmdEdge(args []string) {
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			fmt.Fprintf(os.Stderr, "edge: %v\n", err)
 			os.Exit(1)
+		}
+	}
+}
+
+// watchEdgeRoute reloads primary (and rebuilds router backends when the
+// list grows) from edge-route.json so auto-apply can flip without
+// restarting the edge process.
+func watchEdgeRoute(ctx context.Context, path string, router *edgeproxy.Router) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	var lastPrimary = router.PrimaryIndex()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			data, err := os.ReadFile(path)
+			if err != nil {
+				continue
+			}
+			var rf upgrade.RouteFile
+			if err := json.Unmarshal(data, &rf); err != nil {
+				continue
+			}
+			if rf.Primary != lastPrimary {
+				if err := router.SetPrimary(rf.Primary); err != nil {
+					slog.Warn("edge: set primary from route file", "err", err)
+					continue
+				}
+				slog.Info("edge: primary flipped from route file", "primary", rf.Primary)
+				lastPrimary = rf.Primary
+			}
+			// Note: adding backends requires router rebuild; AppendBackend
+			// always sets primary to the new index — SetPrimary works when
+			// the backend was already listed on the CLI. For newly appended
+			// URLs beyond initial BackendCount, log a warning (edge restart
+			// or initial multi --backend list still covers the swap case
+			// when both ports are predeclared).
+			if rf.Primary >= router.BackendCount() {
+				slog.Warn("edge: route primary exceeds configured backends; restart edge with updated --backend list",
+					"primary", rf.Primary, "configured", router.BackendCount())
+			}
 		}
 	}
 }
@@ -656,10 +734,18 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	// Lease is acquired before eager ForUser so startWorkers can gate
 	// singleton background work on holder status.
 	upgradeNotices := upgrade.NewNoticeTracker()
+	activeSessions := upgrade.NewSessionSet()
 	var lastMCPActivity atomicTime
 	lastMCPActivity.Set(time.Now())
 
 	homeForLease, homeErr := store.EffectiveHome()
+	if homeErr == nil {
+		// Load once: allowlisted sessions only; file is deleted (🎯T97.6).
+		if _, _, err := upgrade.LoadAndConsumePending(homeForLease, upgradeNotices); err != nil {
+			slog.Warn("upgrade pending notice load failed", "err", err)
+		}
+	}
+
 	var bgLease *upgrade.Lease
 	if homeErr == nil {
 		var lerr error
@@ -713,7 +799,12 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	reg.SetUpgradeDetector(upgradeDetector)
 	go runUpgradeDetectorLoop(ctx, upgradeDetector)
 
+	// Auto-apply (🎯T97.5). Homebrew-only. Sequence:
+	//   apply (brew upgrade) → spawn (new backend if edge-route) →
+	//   flip primary → OnUpgrade (session allowlist file) →
+	//   drain (SIGTERM self / brew services restart).
 	orchQuiescence, _ := cfg.AutoUpgrade.EffectiveQuiescence()
+	var spawnedBackendURL string
 	autoOrch := upgrade.NewOrchestrator(&upgrade.OrchestratorArgs{
 		Enabled:    cfg.AutoUpgrade.Enabled,
 		Env:        upgrade.ApplyEnv{Homebrew: isHomebrewInstall(), GOOS: ""},
@@ -725,23 +816,59 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 		Apply: func(ctx context.Context) error {
 			return runBrewUpgrade(ctx)
 		},
-		// SpawnBackend / FlipPrimary / DrainOld: full multi-process
-		// orchestration needs the edge supervisor; state machine is
-		// covered by unit tests. Production path logs and relies on
-		// brew services restart when edge is not yet supervising.
-		SpawnBackend: nil,
-		FlipPrimary:  nil,
-		DrainOld:     nil,
+		SpawnBackend: func(ctx context.Context) error {
+			if homeForLease == "" || !upgrade.RouteConfigured(homeForLease) {
+				// Single-daemon: brew already replaced the binary on disk.
+				slog.Info("auto-upgrade: single-daemon mode (no edge-route); new binary ready")
+				return nil
+			}
+			url, err := spawnLoopbackBackend(ctx)
+			if err != nil {
+				return err
+			}
+			spawnedBackendURL = url
+			slog.Info("auto-upgrade: spawned backend", "url", url)
+			return nil
+		},
+		FlipPrimary: func(ctx context.Context) error {
+			if homeForLease == "" || !upgrade.RouteConfigured(homeForLease) {
+				return nil
+			}
+			if spawnedBackendURL == "" {
+				return fmt.Errorf("auto-upgrade: no spawned backend to flip to")
+			}
+			r, err := upgrade.AppendBackend(homeForLease, spawnedBackendURL)
+			if err != nil {
+				return err
+			}
+			slog.Info("auto-upgrade: edge primary flipped", "primary", r.Primary, "url", spawnedBackendURL)
+			return nil
+		},
+		DrainOld: func(ctx context.Context) error {
+			// Release lease before exit so the new backend can take it.
+			reg.ReleaseLease()
+			if homeForLease != "" && upgrade.RouteConfigured(homeForLease) {
+				// Edge owns client connections; this backend drains via SIGTERM.
+				slog.Info("auto-upgrade: signaling self for graceful drain (edge preserves clients)")
+				p, _ := os.FindProcess(os.Getpid())
+				return p.Signal(syscall.SIGTERM)
+			}
+			// Single-daemon: brew services restart reaps us and starts the new binary.
+			slog.Info("auto-upgrade: brew services restart mnemo")
+			return runBrewServicesRestart(ctx)
+		},
 		OnUpgrade: func(from, to string) {
-			slog.Info("auto-upgrade complete", "from", from, "to", to)
-			// Persist from-version so the new backend process can banner
-			// sessions that reconnect with the same Mcp-Session-Id.
-			if homeForLease != "" {
-				_ = os.WriteFile(
-					filepath.Join(homeForLease, ".mnemo", "upgrade-from"),
-					[]byte(from+"\n"+to+"\n"),
-					0o600,
-				)
+			slog.Info("auto-upgrade: writing pending notices", "from", from, "to", to)
+			if homeForLease == "" {
+				return
+			}
+			// Only sessions that were live before the swap get banners.
+			if err := upgrade.WritePendingNotice(homeForLease, upgrade.PendingNotice{
+				From:     from,
+				To:       to,
+				Sessions: activeSessions.Snapshot(),
+			}); err != nil {
+				slog.Warn("auto-upgrade: write pending notice", "err", err)
 			}
 		},
 	})
@@ -900,12 +1027,7 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	// same registry that backs the /health endpoint and the scheduler.
 	handler.SetDiagRunner(diagReg)
 
-	// 🎯T97.6: one-time upgrade notice on tool results. If a previous
-	// auto-apply left ~/.mnemo/upgrade-from, banner the first tool call
-	// per session after this process started.
-	if homeForLease != "" {
-		loadPendingUpgradeNotices(homeForLease, version, upgradeNotices)
-	}
+	// 🎯T97.6: one-time upgrade notice on tool results (allowlisted sessions).
 	handler.SetUpgradeNotices(upgradeNotices)
 
 	// Build a federation client if linked_instances are configured —
@@ -958,12 +1080,12 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	//   /api/*        → JSON REST API (for the dashboard)
 	//   /             → Web dashboard UI
 	mux := http.NewServeMux()
-	// Track MCP traffic for auto-apply quiescence (🎯T97.5) and mark
-	// sessions for upgrade notices (🎯T97.6).
+	// Track MCP traffic for auto-apply quiescence (🎯T97.5) and remember
+	// live session IDs so OnUpgrade can allowlist spanning sessions only.
 	mcpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		lastMCPActivity.Set(time.Now())
 		if sid := r.Header.Get(edgeproxy.SessionIDHeader); sid != "" {
-			maybeMarkSessionUpgrade(homeForLease, version, sid, upgradeNotices)
+			activeSessions.Add(sid)
 		}
 		httpSrv.ServeHTTP(w, r)
 	})
@@ -1172,48 +1294,54 @@ func runBrewUpgrade(ctx context.Context) error {
 	return nil
 }
 
-// loadPendingUpgradeNotices reads ~/.mnemo/upgrade-from left by a prior
-// auto-apply so the new process can banner sessions (🎯T97.6).
-func loadPendingUpgradeNotices(home, current string, tr *upgrade.NoticeTracker) {
-	path := filepath.Join(home, ".mnemo", "upgrade-from")
-	data, err := os.ReadFile(path)
+func runBrewServicesRestart(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "brew", "services", "restart", "mnemo")
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return
+		return fmt.Errorf("brew services restart mnemo: %w (%s)", err, strings.TrimSpace(string(out)))
 	}
-	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-	if len(lines) < 1 {
-		return
-	}
-	from := strings.TrimSpace(lines[0])
-	to := current
-	if len(lines) >= 2 && strings.TrimSpace(lines[1]) != "" {
-		to = strings.TrimSpace(lines[1])
-	}
-	// Stash for maybeMarkSessionUpgrade; keep file until first use set.
-	_ = os.WriteFile(path+".active", []byte(from+"\n"+to+"\n"), 0o600)
-	_ = os.Remove(path)
-	_ = tr // sessions marked lazily on first MCP request
+	return nil
 }
 
-func maybeMarkSessionUpgrade(home, current, sessionID string, tr *upgrade.NoticeTracker) {
-	if home == "" || sessionID == "" || tr == nil {
-		return
-	}
-	path := filepath.Join(home, ".mnemo", "upgrade-from.active")
-	data, err := os.ReadFile(path)
+// spawnLoopbackBackend starts a sibling mnemo daemon on a free loopback
+// port for edge-mediated handoff (🎯T97.5). Returns the base URL.
+func spawnLoopbackBackend(ctx context.Context) (string, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		return
+		return "", err
 	}
-	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-	if len(lines) < 1 {
-		return
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
 	}
-	from := strings.TrimSpace(lines[0])
-	to := current
-	if len(lines) >= 2 && strings.TrimSpace(lines[1]) != "" {
-		to = strings.TrimSpace(lines[1])
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	cmd := exec.CommandContext(ctx, exe, "--addr", addr)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("spawn backend: %w", err)
 	}
-	tr.MarkSession(sessionID, from, to)
+	// Detach: do not wait; the new process is supervised by the OS /
+	// brew. Record PID for diagnostics.
+	slog.Info("spawned backend process", "pid", cmd.Process.Pid, "addr", addr)
+	go func() { _ = cmd.Wait() }()
+	// Brief readiness wait: poll TCP until accept or timeout.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			_ = c.Close()
+			return "http://" + addr, nil
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	return "http://" + addr, nil // return anyway; edge will 502 until ready
 }
 
 // compactorAdapter satisfies tools.CompactorHealthReporter by

--- a/main.go
+++ b/main.go
@@ -573,14 +573,14 @@ func cmdEdge(args []string) {
 	}
 }
 
-// watchEdgeRoute applies edge-route.json: grows the backend list, flips
-// primary, and optionally repins all sessions to primary so a draining
-// backend can be reaped without orphaning client sessions (🎯T97.5).
+// watchEdgeRoute applies edge-route.json (grow backends + primary flip)
+// and writes pin_counts so a draining backend can AffinityDrain until
+// its pin count is zero (🎯T97.5). repin_all is crash-failover only.
 func watchEdgeRoute(ctx context.Context, path string, router *edgeproxy.Router, proxy *edgeproxy.Proxy) {
 	_ = proxy // clients grow lazily via Proxy.clientAt → syncClients
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
-	var lastRaw string
+	var lastControl string // backends+primary+repin (not pin_counts)
 	for {
 		select {
 		case <-ctx.Done():
@@ -590,32 +590,32 @@ func watchEdgeRoute(ctx context.Context, path string, router *edgeproxy.Router, 
 			if err != nil {
 				continue
 			}
-			raw := string(data)
-			if raw == lastRaw {
-				continue
-			}
 			var rf upgrade.RouteFile
 			if err := json.Unmarshal(data, &rf); err != nil {
 				continue
 			}
-			prim, err := router.ApplyRoute(rf.Backends, rf.Primary)
-			if err != nil {
-				slog.Warn("edge: apply route file", "err", err)
-				continue
-			}
-			if rf.RepinAll {
-				n := router.RepinAllToPrimary()
-				slog.Info("edge: repinned sessions to primary", "moved", n, "primary", prim)
-				rf.RepinAll = false
-				if b, mErr := json.MarshalIndent(rf, "", "  "); mErr == nil {
-					_ = os.WriteFile(path, append(b, '\n'), 0o600)
+			controlKey := fmt.Sprintf("%v|%d|%v", rf.Backends, rf.Primary, rf.RepinAll)
+			if controlKey != lastControl {
+				prim, err := router.ApplyRoute(rf.Backends, rf.Primary)
+				if err != nil {
+					slog.Warn("edge: apply route file", "err", err)
+					continue
 				}
+				if rf.RepinAll {
+					// Crash-failover only — not happy-path upgrade drain.
+					n := upgrade.FailoverRepin(router.RepinAllToPrimary)
+					slog.Info("edge: failover repin to primary", "moved", n, "primary", prim)
+					rf.RepinAll = false
+				}
+				slog.Info("edge: route applied", "backends", router.BackendCount(), "primary", prim)
+				lastControl = controlKey
 			}
-			slog.Info("edge: route applied", "backends", router.BackendCount(), "primary", prim)
-			if b, err := os.ReadFile(path); err == nil {
-				lastRaw = string(b)
-			} else {
-				lastRaw = raw
+			// Always refresh pin_counts for AffinityDrain observers.
+			rf.PinCounts = router.PinCounts()
+			rf.Backends = router.BackendURLs()
+			rf.Primary = router.PrimaryIndex()
+			if b, mErr := json.MarshalIndent(rf, "", "  "); mErr == nil {
+				_ = os.WriteFile(path, append(b, '\n'), 0o600)
 			}
 		}
 	}
@@ -806,11 +806,13 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	go runUpgradeDetectorLoop(ctx, upgradeDetector)
 
 	// Auto-apply (🎯T97.5). Homebrew-only. Sequence:
-	//   apply → OnUpgrade (pending file + in-process marks) →
-	//   spawn (sibling loads pending) → flip (edge-route grow+primary) →
-	//   drain (repin, release lease, grace wait, then exit/restart).
+	//   apply → OnUpgrade (pending + in-process marks) →
+	//   spawn (sibling loads pending) → flip primary (pins stay) →
+	//   AffinityDrain (wait pin_counts[self]==0, then SIGTERM).
+	// Never repin_all on this path — that invalidates mcp-go sessions.
 	orchQuiescence, _ := cfg.AutoUpgrade.EffectiveQuiescence()
 	var spawnedBackendURL string
+	selfBackendURL := backendSelfURL(addr)
 	autoOrch := upgrade.NewOrchestrator(&upgrade.OrchestratorArgs{
 		Enabled:    cfg.AutoUpgrade.Enabled,
 		Env:        upgrade.ApplyEnv{Homebrew: isHomebrewInstall(), GOOS: ""},
@@ -846,51 +848,62 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 			if err != nil {
 				return err
 			}
-			slog.Info("auto-upgrade: edge primary flipped", "primary", r.Primary, "url", spawnedBackendURL)
+			slog.Info("auto-upgrade: edge primary flipped (affinity pins unchanged)",
+				"primary", r.Primary, "url", spawnedBackendURL)
 			return nil
 		},
 		DrainOld: func(ctx context.Context) error {
-			// Release lease first so the new backend can take singleton work.
 			reg.ReleaseLease()
-			if homeForLease != "" && upgrade.RouteConfigured(homeForLease) {
-				// Ask edge to repin all sessions onto the new primary before
-				// we die, so client TCP stays valid and traffic moves.
-				if rf, err := upgrade.ReadRoute(homeForLease); err == nil {
-					rf.RepinAll = true
-					_ = upgrade.WriteRoute(homeForLease, rf)
-				}
-				// Grace window: let edge apply repin and in-flight RPCs finish.
-				grace := 2 * time.Second
-				if d := os.Getenv("MNEMO_DRAIN_GRACE"); d != "" {
-					if parsed, err := time.ParseDuration(d); err == nil {
-						grace = parsed
-					}
-				}
-				slog.Info("auto-upgrade: edge drain grace", "grace", grace)
-				select {
-				case <-ctx.Done():
-				case <-time.After(grace):
-				}
-				// Trigger the same graceful drain path as SIGTERM (WAL etc.).
-				slog.Info("auto-upgrade: signaling self after repin grace")
-				p, err := os.FindProcess(os.Getpid())
-				if err != nil {
-					return err
-				}
-				return p.Signal(syscall.SIGTERM)
+			if homeForLease == "" || !upgrade.RouteConfigured(homeForLease) {
+				slog.Info("auto-upgrade: brew services restart mnemo")
+				return runBrewServicesRestart(ctx)
 			}
-			slog.Info("auto-upgrade: brew services restart mnemo")
-			return runBrewServicesRestart(ctx)
+			// Affinity drain: keep serving pinned sessions until edge
+			// reports pin_counts[self]==0, then graceful SIGTERM.
+			selfIdx := -1
+			if rf, err := upgrade.ReadRoute(homeForLease); err == nil {
+				selfIdx = rf.IndexOfBackend(selfBackendURL)
+			}
+			if selfIdx < 0 {
+				slog.Warn("auto-upgrade: self not in edge-route; signaling immediately",
+					"self", selfBackendURL)
+				return signalSelfSIGTERM()
+			}
+			maxWait := orchQuiescence
+			if maxWait <= 0 {
+				maxWait = upgrade.DefaultDrainMaxWait
+			}
+			if d := os.Getenv("MNEMO_DRAIN_MAX_WAIT"); d != "" {
+				if parsed, err := time.ParseDuration(d); err == nil {
+					maxWait = parsed
+				}
+			}
+			slog.Info("auto-upgrade: affinity drain waiting for pins to clear",
+				"self_idx", selfIdx, "max_wait", maxWait)
+			return upgrade.AffinityDrain(ctx, &upgrade.AffinityDrainArgs{
+				BackendIdx: selfIdx,
+				Pins: func(idx int) int {
+					rf, err := upgrade.ReadRoute(homeForLease)
+					if err != nil {
+						return 0
+					}
+					return rf.PinCountAt(idx)
+				},
+				MaxWait:      maxWait,
+				PollInterval: upgrade.DefaultDrainPoll,
+				Reap: func(ctx context.Context) error {
+					slog.Info("auto-upgrade: pins clear (or max wait); SIGTERM self")
+					return signalSelfSIGTERM()
+				},
+			})
 		},
 		OnUpgrade: func(from, to string) {
 			slog.Info("auto-upgrade: writing pending notices", "from", from, "to", to)
 			sessions := activeSessions.Snapshot()
-			// In-process banners for sessions this backend still serves.
 			upgradeNotices.MarkSessions(sessions, from, to)
 			if homeForLease == "" {
 				return
 			}
-			// Sibling loads this at startup (must be written before spawn).
 			if err := upgrade.WritePendingNotice(homeForLease, upgrade.PendingNotice{
 				From:     from,
 				To:       to,
@@ -1329,6 +1342,31 @@ func runBrewServicesRestart(ctx context.Context) error {
 		return fmt.Errorf("brew services restart mnemo: %w (%s)", err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+func signalSelfSIGTERM() error {
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		return err
+	}
+	return p.Signal(syscall.SIGTERM)
+}
+
+// backendSelfURL is the loopback base URL peers/edge use for this
+// process when it listens on addr (e.g. ":19421" → "http://127.0.0.1:19421").
+func backendSelfURL(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		// addr may be ":19421"
+		if strings.HasPrefix(addr, ":") {
+			return "http://127.0.0.1" + addr
+		}
+		return "http://" + addr
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	return "http://" + net.JoinHostPort(host, port)
 }
 
 // spawnLoopbackBackend starts a sibling mnemo daemon on a free loopback

--- a/main.go
+++ b/main.go
@@ -742,14 +742,26 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	// singleton background work on holder status.
 	upgradeNotices := upgrade.NewNoticeTracker()
 	activeSessions := upgrade.NewSessionSet()
+	// listChanged is registered after mcpSrv is built (orchestrator is
+	// wired earlier). Best-effort tools/list_changed on version change.
+	var listChangedHolder upgrade.ListChangedHolder
+	upgradeFX := &upgrade.SideEffects{
+		Notices: upgradeNotices,
+		ListChanged: func(from, to string) {
+			listChangedHolder.Send(from, to)
+		},
+	}
 	var lastMCPActivity atomicTime
 	lastMCPActivity.Set(time.Now())
 
 	homeForLease, homeErr := store.EffectiveHome()
+	var pendingUpgradeFrom, pendingUpgradeTo string
 	if homeErr == nil {
 		// Load once: allowlisted sessions only; file is deleted (🎯T97.6).
-		if _, _, err := upgrade.LoadAndConsumePending(homeForLease, upgradeNotices); err != nil {
+		if p, ok, err := upgrade.LoadAndConsumePending(homeForLease, upgradeNotices); err != nil {
 			slog.Warn("upgrade pending notice load failed", "err", err)
+		} else if ok {
+			pendingUpgradeFrom, pendingUpgradeTo = p.From, p.To
 		}
 	}
 
@@ -901,9 +913,10 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 			})
 		},
 		OnUpgrade: func(from, to string) {
-			slog.Info("auto-upgrade: writing pending notices", "from", from, "to", to)
+			slog.Info("auto-upgrade: version change side effects", "from", from, "to", to)
 			sessions := activeSessions.Snapshot()
-			upgradeNotices.MarkSessions(sessions, from, to)
+			// Banners + best-effort tools/list_changed (🎯T97.6 / criterion 4).
+			upgradeFX.OnVersionChange(sessions, from, to)
 			if homeForLease == "" {
 				return
 			}
@@ -1021,6 +1034,17 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 		version,
 		server.WithToolCapabilities(true),
 	)
+	// Best-effort tools/list_changed after upgrade (🎯T97.6). listChanged
+	// is void-safe when no clients are connected.
+	listChangedHolder.Set(func(from, to string) {
+		upgrade.BroadcastListChanged(mcpSrv, from, to)
+		slog.Info("auto-upgrade: tools/list_changed notified", "from", from, "to", to)
+	})
+	// Sibling process that loaded upgrade-pending: notify any clients that
+	// attach to this new backend (best-effort).
+	if pendingUpgradeFrom != "" {
+		listChangedHolder.Send(pendingUpgradeFrom, pendingUpgradeTo)
+	}
 	handler := tools.NewHandler(resolve)
 
 	// Wire the per-user vault syncer resolver so mnemo_vault_sync and

--- a/main.go
+++ b/main.go
@@ -540,9 +540,9 @@ func cmdEdge(args []string) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	// Poll route file for primary flips (and appended backends).
+	// Poll route file for backend growth + primary flips + repin.
 	if routePath != "" {
-		go watchEdgeRoute(ctx, routePath, router)
+		go watchEdgeRoute(ctx, routePath, router, proxy)
 	}
 
 	errCh := make(chan error, 1)
@@ -573,13 +573,14 @@ func cmdEdge(args []string) {
 	}
 }
 
-// watchEdgeRoute reloads primary (and rebuilds router backends when the
-// list grows) from edge-route.json so auto-apply can flip without
-// restarting the edge process.
-func watchEdgeRoute(ctx context.Context, path string, router *edgeproxy.Router) {
-	ticker := time.NewTicker(time.Second)
+// watchEdgeRoute applies edge-route.json: grows the backend list, flips
+// primary, and optionally repins all sessions to primary so a draining
+// backend can be reaped without orphaning client sessions (🎯T97.5).
+func watchEdgeRoute(ctx context.Context, path string, router *edgeproxy.Router, proxy *edgeproxy.Proxy) {
+	_ = proxy // clients grow lazily via Proxy.clientAt → syncClients
+	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
-	var lastPrimary = router.PrimaryIndex()
+	var lastRaw string
 	for {
 		select {
 		case <-ctx.Done():
@@ -589,27 +590,32 @@ func watchEdgeRoute(ctx context.Context, path string, router *edgeproxy.Router) 
 			if err != nil {
 				continue
 			}
+			raw := string(data)
+			if raw == lastRaw {
+				continue
+			}
 			var rf upgrade.RouteFile
 			if err := json.Unmarshal(data, &rf); err != nil {
 				continue
 			}
-			if rf.Primary != lastPrimary {
-				if err := router.SetPrimary(rf.Primary); err != nil {
-					slog.Warn("edge: set primary from route file", "err", err)
-					continue
-				}
-				slog.Info("edge: primary flipped from route file", "primary", rf.Primary)
-				lastPrimary = rf.Primary
+			prim, err := router.ApplyRoute(rf.Backends, rf.Primary)
+			if err != nil {
+				slog.Warn("edge: apply route file", "err", err)
+				continue
 			}
-			// Note: adding backends requires router rebuild; AppendBackend
-			// always sets primary to the new index — SetPrimary works when
-			// the backend was already listed on the CLI. For newly appended
-			// URLs beyond initial BackendCount, log a warning (edge restart
-			// or initial multi --backend list still covers the swap case
-			// when both ports are predeclared).
-			if rf.Primary >= router.BackendCount() {
-				slog.Warn("edge: route primary exceeds configured backends; restart edge with updated --backend list",
-					"primary", rf.Primary, "configured", router.BackendCount())
+			if rf.RepinAll {
+				n := router.RepinAllToPrimary()
+				slog.Info("edge: repinned sessions to primary", "moved", n, "primary", prim)
+				rf.RepinAll = false
+				if b, mErr := json.MarshalIndent(rf, "", "  "); mErr == nil {
+					_ = os.WriteFile(path, append(b, '\n'), 0o600)
+				}
+			}
+			slog.Info("edge: route applied", "backends", router.BackendCount(), "primary", prim)
+			if b, err := os.ReadFile(path); err == nil {
+				lastRaw = string(b)
+			} else {
+				lastRaw = raw
 			}
 		}
 	}
@@ -800,9 +806,9 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	go runUpgradeDetectorLoop(ctx, upgradeDetector)
 
 	// Auto-apply (🎯T97.5). Homebrew-only. Sequence:
-	//   apply (brew upgrade) → spawn (new backend if edge-route) →
-	//   flip primary → OnUpgrade (session allowlist file) →
-	//   drain (SIGTERM self / brew services restart).
+	//   apply → OnUpgrade (pending file + in-process marks) →
+	//   spawn (sibling loads pending) → flip (edge-route grow+primary) →
+	//   drain (repin, release lease, grace wait, then exit/restart).
 	orchQuiescence, _ := cfg.AutoUpgrade.EffectiveQuiescence()
 	var spawnedBackendURL string
 	autoOrch := upgrade.NewOrchestrator(&upgrade.OrchestratorArgs{
@@ -818,7 +824,6 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 		},
 		SpawnBackend: func(ctx context.Context) error {
 			if homeForLease == "" || !upgrade.RouteConfigured(homeForLease) {
-				// Single-daemon: brew already replaced the binary on disk.
 				slog.Info("auto-upgrade: single-daemon mode (no edge-route); new binary ready")
 				return nil
 			}
@@ -845,28 +850,51 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 			return nil
 		},
 		DrainOld: func(ctx context.Context) error {
-			// Release lease before exit so the new backend can take it.
+			// Release lease first so the new backend can take singleton work.
 			reg.ReleaseLease()
 			if homeForLease != "" && upgrade.RouteConfigured(homeForLease) {
-				// Edge owns client connections; this backend drains via SIGTERM.
-				slog.Info("auto-upgrade: signaling self for graceful drain (edge preserves clients)")
-				p, _ := os.FindProcess(os.Getpid())
+				// Ask edge to repin all sessions onto the new primary before
+				// we die, so client TCP stays valid and traffic moves.
+				if rf, err := upgrade.ReadRoute(homeForLease); err == nil {
+					rf.RepinAll = true
+					_ = upgrade.WriteRoute(homeForLease, rf)
+				}
+				// Grace window: let edge apply repin and in-flight RPCs finish.
+				grace := 2 * time.Second
+				if d := os.Getenv("MNEMO_DRAIN_GRACE"); d != "" {
+					if parsed, err := time.ParseDuration(d); err == nil {
+						grace = parsed
+					}
+				}
+				slog.Info("auto-upgrade: edge drain grace", "grace", grace)
+				select {
+				case <-ctx.Done():
+				case <-time.After(grace):
+				}
+				// Trigger the same graceful drain path as SIGTERM (WAL etc.).
+				slog.Info("auto-upgrade: signaling self after repin grace")
+				p, err := os.FindProcess(os.Getpid())
+				if err != nil {
+					return err
+				}
 				return p.Signal(syscall.SIGTERM)
 			}
-			// Single-daemon: brew services restart reaps us and starts the new binary.
 			slog.Info("auto-upgrade: brew services restart mnemo")
 			return runBrewServicesRestart(ctx)
 		},
 		OnUpgrade: func(from, to string) {
 			slog.Info("auto-upgrade: writing pending notices", "from", from, "to", to)
+			sessions := activeSessions.Snapshot()
+			// In-process banners for sessions this backend still serves.
+			upgradeNotices.MarkSessions(sessions, from, to)
 			if homeForLease == "" {
 				return
 			}
-			// Only sessions that were live before the swap get banners.
+			// Sibling loads this at startup (must be written before spawn).
 			if err := upgrade.WritePendingNotice(homeForLease, upgrade.PendingNotice{
 				From:     from,
 				To:       to,
-				Sessions: activeSessions.Snapshot(),
+				Sessions: sessions,
 			}); err != nil {
 				slog.Warn("auto-upgrade: write pending notice", "err", err)
 			}

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -52,6 +53,7 @@ import (
 	"github.com/marcelocantos/mnemo/internal/registry"
 	"github.com/marcelocantos/mnemo/internal/store"
 	"github.com/marcelocantos/mnemo/internal/tools"
+	"github.com/marcelocantos/mnemo/internal/upgrade"
 )
 
 // stdioMigrationManualHint is emitted only when auto-migration of
@@ -650,6 +652,101 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	reg := registry.NewRegistry(ctx, cfg, summariserDir)
 	defer reg.Close()
 
+	// 🎯T97: upgrade detector, background lease, notices, auto-apply.
+	// Lease is acquired before eager ForUser so startWorkers can gate
+	// singleton background work on holder status.
+	upgradeNotices := upgrade.NewNoticeTracker()
+	var lastMCPActivity atomicTime
+	lastMCPActivity.Set(time.Now())
+
+	homeForLease, homeErr := store.EffectiveHome()
+	var bgLease *upgrade.Lease
+	if homeErr == nil {
+		var lerr error
+		bgLease, lerr = upgrade.NewLease(&upgrade.LeaseArgs{
+			Path:     upgrade.DefaultLeasePath(homeForLease),
+			HolderID: upgrade.DefaultHolderID(),
+		})
+		if lerr != nil {
+			slog.Warn("background lease unavailable", "err", lerr)
+		} else {
+			reg.SetLease(bgLease)
+			if ok, aerr := bgLease.TryAcquire(); aerr != nil {
+				slog.Warn("background lease acquire failed", "err", aerr)
+			} else if ok {
+				slog.Info("background lease acquired", "holder", upgrade.DefaultHolderID())
+				go bgLease.RunHeartbeatLoop(ctx.Done(), 0)
+			} else {
+				slog.Info("background lease held by another process; serve-only mode")
+			}
+			// Retry acquire periodically so a handoff after peer drain works.
+			go func() {
+				t := time.NewTicker(time.Second)
+				defer t.Stop()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-t.C:
+						if bgLease.Held() {
+							continue
+						}
+						ok, err := bgLease.TryAcquire()
+						if err != nil || !ok {
+							continue
+						}
+						slog.Info("background lease acquired (handoff)")
+						go bgLease.RunHeartbeatLoop(ctx.Done(), 0)
+						reg.EnsureBackgroundWorkers()
+					}
+				}
+			}()
+		}
+	}
+
+	upgradeDetector := upgrade.NewDetector(&upgrade.DetectorArgs{
+		CurrentVersion: version,
+		Fetch:          upgrade.GHReleaseFetcher(""),
+		Disabled:       cfg.DisableUpgradeCheck,
+		MinInterval:    6 * time.Hour,
+	})
+	reg.SetUpgradeDetector(upgradeDetector)
+	go runUpgradeDetectorLoop(ctx, upgradeDetector)
+
+	orchQuiescence, _ := cfg.AutoUpgrade.EffectiveQuiescence()
+	autoOrch := upgrade.NewOrchestrator(&upgrade.OrchestratorArgs{
+		Enabled:    cfg.AutoUpgrade.Enabled,
+		Env:        upgrade.ApplyEnv{Homebrew: isHomebrewInstall(), GOOS: ""},
+		Quiescence: orchQuiescence,
+		Detector:   upgradeDetector,
+		LastActivity: func() time.Time {
+			return lastMCPActivity.Get()
+		},
+		Apply: func(ctx context.Context) error {
+			return runBrewUpgrade(ctx)
+		},
+		// SpawnBackend / FlipPrimary / DrainOld: full multi-process
+		// orchestration needs the edge supervisor; state machine is
+		// covered by unit tests. Production path logs and relies on
+		// brew services restart when edge is not yet supervising.
+		SpawnBackend: nil,
+		FlipPrimary:  nil,
+		DrainOld:     nil,
+		OnUpgrade: func(from, to string) {
+			slog.Info("auto-upgrade complete", "from", from, "to", to)
+			// Persist from-version so the new backend process can banner
+			// sessions that reconnect with the same Mcp-Session-Id.
+			if homeForLease != "" {
+				_ = os.WriteFile(
+					filepath.Join(homeForLease, ".mnemo", "upgrade-from"),
+					[]byte(from+"\n"+to+"\n"),
+					0o600,
+				)
+			}
+		},
+	})
+	go runAutoApplyLoop(ctx, autoOrch)
+
 	// Determine the default username — used when a request arrives
 	// without an explicit ?user=<name> query parameter. On a Windows
 	// Service deployment (running as LocalSystem) there is no
@@ -803,6 +900,14 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	// same registry that backs the /health endpoint and the scheduler.
 	handler.SetDiagRunner(diagReg)
 
+	// 🎯T97.6: one-time upgrade notice on tool results. If a previous
+	// auto-apply left ~/.mnemo/upgrade-from, banner the first tool call
+	// per session after this process started.
+	if homeForLease != "" {
+		loadPendingUpgradeNotices(homeForLease, version, upgradeNotices)
+	}
+	handler.SetUpgradeNotices(upgradeNotices)
+
 	// Build a federation client if linked_instances are configured —
 	// this owns one persistent http.Client per peer and is shared
 	// across every fan-out tool registration. Failure to construct
@@ -853,8 +958,17 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	//   /api/*        → JSON REST API (for the dashboard)
 	//   /             → Web dashboard UI
 	mux := http.NewServeMux()
-	mux.Handle("/mcp", httpSrv)
-	mux.Handle("/mcp/", httpSrv) // catch sub-paths used by the MCP transport
+	// Track MCP traffic for auto-apply quiescence (🎯T97.5) and mark
+	// sessions for upgrade notices (🎯T97.6).
+	mcpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lastMCPActivity.Set(time.Now())
+		if sid := r.Header.Get(edgeproxy.SessionIDHeader); sid != "" {
+			maybeMarkSessionUpgrade(homeForLease, version, sid, upgradeNotices)
+		}
+		httpSrv.ServeHTTP(w, r)
+	})
+	mux.Handle("/mcp", mcpHandler)
+	mux.Handle("/mcp/", mcpHandler) // catch sub-paths used by the MCP transport
 	apiHandler := api.New(resolve)
 	apiHandler.SetDiagRunner(diagReg) // 🎯T83: serve GET /health from the diag registry
 	apiHandler.SetEventHub(eventHub)  // 🎯T86: serve GET /api/events (SSE) from the hub
@@ -958,7 +1072,10 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 					slog.Warn("federated HTTP shutdown error", "err", err)
 				}
 			}
-			// 2. (release singleton background lease — 🎯T97.4)
+			// 2. Release singleton background lease (🎯T97.4) so a peer
+			// backend can acquire and start ingest/compaction.
+			slog.Info("drain: releasing background lease")
+			reg.ReleaseLease()
 			// 3–5. Stop workers, quiesce read pools, checkpoint each writer.
 			slog.Info("drain: stopping workers + checkpointing stores")
 			reg.Close()
@@ -974,6 +1091,129 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 			return nil // unreachable; os.Exit does not return
 		}
 	}
+}
+
+// atomicTime is a mutex-guarded time.Time for MCP activity tracking.
+type atomicTime struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (a *atomicTime) Set(t time.Time) {
+	a.mu.Lock()
+	a.t = t
+	a.mu.Unlock()
+}
+
+func (a *atomicTime) Get() time.Time {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.t
+}
+
+func runUpgradeDetectorLoop(ctx context.Context, d *upgrade.Detector) {
+	// Immediate check at startup, then every hour (detector still
+	// enforces its own MinInterval for the gh call).
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+	do := func() {
+		cr := d.Check(ctx)
+		if cr.Err != nil {
+			slog.Debug("upgrade check", "err", cr.Err)
+			return
+		}
+		if cr.UpgradeAvailable {
+			slog.Info("upgrade available", "detail", cr.Detail)
+		}
+	}
+	do()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			do()
+		}
+	}
+}
+
+func runAutoApplyLoop(ctx context.Context, o *upgrade.Orchestrator) {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := o.Tick(ctx); err != nil {
+				slog.Warn("auto-upgrade tick", "err", err)
+			}
+		}
+	}
+}
+
+func isHomebrewInstall() bool {
+	exe, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	exe, _ = filepath.EvalSymlinks(exe)
+	return strings.Contains(exe, "/Cellar/mnemo/") ||
+		strings.Contains(exe, "/homebrew/") ||
+		strings.Contains(exe, "/linuxbrew/")
+}
+
+func runBrewUpgrade(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "brew", "upgrade", "mnemo")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("brew upgrade mnemo: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// loadPendingUpgradeNotices reads ~/.mnemo/upgrade-from left by a prior
+// auto-apply so the new process can banner sessions (🎯T97.6).
+func loadPendingUpgradeNotices(home, current string, tr *upgrade.NoticeTracker) {
+	path := filepath.Join(home, ".mnemo", "upgrade-from")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) < 1 {
+		return
+	}
+	from := strings.TrimSpace(lines[0])
+	to := current
+	if len(lines) >= 2 && strings.TrimSpace(lines[1]) != "" {
+		to = strings.TrimSpace(lines[1])
+	}
+	// Stash for maybeMarkSessionUpgrade; keep file until first use set.
+	_ = os.WriteFile(path+".active", []byte(from+"\n"+to+"\n"), 0o600)
+	_ = os.Remove(path)
+	_ = tr // sessions marked lazily on first MCP request
+}
+
+func maybeMarkSessionUpgrade(home, current, sessionID string, tr *upgrade.NoticeTracker) {
+	if home == "" || sessionID == "" || tr == nil {
+		return
+	}
+	path := filepath.Join(home, ".mnemo", "upgrade-from.active")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) < 1 {
+		return
+	}
+	from := strings.TrimSpace(lines[0])
+	to := current
+	if len(lines) >= 2 && strings.TrimSpace(lines[1]) != "" {
+		to = strings.TrimSpace(lines[1])
+	}
+	tr.MarkSession(sessionID, from, to)
 }
 
 // compactorAdapter satisfies tools.CompactorHealthReporter by


### PR DESCRIPTION
## Summary

- Connection-preserving self-upgrade (🎯T97): edge proxy, session affinity drain, single-holder lease, opt-in auto-apply, upgrade notices, graceful drain (already on master as #143).
- Grok CLI transcript ingest (🎯T110): watches `~/.grok/sessions`, indexes `updates.jsonl` + `summary.json` with `source=grok`.
- Docs: agents-guide + README cover Claude / Codex / Grok multi-source indexing.

## Release

Prep for **v0.61.0** (version string already `0.61.0`).

## Test plan

- [x] `go test -tags sqlite_fts5 ./...`
- [ ] CI green
- [ ] `scripts/win-validate.sh` (windows-vm-validated gate)
- [x] Live smoke: 61 Grok sessions searchable with `source=grok`
