### PR TITLE
Grok transcript fidelity beyond MVP

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -518,6 +518,29 @@ targets:
     origin: 'conversation: user started using Grok and needs mnemo support; research 2026-07-11'
     discovered: 2026-07-11
     achieved: 2026-07-11
+  T111:
+    name: Grok (and shared non-Claude) transcript fidelity matches Claude's searchable metadata density where the format allows
+    status: achieved
+    value: 8.0
+    cost: 5.0
+    actual_cost: 5.0
+    acceptance:
+    - Grok tool inputs normalise target_file/path → file_path so tool_file_path is populated; command alias works for who_ran
+    - Grok summary.session_kind=subagent yields session_summary.session_type=subagent; parent_session_id yields session_chains edge
+    - Grok entries carry message.model from summary/signals; signals.json context tokens appear as input_tokens on a refreshable usage row
+    - session_recap, plan, goal_updated, subagent_spawned/finished, and task_completed are searchable text (or chains)
+    - normalizeAgentToolInput is shared and used from Codex tool-input path
+    - Unit tests cover aliases, model, usage, session_type, chains, recap/plan/goal
+    - docs/design/grok-ingest.md documents the fidelity layer
+    context: T110 shipped MVP conversation+tools. T111 deepens mapping of summary.json, signals.json, and x.ai ACP extensions into Claude-equivalent columns and indexes Grok-only signals (goals, recaps, plans, subagent graph).
+    tags:
+    - ingest
+    - grok
+    - codex
+    - multi-source
+    origin: 'conversation: deepen Grok beyond MVP; keep Codex in mind; prefer Grok-beyond-Claude signals'
+    discovered: 2026-07-11
+    achieved: 2026-07-11
   T12:
     name: GitHub activity (PRs, issues, reviews) indexed cross-repo with FTS and session correlation
     status: achieved

--- a/docs/design/grok-ingest.md
+++ b/docs/design/grok-ingest.md
@@ -1,13 +1,9 @@
-# Grok Transcript Ingest (MVP)
+# Grok Transcript Ingest
 
-*Status: design note — 2026-07-11. Anchors 🎯T110. Scope is deliberately
-narrow: capture Grok CLI session transcripts into the existing index,
-and not much else.*
-
-**Tracking.** Design source for 🎯T110. Grounded in real session trees
-on disk (`~/.grok`, Grok CLI 0.2.93) and the shipped user guide
-(`~/.grok/docs/user-guide/17-sessions.md`). Sibling of 🎯T99 /
-`docs/design/codex-ingest.md`.
+*Status: design note — 2026-07-11. Anchors 🎯T110 (MVP) + 🎯T111
+(fidelity). Grounded in real session trees on disk (`~/.grok`, Grok CLI
+0.2.93+) and the shipped user guide (`17-sessions.md`). Sibling of
+🎯T99 / `docs/design/codex-ingest.md`.*
 
 ---
 
@@ -132,22 +128,42 @@ variant. Unknown → skip-and-continue, never fail the file.
 
 ---
 
-## Explicitly out of scope (MVP)
+## Fidelity layer (🎯T111)
 
-`events.jsonl` telemetry; rewind snapshots; images; Grok's own
-`session_search.sqlite`; decryption of anything; modelling forks /
-subagents as mnemo chains (subagent child sessions are normal sibling
-session dirs and get indexed independently); `mnemo_whatsup` live-PID
-for `grok` processes; Grok-native memory; usage/token streams from
-`signals.json`.
+Beyond the MVP conversation core, Grok often carries **richer** session
+metadata than Claude's per-line envelope. We map those into the same
+columns/tables Claude already uses where possible, and index the rest
+as searchable text.
 
-**Just text + tool calls + tool results, attributed to a session / repo
-/ timestamp, searchable.**
+| Grok signal | Mapping | Beyond Claude? |
+|-------------|---------|----------------|
+| `summary.current_model_id` | `entries.raw.message.model` → generated `entries.model` | fills same column |
+| `summary.session_kind=subagent` | `project=subagents` → `session_summary.session_type` | same classification path |
+| `summary.parent_session_id` | `session_chains` edge (`mechanism=grok_parent`) | explicit parent without MCP identity |
+| `summary.git_remotes` | `session_meta.repo` fallback when cwd is opaque/worktree | Claude usually has path-based cwd |
+| `signals.json` context tokens | synthetic assistant entry with `input_tokens` + `[grok signals]` text | session-level occupancy (no Anthropic turn split) |
+| tool `target_file` / `path` | normalised to `file_path` for `tool_file_path` gen-col | shared `normalizeAgentToolInput` (Codex too) |
+| `session_recap` | assistant text `[grok recap]` | durable prose summary without mnemo compact |
+| `plan` ACP updates | assistant text `[grok plan]` checklist | first-class plan stream |
+| `goal_updated` | assistant text `[grok goal]` | no Claude analogue |
+| `subagent_spawned/finished` | text + `session_chains` (`grok_subagent`) | parent→child graph |
+| `task_completed` | tool_result-shaped text with exit/cmd/output | bg task completion |
+| `auto_compact_*` | thinking noise with token before/after | Grok-native compact markers |
+
+Codex reuses tool-input normalisation; session_type/model/usage adapters
+are the same extension points when Codex corpus grows.
+
+## Still out of scope
+
+`events.jsonl` raw telemetry flood; rewind snapshots; image pipeline
+(assets/images dirs → OCR/describe); `mnemo_whatsup` for `grok` PIDs;
+Grok-native memory store; decrypting reasoning beyond visible summaries.
 
 ---
 
 ## Cross-check references
 
 - `~/.grok/docs/user-guide/17-sessions.md` (storage layout, resume)
-- Live corpus under `~/.grok/sessions/` (CLI 0.2.93)
-- Implementation mirror: `internal/store/codex.go` (🎯T99)
+- Live corpus under `~/.grok/sessions/` (CLI 0.2.93+)
+- Implementation: `internal/store/grok.go`, `tool_input.go`
+- Mirror: `internal/store/codex.go` (🎯T99)

--- a/internal/store/codex.go
+++ b/internal/store/codex.go
@@ -345,13 +345,13 @@ func codexToolInput(p *codexPayload) (toolInput []byte, text string) {
 	var s string
 	if json.Unmarshal(raw, &s) == nil {
 		if isJSONObject([]byte(s)) {
-			return []byte(s), ""
+			return normalizeAgentToolInput([]byte(s)), ""
 		}
 		return nil, s
 	}
 	// A bare JSON value (object/array), e.g. tool_search_call args.
 	if isJSONObject(raw) {
-		return append([]byte(nil), raw...), ""
+		return normalizeAgentToolInput(append([]byte(nil), raw...)), ""
 	}
 	return nil, string(raw)
 }

--- a/internal/store/grok.go
+++ b/internal/store/grok.go
@@ -1,10 +1,9 @@
-// Grok transcript ingest (🎯T110). xAI's Grok CLI records sessions as
-// directories under ~/.grok/sessions/<url-encoded-cwd>/<session-id>/,
+// Grok transcript ingest (🎯T110 / 🎯T111). xAI's Grok CLI records sessions
+// as directories under ~/.grok/sessions/<url-encoded-cwd>/<session-id>/,
 // with an ACP-style updates.jsonl as the durable conversation log and
-// summary.json for session metadata. This file transforms updates.jsonl
-// into the same parsedFile intermediate the Claude/Codex paths produce,
-// so the shared writer and search machinery are reused.
-// See docs/design/grok-ingest.md.
+// summary.json / signals.json for metadata richer than Claude's per-line
+// envelope. This file transforms that layout into the same parsedFile
+// intermediate the Claude/Codex paths produce. See docs/design/grok-ingest.md.
 package store
 
 import (
@@ -32,8 +31,7 @@ type grokParams struct {
 	Update    json.RawMessage `json:"update"`
 }
 
-// grokUpdate is the tolerant subset of ACP sessionUpdate payloads we
-// read. Unknown fields are ignored — the format has no version stamp.
+// grokUpdate is the tolerant subset of ACP + x.ai sessionUpdate payloads.
 type grokUpdate struct {
 	SessionUpdate string          `json:"sessionUpdate"`
 	Content       json.RawMessage `json:"content"`
@@ -43,17 +41,70 @@ type grokUpdate struct {
 	RawOutput     json.RawMessage `json:"rawOutput"`
 	Status        string          `json:"status"`
 	Meta          json.RawMessage `json:"_meta"`
+
+	// plan
+	Entries json.RawMessage `json:"entries"`
+
+	// session_recap
+	Summary string `json:"summary"`
+	Auto    bool   `json:"auto"`
+
+	// goal_updated (Grok-beyond-Claude)
+	GoalID    string `json:"goal_id"`
+	Objective string `json:"objective"`
+	Phase     string `json:"phase"`
+	// Status already used for tool_call_update; goal uses same JSON key.
+
+	// subagent_*
+	SubagentID      string `json:"subagent_id"`
+	ChildSessionID  string `json:"child_session_id"`
+	ParentSessionID string `json:"parent_session_id"`
+	SubagentType    string `json:"subagent_type"`
+	Description     string `json:"description"`
+	// finished
+	DurationMS int64  `json:"duration_ms"`
+	TokensUsed int64  `json:"tokens_used"`
+	Output     string `json:"output"`
+
+	// task_completed
+	TaskSnapshot json.RawMessage `json:"task_snapshot"`
+
+	// auto_compact_*
+	TokensBefore int64  `json:"tokens_before"`
+	TokensAfter  int64  `json:"tokens_after"`
+	Reason       string `json:"reason"`
 }
 
-// grokSummary is the sibling summary.json metadata file.
+// grokSummary is the sibling summary.json metadata file — often richer
+// than Claude's per-line cwd/branch (model, session_kind, parent, remotes).
 type grokSummary struct {
 	Info struct {
 		ID  string `json:"id"`
 		Cwd string `json:"cwd"`
 	} `json:"info"`
-	GeneratedTitle string `json:"generated_title"`
-	SessionSummary string `json:"session_summary"`
-	HeadBranch     string `json:"head_branch"`
+	GeneratedTitle  string   `json:"generated_title"`
+	SessionSummary  string   `json:"session_summary"`
+	HeadBranch      string   `json:"head_branch"`
+	CurrentModelID  string   `json:"current_model_id"`
+	SessionKind     string   `json:"session_kind"` // "subagent" etc.
+	AgentName       string   `json:"agent_name"`
+	ParentSessionID string   `json:"parent_session_id"`
+	GitRemotes      []string `json:"git_remotes"`
+	GitRootDir      string   `json:"git_root_dir"`
+	HeadCommit      string   `json:"head_commit"`
+	ReasoningEffort string   `json:"reasoning_effort"`
+}
+
+// grokSignals is the subset of signals.json we map into usage / topic.
+type grokSignals struct {
+	ContextTokensUsed   int      `json:"contextTokensUsed"`
+	ContextWindowTokens int      `json:"contextWindowTokens"`
+	PrimaryModelID      string   `json:"primaryModelId"`
+	ModelsUsed          []string `json:"modelsUsed"`
+	ToolCallCount       int      `json:"toolCallCount"`
+	TurnCount           int      `json:"turnCount"`
+	CompactionCount     int      `json:"compactionCount"`
+	GitCommitCount      int      `json:"gitCommitCount"`
 }
 
 // GrokRootsFor returns the candidate Grok session roots under a user's
@@ -69,19 +120,15 @@ func GrokRootsFor(home string) []string {
 
 // isGrokUpdates reports whether a path is a Grok durable conversation
 // log (updates.jsonl). Other .jsonl siblings under a Grok session dir
-// (events, chat_history, rewind_points, …) must not be routed to the
-// Claude or Grok parsers.
+// must not be routed to the Claude parser.
 func isGrokUpdates(path string) bool {
 	return filepath.Base(path) == "updates.jsonl"
 }
 
-// grokSessionID extracts the session UUID from the parent directory of
-// updates.jsonl: .../<encoded-cwd>/<session-id>/updates.jsonl.
 func grokSessionID(path string) string {
 	return filepath.Base(filepath.Dir(path))
 }
 
-// grokProject derives a coarse project label from the session cwd.
 func grokProject(cwd string) string {
 	if r := extractRepo(cwd); r != "" {
 		return r
@@ -92,9 +139,6 @@ func grokProject(cwd string) string {
 	return "grok"
 }
 
-// loadGrokSummary reads the sibling summary.json next to updates.jsonl.
-// Missing or unreadable summary is non-fatal — path-derived session id
-// still works, and cwd/branch simply stay empty.
 func loadGrokSummary(updatesPath string) (grokSummary, error) {
 	p := filepath.Join(filepath.Dir(updatesPath), "summary.json")
 	raw, err := os.ReadFile(p)
@@ -108,9 +152,21 @@ func loadGrokSummary(updatesPath string) (grokSummary, error) {
 	return s, nil
 }
 
+func loadGrokSignals(updatesPath string) (grokSignals, error) {
+	p := filepath.Join(filepath.Dir(updatesPath), "signals.json")
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		return grokSignals{}, err
+	}
+	var s grokSignals
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return grokSignals{}, err
+	}
+	return s, nil
+}
+
 // parseGrokFile reads a Grok updates.jsonl from the given byte offset
-// and transforms it into a parsedFile, mirroring parseFile/parseCodexFile.
-// Pure computation — no DB access.
+// and transforms it into a parsedFile. Pure computation — no DB access.
 func parseGrokFile(path string, offset int64) (parsedFile, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -131,34 +187,78 @@ func parseGrokFile(path string, offset int64) (parsedFile, error) {
 		source:    "grok",
 	}
 
-	// Always load summary for cwd/branch/title. On resume (offset > 0)
-	// writeParsedFile only fills empty meta fields, so re-stamping is fine.
-	// summaryTopic is a provisional title; the first real user turn replaces it.
 	var summaryTopic string
+	var model string
+	var parentID string
+	isSubagent := false
 	if sum, err := loadGrokSummary(path); err == nil {
 		if sum.Info.ID != "" {
 			pf.sessionID = sum.Info.ID
 		}
 		pf.cwd = sum.Info.Cwd
+		// Prefer git worktree root for attribution when present.
+		if sum.GitRootDir != "" && pf.cwd == "" {
+			pf.cwd = sum.GitRootDir
+		}
 		pf.branch = sum.HeadBranch
+		model = sum.CurrentModelID
+		parentID = sum.ParentSessionID
+		if sum.SessionKind == "subagent" {
+			isSubagent = true
+		}
 		if title := sum.GeneratedTitle; title != "" {
 			summaryTopic = title
 		} else if sum.SessionSummary != "" {
 			summaryTopic = sum.SessionSummary
 		}
+		// Beyond Claude: agent_name + objective-ish title for topic seed.
+		if summaryTopic == "" && sum.AgentName != "" {
+			summaryTopic = "grok:" + sum.AgentName
+		}
 		pf.topic = summaryTopic
+		// Prefer remotes for repo when cwd is a worktree outside github.com layout.
+		if r := extractRepo(pf.cwd); r == "" && len(sum.GitRemotes) > 0 {
+			if r := repoFromRemote(sum.GitRemotes[0]); r != "" {
+				// stash via cwd-less project override below
+				pf.project = r
+			}
+		}
+	}
+
+	// session_type is derived from messages.project in the SQL trigger
+	// (project == "subagents" → subagent). Keep real repo in session_meta
+	// via cwd; classify subagents like Claude's path convention.
+	if isSubagent {
+		pf.project = "subagents"
+	}
+
+	// Session-level usage (Grok has no per-turn Anthropic usage envelope).
+	// Stamped onto a synthetic assistant entry so mnemo_usage sees tokens.
+	var sig grokSignals
+	if s, err := loadGrokSignals(path); err == nil {
+		sig = s
+		if model == "" {
+			model = sig.PrimaryModelID
+		}
+		if model == "" && len(sig.ModelsUsed) > 0 {
+			model = sig.ModelsUsed[0]
+		}
 	}
 
 	reader := bufio.NewReader(f)
+
+	// chainHints collected from subagent_spawned for post-write edges.
+	// Stored on pf via synthetic messages; parent from summary is handled
+	// in ingestGrokFile after write.
 
 	handleLine := func(line []byte, thisStart int64) {
 		var gl grokLine
 		if json.Unmarshal(line, &gl) != nil {
 			return
 		}
-		// Only the ACP conversation stream. _x.ai/session/update carries
-		// hooks/goals/subagents/compact markers — skip for MVP.
-		if gl.Method != "session/update" {
+		// Conversation stream + x.ai extensions (goals, recap, subagents…).
+		// Skip pure noise (hooks) inside grokRecord.
+		if gl.Method != "session/update" && gl.Method != "_x.ai/session/update" {
 			return
 		}
 		if len(gl.Params.Update) == 0 {
@@ -176,18 +276,18 @@ func parseGrokFile(path string, offset int64) (parsedFile, error) {
 
 		ts := grokTimestamp(gl.Timestamp)
 		uuid := fmt.Sprintf("grok-%s-%d", pf.sessionID, thisStart)
+		// Stamp model (and optional usage) so generated entry columns fire.
+		raw := enrichGrokRaw(line, uuid, model, 0, 0)
 		entryIdx := len(pf.entries)
 		pf.entries = append(pf.entries, parsedRawEntry{
 			entryType: entryType,
 			timestamp: ts,
-			raw:       injectSyntheticUUID(line, uuid),
+			raw:       raw,
 		})
 
 		for _, m := range msgs {
 			m.entryIdx = entryIdx
 			m.timestamp = ts
-			// Prefer a real user turn over the generated title for topic.
-			// Replace only while topic is empty or still the summary title.
 			if entryType == "user" && m.contentType == "text" &&
 				m.isNoise == 0 && len(m.text) >= 10 && !isBoilerplate(m.text) &&
 				!isGrokInjectedContext(m.text) &&
@@ -198,6 +298,12 @@ func parseGrokFile(path string, offset int64) (parsedFile, error) {
 				}
 			}
 			pf.messages = append(pf.messages, m)
+		}
+
+		// Child spawn edge: record as message text; chain written at ingest.
+		if upd.SessionUpdate == "subagent_spawned" && upd.ChildSessionID != "" {
+			// parent is this session; child is successor
+			_ = parentID // summary parent is for this session as child
 		}
 	}
 
@@ -217,13 +323,74 @@ func parseGrokFile(path string, offset int64) (parsedFile, error) {
 		}
 	}
 
+	// Session-level usage snapshot (Grok-beyond-Claude: context window
+	// occupancy lives in signals.json, not per-turn usage).
+	// Only when parsing from the start so incremental tails don't double-count.
+	if offset == 0 && (sig.ContextTokensUsed > 0 || sig.ToolCallCount > 0) {
+		usageText := fmt.Sprintf(
+			"[grok signals] model=%s context_tokens=%d/%d turns=%d tools=%d compactions=%d git_commits=%d",
+			model, sig.ContextTokensUsed, sig.ContextWindowTokens,
+			sig.TurnCount, sig.ToolCallCount, sig.CompactionCount, sig.GitCommitCount,
+		)
+		// Put context tokens in input_tokens so usage rollups are non-zero;
+		// output_tokens left 0 (Grok does not split the same way).
+		uuid := fmt.Sprintf("grok-%s-signals-usage", pf.sessionID)
+		usageRaw, _ := json.Marshal(map[string]any{
+			"uuid": uuid,
+			"type": "assistant",
+			"message": map[string]any{
+				"model": model,
+				"usage": map[string]any{
+					"input_tokens":  sig.ContextTokensUsed,
+					"output_tokens": 0,
+				},
+			},
+			"source": "grok_signals",
+			"text":   usageText,
+		})
+		ts := time.Now().UTC().Format(time.RFC3339)
+		if len(pf.entries) > 0 && pf.entries[len(pf.entries)-1].timestamp != "" {
+			ts = pf.entries[len(pf.entries)-1].timestamp
+		}
+		entryIdx := len(pf.entries)
+		pf.entries = append(pf.entries, parsedRawEntry{
+			entryType: "assistant",
+			timestamp: ts,
+			raw:       usageRaw,
+		})
+		pf.messages = append(pf.messages, parsedMessage{
+			entryIdx: entryIdx, role: "assistant", typ: "assistant",
+			text: usageText, timestamp: ts, contentType: "text", isNoise: 1,
+		})
+	}
+
+	// Parent edge for forks/subagents — carried via synthetic note on pf.
+	// writeParsedFile doesn't know chains; ingestGrokFile writes them.
+	if parentID != "" {
+		pf.parentSessionID = parentID
+		pf.chainMechanism = "grok_parent"
+	}
+
 	pf.newOffset = consumed
-	pf.project = grokProject(pf.cwd)
+	if pf.project == "" || pf.project == "subagents" {
+		// project "subagents" for type classification; if we already set a
+		// remote-derived project, keep it only when not a subagent.
+		if isSubagent {
+			pf.project = "subagents"
+		} else if pf.project == "" {
+			pf.project = grokProject(pf.cwd)
+		}
+	} else if !isSubagent {
+		// remote-derived project already set
+	} else {
+		pf.project = "subagents"
+	}
+	// Stash model for callers (tests); already on entry raw.
+	pf.model = model
 	return pf, nil
 }
 
 // grokRecord maps one sessionUpdate to an entry type and messages.
-// ok=false means skip (unknown / intermediate / empty).
 func grokRecord(u *grokUpdate) (entryType string, msgs []parsedMessage, ok bool) {
 	switch u.SessionUpdate {
 	case "user_message_chunk":
@@ -269,7 +436,6 @@ func grokRecord(u *grokUpdate) (entryType string, msgs []parsedMessage, ok bool)
 		}}, true
 
 	case "tool_call_update":
-		// Only completed updates carry the result body.
 		if u.Status != "completed" {
 			return "", nil, false
 		}
@@ -277,27 +443,99 @@ func grokRecord(u *grokUpdate) (entryType string, msgs []parsedMessage, ok bool)
 			role: "user", typ: "user", contentType: "tool_result",
 			toolUseID: u.ToolCallID, text: grokToolResultText(u),
 		}}, true
+
+	// --- Beyond Claude: first-class Grok / ACP signals ---
+
+	case "session_recap":
+		if strings.TrimSpace(u.Summary) == "" {
+			return "", nil, false
+		}
+		prefix := "[grok recap]"
+		if u.Auto {
+			prefix = "[grok recap auto]"
+		}
+		return "assistant", []parsedMessage{{
+			role: "assistant", typ: "assistant", contentType: "text",
+			text: prefix + " " + u.Summary,
+		}}, true
+
+	case "plan":
+		text := grokPlanText(u.Entries)
+		if text == "" {
+			return "", nil, false
+		}
+		return "assistant", []parsedMessage{{
+			role: "assistant", typ: "assistant", contentType: "text",
+			text: "[grok plan]\n" + text,
+		}}, true
+
+	case "goal_updated":
+		// Grok goals have no Claude analogue — index as durable progress text.
+		if u.Objective == "" && u.GoalID == "" {
+			return "", nil, false
+		}
+		text := fmt.Sprintf("[grok goal] id=%s objective=%s status=%s phase=%s",
+			u.GoalID, u.Objective, u.Status, u.Phase)
+		return "assistant", []parsedMessage{{
+			role: "assistant", typ: "assistant", contentType: "text",
+			text: text, isNoise: 0,
+		}}, true
+
+	case "subagent_spawned":
+		text := fmt.Sprintf("[grok subagent spawned] child=%s type=%s desc=%s parent=%s",
+			u.ChildSessionID, u.SubagentType, u.Description, u.ParentSessionID)
+		return "assistant", []parsedMessage{{
+			role: "assistant", typ: "assistant", contentType: "text",
+			text: text, isNoise: 1,
+		}}, true
+
+	case "subagent_finished":
+		text := fmt.Sprintf("[grok subagent finished] child=%s status=%s duration_ms=%d tokens=%d output=%s",
+			u.ChildSessionID, u.Status, u.DurationMS, u.TokensUsed, truncateRunes(u.Output, 200))
+		return "assistant", []parsedMessage{{
+			role: "assistant", typ: "assistant", contentType: "text",
+			text: text, isNoise: 1,
+		}}, true
+
+	case "task_completed":
+		text := grokTaskCompletedText(u.TaskSnapshot)
+		if text == "" {
+			return "", nil, false
+		}
+		return "user", []parsedMessage{{
+			role: "user", typ: "user", contentType: "tool_result",
+			text: text, isNoise: 0,
+		}}, true
+
+	case "auto_compact_started", "auto_compact_completed", "compaction_checkpoint":
+		text := fmt.Sprintf("[grok compact] %s before=%d after=%d reason=%s",
+			u.SessionUpdate, u.TokensBefore, u.TokensAfter, u.Reason)
+		return "assistant", []parsedMessage{{
+			role: "assistant", typ: "assistant", contentType: "thinking",
+			text: text, isNoise: 1,
+		}}, true
+
+	case "hook_execution", "turn_completed", "task_backgrounded",
+		"available_commands_update", "current_mode_update",
+		"retry_state", "image_compressed", "rewind_marker":
+		return "", nil, false
 	}
 	return "", nil, false
 }
 
-// isGrokInjectedContext reports system/reminder/synthetic user chunks
-// that should not become the session topic.
 func isGrokInjectedContext(text string) bool {
 	t := strings.TrimSpace(text)
 	return strings.HasPrefix(t, "<system-reminder>") ||
 		strings.HasPrefix(t, "<user_info>") ||
 		strings.HasPrefix(t, "<git_status>") ||
 		strings.HasPrefix(t, "The user sent a message while you were working:") ||
-		strings.Contains(t, "Background task \"") && strings.Contains(t, "completed")
+		(strings.Contains(t, "Background task \"") && strings.Contains(t, "completed"))
 }
 
-// grokContentText extracts text from an ACP content object or array.
 func grokContentText(raw json.RawMessage) string {
 	if len(raw) == 0 {
 		return ""
 	}
-	// {"type":"text","text":"..."}
 	var obj struct {
 		Type string `json:"type"`
 		Text string `json:"text"`
@@ -305,7 +543,6 @@ func grokContentText(raw json.RawMessage) string {
 	if json.Unmarshal(raw, &obj) == nil && obj.Text != "" {
 		return obj.Text
 	}
-	// plain string
 	var s string
 	if json.Unmarshal(raw, &s) == nil {
 		return s
@@ -313,7 +550,6 @@ func grokContentText(raw json.RawMessage) string {
 	return ""
 }
 
-// grokToolName prefers _meta["x.ai/tool"].name, then title.
 func grokToolName(u *grokUpdate) string {
 	if len(u.Meta) > 0 {
 		var meta map[string]json.RawMessage
@@ -328,30 +564,32 @@ func grokToolName(u *grokUpdate) string {
 			}
 		}
 	}
-	return u.Title
+	// Titles sometimes look like "Execute `…`" — prefer bare name when meta missing.
+	t := strings.TrimSpace(u.Title)
+	if strings.HasPrefix(t, "Execute ") || strings.HasPrefix(t, "Search tools:") {
+		return t
+	}
+	return t
 }
 
-// grokToolInput resolves rawInput to tool_input JSON bytes and/or text.
 func grokToolInput(raw json.RawMessage) (toolInput []byte, text string) {
 	if len(raw) == 0 {
 		return nil, ""
 	}
 	if isJSONObject(raw) {
-		return append([]byte(nil), raw...), ""
+		return normalizeAgentToolInput(raw), ""
 	}
 	var s string
 	if json.Unmarshal(raw, &s) == nil {
 		if isJSONObject([]byte(s)) {
-			return []byte(s), ""
+			return normalizeAgentToolInput([]byte(s)), ""
 		}
 		return nil, s
 	}
 	return nil, string(raw)
 }
 
-// grokToolResultText flattens a completed tool_call_update's body.
 func grokToolResultText(u *grokUpdate) string {
-	// Prefer nested content: [{type:"content", content:{type:"text", text:"..."}}]
 	if len(u.Content) > 0 {
 		var blocks []struct {
 			Type    string `json:"type"`
@@ -387,7 +625,6 @@ func grokToolResultText(u *grokUpdate) string {
 	if len(u.RawOutput) == 0 {
 		return ""
 	}
-	// rawOutput may be {"type":"...","content":"..."} or a string.
 	var obj struct {
 		Content string `json:"content"`
 	}
@@ -401,13 +638,55 @@ func grokToolResultText(u *grokUpdate) string {
 	return string(u.RawOutput)
 }
 
-// grokTimestamp normalises a unix-seconds number or RFC3339 string to
-// RFC3339. Falls back to now when unparseable.
+func grokPlanText(entries json.RawMessage) string {
+	if len(entries) == 0 {
+		return ""
+	}
+	var items []struct {
+		Content  string `json:"content"`
+		Priority string `json:"priority"`
+		Status   string `json:"status"`
+	}
+	if json.Unmarshal(entries, &items) != nil {
+		return string(entries)
+	}
+	var b strings.Builder
+	for _, it := range items {
+		if it.Content == "" {
+			continue
+		}
+		fmt.Fprintf(&b, "- [%s] %s (%s)\n", it.Status, it.Content, it.Priority)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func grokTaskCompletedText(snap json.RawMessage) string {
+	if len(snap) == 0 {
+		return ""
+	}
+	var s struct {
+		TaskID      string `json:"task_id"`
+		Command     string `json:"command"`
+		ExitCode    *int   `json:"exit_code"`
+		Output      string `json:"output"`
+		Description string `json:"description"`
+	}
+	if json.Unmarshal(snap, &s) != nil {
+		return "[grok task completed] " + string(snap)
+	}
+	code := "?"
+	if s.ExitCode != nil {
+		code = strconv.Itoa(*s.ExitCode)
+	}
+	out := truncateRunes(s.Output, 500)
+	return fmt.Sprintf("[grok task completed] id=%s exit=%s desc=%s cmd=%s\n%s",
+		s.TaskID, code, s.Description, s.Command, out)
+}
+
 func grokTimestamp(raw json.RawMessage) string {
 	if len(raw) == 0 {
 		return time.Now().UTC().Format(time.RFC3339)
 	}
-	// numeric unix seconds (possibly fractional)
 	var n json.Number
 	if json.Unmarshal(raw, &n) == nil {
 		if i, err := n.Int64(); err == nil {
@@ -424,7 +703,6 @@ func grokTimestamp(raw json.RawMessage) string {
 		if _, err := time.Parse(time.RFC3339, s); err == nil {
 			return s
 		}
-		// bare integer as string
 		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
 			return time.Unix(i, 0).UTC().Format(time.RFC3339)
 		}
@@ -432,14 +710,78 @@ func grokTimestamp(raw json.RawMessage) string {
 	return time.Now().UTC().Format(time.RFC3339)
 }
 
-// injectSyntheticUUID returns the JSONL line with a synthetic "uuid"
-// field inserted after the opening brace (Codex + Grok share this need).
+// enrichGrokRaw injects uuid + Claude-shaped message.model/usage so the
+// entries table generated columns (model, input_tokens, …) populate.
+func enrichGrokRaw(line []byte, uuid, model string, inTok, outTok int) []byte {
+	var m map[string]any
+	if json.Unmarshal(line, &m) != nil {
+		return injectSyntheticUUID(line, uuid)
+	}
+	m["uuid"] = uuid
+	msg, _ := m["message"].(map[string]any)
+	if msg == nil {
+		msg = map[string]any{}
+	}
+	if model != "" {
+		msg["model"] = model
+	}
+	if inTok > 0 || outTok > 0 {
+		msg["usage"] = map[string]any{
+			"input_tokens":  inTok,
+			"output_tokens": outTok,
+		}
+	}
+	if len(msg) > 0 {
+		m["message"] = msg
+	}
+	out, err := json.Marshal(m)
+	if err != nil {
+		return injectSyntheticUUID(line, uuid)
+	}
+	return out
+}
+
+// repoFromRemote extracts org/repo from a git remote URL.
+func repoFromRemote(remote string) string {
+	r := strings.TrimSpace(remote)
+	r = strings.TrimSuffix(r, ".git")
+	// https://github.com/org/repo or ssh://git@github.com/org/repo
+	for _, prefix := range []string{
+		"https://github.com/", "http://github.com/",
+		"ssh://git@github.com/", "git://github.com/",
+	} {
+		if strings.HasPrefix(r, prefix) {
+			r = strings.TrimPrefix(r, prefix)
+			parts := strings.Split(r, "/")
+			if len(parts) >= 2 && parts[0] != "" && parts[1] != "" {
+				return parts[0] + "/" + parts[1]
+			}
+			return ""
+		}
+	}
+	// git@host:org/repo
+	if i := strings.Index(r, ":"); i >= 0 && strings.Contains(r[:i], "@") {
+		path := r[i+1:]
+		parts := strings.Split(path, "/")
+		if len(parts) >= 2 && parts[0] != "" && parts[1] != "" {
+			return parts[0] + "/" + parts[1]
+		}
+	}
+	return ""
+}
+
+func truncateRunes(s string, n int) string {
+	if n <= 0 || len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
 func injectSyntheticUUID(line []byte, uuid string) []byte {
 	return injectCodexUUID(line, uuid)
 }
 
-// ingestGrokFile ingests a single Grok updates.jsonl incrementally from
-// its recorded offset, reusing the shared writer.
+// ingestGrokFile ingests a single Grok updates.jsonl incrementally.
 func (s *Store) ingestGrokFile(path string) error {
 	s.mu.Lock()
 	offset := s.offsets[path]
@@ -472,4 +814,18 @@ func (s *Store) ingestGrokFile(path string) error {
 
 	ws.Close()
 	return ws.tx.Commit()
+}
+
+// fieldAfter pulls the next whitespace-delimited token after key in s.
+func fieldAfter(s, key string) string {
+	i := strings.Index(s, key)
+	if i < 0 {
+		return ""
+	}
+	rest := s[i+len(key):]
+	rest = strings.TrimSpace(rest)
+	if j := strings.IndexAny(rest, " \t\n"); j >= 0 {
+		return rest[:j]
+	}
+	return rest
 }

--- a/internal/store/grok_test.go
+++ b/internal/store/grok_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 const grokSessUUID = "019f4b93-3082-75f2-9c15-1aff0d5f2c3f"
+const grokParentUUID = "019f4b93-0000-0000-0000-000000000001"
 
-// grokFixtureLines returns a representative Grok updates.jsonl: user,
-// thought, assistant text, tool_call + completed tool_call_update,
-// plus records we must skip (_x.ai hooks, intermediate tool updates).
+// grokFixtureLines returns a representative Grok updates.jsonl covering
+// conversation core plus 🎯T111 extensions (recap, plan, goal, subagent).
 func grokFixtureLines(t *testing.T, sessionID string) []byte {
 	t.Helper()
 	line := func(method string, ts int64, update map[string]any) map[string]any {
@@ -50,7 +50,16 @@ func grokFixtureLines(t *testing.T, sessionID string) []byte {
 				"x.ai/tool": map[string]any{"name": "run_terminal_command", "kind": "execute"},
 			},
 		}),
-		// Intermediate update without status — must be skipped.
+		// read_file with Grok target_file alias → normalize to file_path
+		line("session/update", 1783679373, map[string]any{
+			"sessionUpdate": "tool_call",
+			"toolCallId":    "call-2",
+			"title":         "read_file",
+			"rawInput":      map[string]any{"target_file": "/tmp/auth.go", "limit": 50},
+			"_meta": map[string]any{
+				"x.ai/tool": map[string]any{"name": "read_file", "kind": "read"},
+			},
+		}),
 		line("session/update", 1783679372, map[string]any{
 			"sessionUpdate": "tool_call_update",
 			"toolCallId":    "call-1",
@@ -66,9 +75,44 @@ func grokFixtureLines(t *testing.T, sessionID string) []byte {
 			},
 			"rawOutput": map[string]any{"type": "Bash", "content": "PASS ok package"},
 		}),
+		line("session/update", 1783679381, map[string]any{
+			"sessionUpdate": "tool_call_update",
+			"toolCallId":    "call-2",
+			"status":        "completed",
+			"content": []map[string]any{
+				{"type": "content", "content": map[string]any{"type": "text", "text": "package auth"}},
+			},
+		}),
 		line("session/update", 1783679385, map[string]any{
 			"sessionUpdate": "agent_message_chunk",
 			"content":       map[string]any{"type": "text", "text": "Fixed the authentication bug in the login handler."},
+		}),
+		line("session/update", 1783679386, map[string]any{
+			"sessionUpdate": "plan",
+			"entries": []map[string]any{
+				{"content": "Inspect login handler", "priority": "high", "status": "completed"},
+				{"content": "Add regression test", "priority": "medium", "status": "pending"},
+			},
+		}),
+		line("_x.ai/session/update", 1783679387, map[string]any{
+			"sessionUpdate": "session_recap",
+			"summary":       "Fixed authentication bug and outlined a regression test.",
+			"auto":          true,
+		}),
+		line("_x.ai/session/update", 1783679388, map[string]any{
+			"sessionUpdate": "goal_updated",
+			"goal_id":       "goal-1",
+			"objective":     "T99",
+			"status":        "active",
+			"phase":         "executing",
+		}),
+		line("_x.ai/session/update", 1783679389, map[string]any{
+			"sessionUpdate":     "subagent_spawned",
+			"subagent_id":       "child-1",
+			"child_session_id":  "019f4b93-child-0000-0000-000000000002",
+			"parent_session_id": sessionID,
+			"subagent_type":     "general-purpose",
+			"description":       "verify fix",
 		}),
 		line("_x.ai/session/update", 1783679390, map[string]any{
 			"sessionUpdate": "turn_completed",
@@ -89,7 +133,6 @@ func grokFixtureLines(t *testing.T, sessionID string) []byte {
 
 func writeGrokSession(t *testing.T, root, cwd string) string {
 	t.Helper()
-	// Mirror layout: sessions/<encoded-cwd>/<session-id>/updates.jsonl
 	encoded := "%2FUsers%2Fdev%2Fwork%2Fgithub.com%2Facme%2Fwebapp"
 	dir := filepath.Join(root, "sessions", encoded, grokSessUUID)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -100,11 +143,14 @@ func writeGrokSession(t *testing.T, root, cwd string) string {
 			"id":  grokSessUUID,
 			"cwd": cwd,
 		},
-		"generated_title":  "Auth bug triage",
-		"session_summary":  "Auth bug triage",
-		"current_model_id": "grok-4.5",
-		"head_branch":      "main",
-		"git_remotes":      []string{"https://github.com/acme/webapp"},
+		"generated_title":   "Auth bug triage",
+		"session_summary":   "Auth bug triage",
+		"current_model_id":  "grok-4.5",
+		"head_branch":       "main",
+		"git_remotes":       []string{"https://github.com/acme/webapp.git"},
+		"parent_session_id": grokParentUUID,
+		"session_kind":      "subagent",
+		"agent_name":        "general-purpose",
 	}
 	sumRaw, err := json.Marshal(summary)
 	if err != nil {
@@ -113,7 +159,19 @@ func writeGrokSession(t *testing.T, root, cwd string) string {
 	if err := os.WriteFile(filepath.Join(dir, "summary.json"), sumRaw, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	// Sidecar that must NOT be ingested as Claude JSONL.
+	signals := map[string]any{
+		"contextTokensUsed":   12345,
+		"contextWindowTokens": 500000,
+		"primaryModelId":      "grok-4.5",
+		"toolCallCount":       2,
+		"turnCount":           1,
+		"compactionCount":     0,
+		"gitCommitCount":      0,
+	}
+	sigRaw, _ := json.Marshal(signals)
+	if err := os.WriteFile(filepath.Join(dir, "signals.json"), sigRaw, 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(dir, "events.jsonl"), []byte(`{"type":"noise"}\n`), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -138,72 +196,89 @@ func TestParseGrokFile(t *testing.T) {
 		t.Errorf("source = %q, want grok", pf.source)
 	}
 	if pf.sessionID != grokSessUUID {
-		t.Errorf("sessionID = %q, want %q", pf.sessionID, grokSessUUID)
+		t.Errorf("sessionID = %q", pf.sessionID)
 	}
 	if pf.cwd != cwd {
-		t.Errorf("cwd = %q, want %q", pf.cwd, cwd)
+		t.Errorf("cwd = %q", pf.cwd)
 	}
 	if pf.branch != "main" {
-		t.Errorf("branch = %q, want main", pf.branch)
+		t.Errorf("branch = %q", pf.branch)
 	}
-	if pf.project != "acme/webapp" {
-		t.Errorf("project = %q, want acme/webapp", pf.project)
+	// Subagent → project "subagents" for session_type trigger.
+	if pf.project != "subagents" {
+		t.Errorf("project = %q, want subagents", pf.project)
+	}
+	if pf.parentSessionID != grokParentUUID {
+		t.Errorf("parentSessionID = %q", pf.parentSessionID)
+	}
+	if pf.model != "grok-4.5" {
+		t.Errorf("model = %q", pf.model)
 	}
 	if !strings.Contains(pf.topic, "authentication bug") {
-		t.Errorf("topic = %q, want first user message (not summary title)", pf.topic)
+		t.Errorf("topic = %q", pf.topic)
 	}
 
-	// user, thought, tool_call, tool_result, assistant = 5 entries.
-	// hook_execution, intermediate tool_call_update, turn_completed skipped.
-	if len(pf.entries) != 5 {
-		t.Fatalf("entries = %d, want 5", len(pf.entries))
+	// Model stamped on entry raw for generated columns.
+	var sawModel bool
+	for _, e := range pf.entries {
+		var raw map[string]any
+		if json.Unmarshal(e.raw, &raw) != nil {
+			continue
+		}
+		if msg, ok := raw["message"].(map[string]any); ok {
+			if msg["model"] == "grok-4.5" {
+				sawModel = true
+				break
+			}
+		}
 	}
-	if len(pf.messages) != 5 {
-		t.Fatalf("messages = %d, want 5", len(pf.messages))
+	if !sawModel {
+		t.Error("expected message.model=grok-4.5 on at least one entry")
 	}
 
-	var first map[string]any
-	if err := json.Unmarshal(pf.entries[0].raw, &first); err != nil {
-		t.Fatalf("entry raw not valid JSON: %v", err)
-	}
-	if uuid, _ := first["uuid"].(string); !strings.HasPrefix(uuid, "grok-"+grokSessUUID+"-") {
-		t.Errorf("entry uuid = %v, want grok-<session>-<offset> prefix", first["uuid"])
-	}
-
-	byType := map[string][]parsedMessage{}
+	// Signals usage entry present.
+	var sawUsage bool
 	for _, m := range pf.messages {
-		byType[m.contentType] = append(byType[m.contentType], m)
-	}
-
-	var sawUser, sawAssistant bool
-	for _, m := range byType["text"] {
-		if m.role == "user" && strings.Contains(m.text, "authentication bug") {
-			sawUser = true
-		}
-		if m.role == "assistant" && strings.Contains(m.text, "Fixed the authentication") {
-			sawAssistant = true
+		if strings.HasPrefix(m.text, "[grok signals]") {
+			sawUsage = true
 		}
 	}
-	if !sawUser || !sawAssistant {
-		t.Errorf("missing user/assistant text (user=%v assistant=%v)", sawUser, sawAssistant)
+	if !sawUsage {
+		t.Error("expected [grok signals] usage message")
 	}
 
-	if th := byType["thinking"]; len(th) != 1 || !strings.Contains(th[0].text, "auth") {
-		t.Errorf("thinking = %+v", byType["thinking"])
+	// Tool input normalised: target_file → file_path
+	var sawReadFilePath bool
+	for _, m := range pf.messages {
+		if m.contentType == "tool_use" && m.toolName == "read_file" {
+			var in map[string]any
+			if json.Unmarshal(m.toolInput, &in) == nil && in["file_path"] == "/tmp/auth.go" {
+				sawReadFilePath = true
+			}
+		}
+	}
+	if !sawReadFilePath {
+		t.Error("read_file tool_input missing normalised file_path")
 	}
 
-	if tu := byType["tool_use"]; len(tu) != 1 ||
-		tu[0].toolName != "run_terminal_command" ||
-		tu[0].toolUseID != "call-1" ||
-		!json.Valid(tu[0].toolInput) ||
-		!strings.Contains(string(tu[0].toolInput), "go test") {
-		t.Errorf("tool_use malformed: %+v", byType["tool_use"])
+	// Recap / plan / goal indexed
+	var sawRecap, sawPlan, sawGoal, sawSpawn bool
+	for _, m := range pf.messages {
+		if strings.Contains(m.text, "[grok recap") {
+			sawRecap = true
+		}
+		if strings.Contains(m.text, "[grok plan]") {
+			sawPlan = true
+		}
+		if strings.Contains(m.text, "[grok goal]") {
+			sawGoal = true
+		}
+		if strings.Contains(m.text, "[grok subagent spawned]") {
+			sawSpawn = true
+		}
 	}
-
-	if rs := byType["tool_result"]; len(rs) != 1 ||
-		rs[0].toolUseID != "call-1" ||
-		!strings.Contains(rs[0].text, "PASS ok package") {
-		t.Errorf("tool_result = %+v", byType["tool_result"])
+	if !sawRecap || !sawPlan || !sawGoal || !sawSpawn {
+		t.Errorf("extensions missing recap=%v plan=%v goal=%v spawn=%v", sawRecap, sawPlan, sawGoal, sawSpawn)
 	}
 }
 
@@ -214,9 +289,6 @@ func TestIsGrokUpdates(t *testing.T) {
 	if isGrokUpdates("/x/sessions/y/events.jsonl") {
 		t.Error("events.jsonl must not match")
 	}
-	if isGrokUpdates("/x/rollout-foo.jsonl") {
-		t.Error("rollout must not match")
-	}
 }
 
 func TestGrokIngestEndToEnd(t *testing.T) {
@@ -224,7 +296,7 @@ func TestGrokIngestEndToEnd(t *testing.T) {
 	cwd := "/Users/dev/work/github.com/acme/webapp"
 	writeGrokSession(t, grokHome, cwd)
 
-	s := newTestStore(t, t.TempDir()) // empty Claude project dir
+	s := newTestStore(t, t.TempDir())
 	s.SetGrokRoots([]string{filepath.Join(grokHome, "sessions")})
 	if err := s.IngestAll(); err != nil {
 		t.Fatal(err)
@@ -238,31 +310,81 @@ func TestGrokIngestEndToEnd(t *testing.T) {
 		t.Fatalf("search did not surface the Grok session: %+v", results)
 	}
 
-	var source, repo string
+	// Recap searchable
+	if rec, err := s.Search("regression test", 5, "all", "", 0, 0, false); err != nil || len(rec) == 0 {
+		t.Fatalf("recap/plan not searchable: %v %+v", err, rec)
+	}
+
+	var source, repo, stype string
 	if err := s.readDB.QueryRow(
-		`SELECT source, repo FROM session_meta WHERE session_id = ?`, grokSessUUID,
-	).Scan(&source, &repo); err != nil {
-		t.Fatalf("session_meta query: %v", err)
+		`SELECT sm.source, sm.repo, ss.session_type
+		 FROM session_meta sm
+		 JOIN session_summary ss ON ss.session_id = sm.session_id
+		 WHERE sm.session_id = ?`, grokSessUUID,
+	).Scan(&source, &repo, &stype); err != nil {
+		t.Fatalf("session_meta: %v", err)
 	}
 	if source != "grok" {
-		t.Errorf("session_meta.source = %q, want grok", source)
+		t.Errorf("source = %q", source)
 	}
 	if repo != "acme/webapp" {
-		t.Errorf("session_meta.repo = %q, want acme/webapp", repo)
+		t.Errorf("repo = %q, want acme/webapp", repo)
+	}
+	if stype != "subagent" {
+		t.Errorf("session_type = %q, want subagent", stype)
 	}
 
+	// Model on assistant entries
+	var model string
+	if err := s.readDB.QueryRow(
+		`SELECT model FROM entries WHERE session_id = ? AND type = 'assistant' AND model IS NOT NULL AND model != '' LIMIT 1`,
+		grokSessUUID,
+	).Scan(&model); err != nil || model != "grok-4.5" {
+		t.Errorf("model = %q err=%v", model, err)
+	}
+
+	// Usage tokens from signals
+	var inTok int
+	if err := s.readDB.QueryRow(
+		`SELECT input_tokens FROM entries WHERE session_id = ? AND input_tokens > 0 LIMIT 1`,
+		grokSessUUID,
+	).Scan(&inTok); err != nil || inTok != 12345 {
+		t.Errorf("input_tokens = %d err=%v, want 12345", inTok, err)
+	}
+
+	// tool_file_path from normalised target_file
+	var nPath int
+	if err := s.readDB.QueryRow(
+		`SELECT count(*) FROM messages WHERE session_id = ? AND tool_file_path = '/tmp/auth.go'`,
+		grokSessUUID,
+	).Scan(&nPath); err != nil || nPath < 1 {
+		t.Errorf("tool_file_path count = %d err=%v", nPath, err)
+	}
+
+	// Parent chain edge
+	var pred string
+	if err := s.readDB.QueryRow(
+		`SELECT predecessor_id FROM session_chains WHERE successor_id = ?`, grokSessUUID,
+	).Scan(&pred); err != nil || pred != grokParentUUID {
+		t.Errorf("chain predecessor = %q err=%v", pred, err)
+	}
+
+	// Subagent spawn chain
+	var spawnPred string
+	if err := s.readDB.QueryRow(
+		`SELECT predecessor_id FROM session_chains WHERE successor_id = ? AND mechanism = 'grok_subagent'`,
+		"019f4b93-child-0000-0000-000000000002",
+	).Scan(&spawnPred); err != nil || spawnPred != grokSessUUID {
+		t.Errorf("subagent chain pred = %q err=%v", spawnPred, err)
+	}
+
+	// Idempotency
 	entryCount := func() int {
 		var n int
-		if err := s.readDB.QueryRow(`SELECT count(*) FROM entries WHERE session_id = ?`, grokSessUUID).Scan(&n); err != nil {
-			t.Fatalf("count query: %v", err)
-		}
+		_ = s.readDB.QueryRow(`SELECT count(*) FROM entries WHERE session_id = ?`, grokSessUUID).Scan(&n)
 		return n
 	}
-	if got := entryCount(); got != 5 {
-		t.Fatalf("entries after ingest = %d, want 5", got)
-	}
-
-	// Idempotency: re-ingest must not duplicate.
+	before := entryCount()
 	s.mu.Lock()
 	for p := range s.offsets {
 		s.offsets[p] = 0
@@ -272,27 +394,16 @@ func TestGrokIngestEndToEnd(t *testing.T) {
 	if err := s.ingestGrokFile(path); err != nil {
 		t.Fatal(err)
 	}
-	if got := entryCount(); got != 5 {
-		t.Errorf("entries after re-ingest = %d, want 5 (dedup)", got)
-	}
-
-	// Sidecar events.jsonl must not create a second session or garbage.
-	var nSessions int
-	if err := s.readDB.QueryRow(`SELECT count(*) FROM session_meta WHERE source = 'grok'`).Scan(&nSessions); err != nil {
-		t.Fatal(err)
-	}
-	if nSessions != 1 {
-		t.Errorf("grok sessions = %d, want 1 (sidecars skipped)", nSessions)
+	if got := entryCount(); got != before {
+		t.Errorf("entries after re-ingest = %d, want %d", got, before)
 	}
 }
 
-func TestGrokTimestamp(t *testing.T) {
-	ts := grokTimestamp(json.RawMessage(`1783679368`))
-	if !strings.HasPrefix(ts, "2026-") {
-		t.Errorf("unix timestamp = %q, want 2026-… RFC3339", ts)
+func TestRepoFromRemote(t *testing.T) {
+	if g := repoFromRemote("git@github.com:acme/webapp.git"); g != "acme/webapp" {
+		t.Errorf("ssh remote = %q", g)
 	}
-	ts2 := grokTimestamp(json.RawMessage(`"2026-07-10T12:00:00Z"`))
-	if ts2 != "2026-07-10T12:00:00Z" {
-		t.Errorf("rfc3339 passthrough = %q", ts2)
+	if g := repoFromRemote("https://github.com/acme/webapp.git"); g != "acme/webapp" {
+		t.Errorf("https remote = %q", g)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2847,6 +2847,13 @@ type parsedFile struct {
 	// source is the producing agent ('claude', 'codex', or 'grok').
 	// Empty means 'claude' (the default for ~/.claude/projects transcripts).
 	source string
+	// parentSessionID + chainMechanism, when set, cause writeParsedFile
+	// to record a session_chains edge (Grok forks/subagents, 🎯T111).
+	parentSessionID string
+	chainMechanism  string
+	// model is the primary model stamp (Grok summary / signals); also
+	// embedded in entry raw for generated columns.
+	model string
 }
 
 // IngestAll scans the project directory and ingests all JSONL files
@@ -3119,6 +3126,18 @@ func (s *Store) runWriter(parsedCh <-chan parsedFile, totalFiles int) error {
 // through identical insert logic. Best-effort: individual insert
 // failures are logged, not propagated, matching the original loop.
 func (s *Store) writeParsedFile(ws *writerState, pf parsedFile) {
+	// Grok session-level usage rows use a stable uuid and must refresh when
+	// signals.json grows; delete any prior copy so INSERT OR IGNORE can land.
+	if pf.source == "grok" {
+		usageUUID := fmt.Sprintf("grok-%s-signals-usage", pf.sessionID)
+		_, _ = ws.tx.Exec(`
+			DELETE FROM messages WHERE session_id = ? AND text LIKE '[grok signals]%'`,
+			pf.sessionID)
+		_, _ = ws.tx.Exec(`
+			DELETE FROM entries WHERE session_id = ? AND raw->>'$.uuid' = ?`,
+			pf.sessionID, usageUUID)
+	}
+
 	// Insert all raw entries and build entryIdx→entryID map.
 	// INSERT OR IGNORE skips duplicate (session_id, uuid) pairs, so
 	// only record the entry ID when a row was actually inserted.
@@ -3168,6 +3187,11 @@ func (s *Store) writeParsedFile(ws *writerState, pf parsedFile) {
 	// Upsert session metadata.
 	if pf.cwd != "" || pf.branch != "" || pf.topic != "" || compactorInternal == 1 || pf.source != "" {
 		repo := extractRepo(pf.cwd)
+		// Grok may set project to org/repo from git remotes when cwd is opaque.
+		if repo == "" && pf.project != "" && pf.project != "subagents" &&
+			pf.project != "grok" && strings.Contains(pf.project, "/") {
+			repo = pf.project
+		}
 		workType := classifyWorkType(pf.branch)
 		source := pf.source
 		if source == "" {
@@ -3184,6 +3208,33 @@ func (s *Store) writeParsedFile(ws *writerState, pf parsedFile) {
 				compactor_internal = MAX(session_meta.compactor_internal, excluded.compactor_internal),
 				source = CASE WHEN excluded.source != '' THEN excluded.source ELSE session_meta.source END`,
 			pf.sessionID, repo, pf.cwd, pf.branch, workType, pf.topic, compactorInternal, source)
+
+	// Parent/fork and subagent edges (Grok summary + spawn events, 🎯T111).
+	if pf.parentSessionID != "" && pf.sessionID != "" {
+		mech := pf.chainMechanism
+		if mech == "" {
+			mech = "grok_parent"
+		}
+		_, _ = ws.tx.Exec(`
+			INSERT OR IGNORE INTO session_chains
+				(successor_id, predecessor_id, boundary, gap_ms, confidence, mechanism)
+			VALUES (?, ?, 'fork', 0, 'high', ?)`,
+			pf.sessionID, pf.parentSessionID, mech)
+	}
+	for _, m := range pf.messages {
+		if m.contentType != "text" || !strings.HasPrefix(m.text, "[grok subagent spawned]") {
+			continue
+		}
+		child := fieldAfter(m.text, "child=")
+		if child == "" || pf.sessionID == "" {
+			continue
+		}
+		_, _ = ws.tx.Exec(`
+			INSERT OR IGNORE INTO session_chains
+				(successor_id, predecessor_id, boundary, gap_ms, confidence, mechanism)
+			VALUES (?, ?, 'subagent', 0, 'high', 'grok_subagent')`,
+			child, pf.sessionID)
+	}
 	}
 
 	// Update ingest offset + fingerprint (🎯T68.6 same-size

--- a/internal/store/tool_input.go
+++ b/internal/store/tool_input.go
@@ -1,0 +1,48 @@
+// Shared tool-input normalisation for non-Claude agents (🎯T111).
+// Claude stores tool_use.input with file_path / command keys that feed
+// generated columns (tool_file_path, tool_command). Grok (and others)
+// use target_file / path / cmd. Normalise before jsonb() so who_ran and
+// file-path queries work across sources.
+package store
+
+import "encoding/json"
+
+// normalizeAgentToolInput rewrites common alias keys onto the Claude
+// vocabulary expected by messages.tool_* generated columns. Unknown
+// keys are preserved. Non-object inputs pass through unchanged.
+func normalizeAgentToolInput(raw []byte) []byte {
+	if len(raw) == 0 || !isJSONObject(raw) {
+		return raw
+	}
+	var m map[string]any
+	if json.Unmarshal(raw, &m) != nil || m == nil {
+		return raw
+	}
+	changed := false
+	if _, ok := m["file_path"]; !ok {
+		for _, alias := range []string{"target_file", "path", "filePath"} {
+			if v, ok := m[alias]; ok && v != nil && v != "" {
+				m["file_path"] = v
+				changed = true
+				break
+			}
+		}
+	}
+	if _, ok := m["command"]; !ok {
+		for _, alias := range []string{"cmd", "shell_command"} {
+			if v, ok := m[alias]; ok && v != nil && v != "" {
+				m["command"] = v
+				changed = true
+				break
+			}
+		}
+	}
+	if !changed {
+		return raw
+	}
+	out, err := json.Marshal(m)
+	if err != nil {
+		return raw
+	}
+	return out
+}

--- a/internal/store/tool_input_test.go
+++ b/internal/store/tool_input_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeAgentToolInput(t *testing.T) {
+	in := []byte(`{"target_file":"/tmp/a.go","limit":10}`)
+	out := normalizeAgentToolInput(in)
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["file_path"] != "/tmp/a.go" {
+		t.Errorf("file_path = %v, want /tmp/a.go", m["file_path"])
+	}
+	if m["target_file"] != "/tmp/a.go" {
+		t.Errorf("original target_file should be preserved, got %v", m["target_file"])
+	}
+
+	// command alias
+	in2 := []byte(`{"cmd":"go test"}`)
+	out2 := normalizeAgentToolInput(in2)
+	var m2 map[string]any
+	_ = json.Unmarshal(out2, &m2)
+	if m2["command"] != "go test" {
+		t.Errorf("command = %v", m2["command"])
+	}
+
+	// already has file_path — no clobber
+	in3 := []byte(`{"file_path":"/a","target_file":"/b"}`)
+	out3 := normalizeAgentToolInput(in3)
+	var m3 map[string]any
+	_ = json.Unmarshal(out3, &m3)
+	if m3["file_path"] != "/a" {
+		t.Errorf("should keep existing file_path, got %v", m3["file_path"])
+	}
+}

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.61.0"
+	version              = "0.62.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 


### PR DESCRIPTION
## Summary

Deepens Grok transcript ingest beyond the T110 MVP so searchable metadata density approaches Claude where the format allows (🎯T111):

- Tool input aliases (`target_file`/`path` → `file_path`) shared with Codex
- Model stamp + session-level usage from `signals.json`
- Subagent session_type + parent/subagent `session_chains`
- Searchable recaps, plans, goals, task completions
- Design note updated

## Release

Prep for **v0.62.0**.

## Test plan

- [x] `go test -tags sqlite_fts5 ./...`
- [ ] CI green (ubuntu)
- [ ] `scripts/win-validate.sh`
