### PR TITLE
Auto-upgrade hot-reload, 5m idle default, Windows flake fix

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -3781,7 +3781,7 @@ targets:
     actual_cost: 8.0
     acceptance:
     - auto_upgrade.enabled gates the apply path; default off (detection/notification stay on).
-    - When enabled and a newer release is detected, after 30 min of MCP traffic quiescence the daemon runs a detached `brew upgrade mnemo`, spawns the new backend, routes new sessions to it, and drains+checkpoints+reaps the old backend.
+    - When enabled and a newer release is detected, after 5 min of MCP traffic quiescence (auto_upgrade.quiescence, default 5m) the daemon runs a detached `brew upgrade mnemo`, spawns the new backend, routes new sessions to it, and drains+checkpoints+reaps the old backend.
     - Throughout the swap an existing connected session keeps working without /mcp.
     - Installs not managed by Homebrew degrade to notify-only.
     context: |-

--- a/docs/design/connection-preserving-upgrade.md
+++ b/docs/design/connection-preserving-upgrade.md
@@ -69,7 +69,7 @@ upgrade.
 |-----|---------|---------|
 | `disable_upgrade_check` | `false` | When true, no `gh release list` calls; `upgrade.available` stays healthy |
 | `auto_upgrade.enabled` | `false` | Opt-in apply after quiescence (Homebrew non-Windows only) |
-| `auto_upgrade.quiescence` | `"30m"` | MCP idle window before apply |
+| `auto_upgrade.quiescence` | `"5m"` | MCP idle window before apply |
 
 Non-Homebrew and Windows installs are **notify-only** even when
 `auto_upgrade.enabled` is true: detection and `upgrade.available` still

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -168,14 +168,14 @@ type AutoUpgradeConfig struct {
 	Enabled bool `json:"enabled,omitempty"`
 
 	// Quiescence is how long MCP traffic must be idle before apply
-	// (Go duration string). Empty → "30m".
+	// (Go duration string). Empty → "5m".
 	Quiescence string `json:"quiescence,omitempty"`
 }
 
-// EffectiveQuiescence returns the parsed idle window or 30m.
+// EffectiveQuiescence returns the parsed idle window or 5m.
 func (a AutoUpgradeConfig) EffectiveQuiescence() (time.Duration, error) {
 	if a.Quiescence == "" {
-		return 30 * time.Minute, nil
+		return 5 * time.Minute, nil
 	}
 	d, err := time.ParseDuration(a.Quiescence)
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3209,32 +3209,32 @@ func (s *Store) writeParsedFile(ws *writerState, pf parsedFile) {
 				source = CASE WHEN excluded.source != '' THEN excluded.source ELSE session_meta.source END`,
 			pf.sessionID, repo, pf.cwd, pf.branch, workType, pf.topic, compactorInternal, source)
 
-	// Parent/fork and subagent edges (Grok summary + spawn events, 🎯T111).
-	if pf.parentSessionID != "" && pf.sessionID != "" {
-		mech := pf.chainMechanism
-		if mech == "" {
-			mech = "grok_parent"
-		}
-		_, _ = ws.tx.Exec(`
+		// Parent/fork and subagent edges (Grok summary + spawn events, 🎯T111).
+		if pf.parentSessionID != "" && pf.sessionID != "" {
+			mech := pf.chainMechanism
+			if mech == "" {
+				mech = "grok_parent"
+			}
+			_, _ = ws.tx.Exec(`
 			INSERT OR IGNORE INTO session_chains
 				(successor_id, predecessor_id, boundary, gap_ms, confidence, mechanism)
 			VALUES (?, ?, 'fork', 0, 'high', ?)`,
-			pf.sessionID, pf.parentSessionID, mech)
-	}
-	for _, m := range pf.messages {
-		if m.contentType != "text" || !strings.HasPrefix(m.text, "[grok subagent spawned]") {
-			continue
+				pf.sessionID, pf.parentSessionID, mech)
 		}
-		child := fieldAfter(m.text, "child=")
-		if child == "" || pf.sessionID == "" {
-			continue
-		}
-		_, _ = ws.tx.Exec(`
+		for _, m := range pf.messages {
+			if m.contentType != "text" || !strings.HasPrefix(m.text, "[grok subagent spawned]") {
+				continue
+			}
+			child := fieldAfter(m.text, "child=")
+			if child == "" || pf.sessionID == "" {
+				continue
+			}
+			_, _ = ws.tx.Exec(`
 			INSERT OR IGNORE INTO session_chains
 				(successor_id, predecessor_id, boundary, gap_ms, confidence, mechanism)
 			VALUES (?, ?, 'subagent', 0, 'high', 'grok_subagent')`,
-			child, pf.sessionID)
-	}
+				child, pf.sessionID)
+		}
 	}
 
 	// Update ingest offset + fingerprint (🎯T68.6 same-size

--- a/internal/upgrade/autoapply.go
+++ b/internal/upgrade/autoapply.go
@@ -12,7 +12,10 @@ import (
 )
 
 // DefaultQuiescence is the MCP-idle window before auto-apply (🎯T97.5).
-const DefaultQuiescence = 30 * time.Minute
+// Short on purpose: clients (Claude sticky sessions, Grok reconnect)
+// recover quickly from a brew services restart, so waiting half an
+// hour mainly delays the upgrade without much benefit.
+const DefaultQuiescence = 5 * time.Minute
 
 // ApplyEnv describes install environment constraints for auto-apply.
 type ApplyEnv struct {

--- a/internal/upgrade/autoapply.go
+++ b/internal/upgrade/autoapply.go
@@ -148,6 +148,17 @@ func (o *Orchestrator) SetEnabled(enabled bool) {
 	}
 }
 
+// SetQuiescence updates the MCP-idle window (config hot-reload).
+// Non-positive values keep the current setting.
+func (o *Orchestrator) SetQuiescence(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.quiescence = d
+}
+
 // Phase returns the current state machine phase.
 func (o *Orchestrator) Phase() Phase {
 	o.mu.Lock()

--- a/internal/upgrade/drain_test.go
+++ b/internal/upgrade/drain_test.go
@@ -150,12 +150,24 @@ func TestWriteRouteFileAtomicReadable(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	// Concurrent readers must always get valid JSON.
+	// Concurrent readers must always get valid JSON when a read succeeds.
+	// On Windows, os.Rename of the destination can briefly deny ReadFile
+	// with a sharing violation; retry that — the invariant is "no partial
+	// JSON", not "every open succeeds mid-replace".
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		for i := 0; i < 50; i++ {
-			data, err := os.ReadFile(path)
+			var data []byte
+			var err error
+			for attempt := 0; attempt < 20; attempt++ {
+				data, err = os.ReadFile(path)
+				if err == nil {
+					break
+				}
+				// Sharing violation / exclusive lock during replace.
+				time.Sleep(time.Millisecond)
+			}
 			if err != nil {
 				t.Errorf("read: %v", err)
 				return

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.62.0"
+	version              = "0.63.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 

--- a/main.go
+++ b/main.go
@@ -826,9 +826,10 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	orchQuiescence, _ := cfg.AutoUpgrade.EffectiveQuiescence()
 	var spawnedBackendURL string
 	selfBackendURL := backendSelfURL(addr)
+	homebrewInstall := isHomebrewInstall()
 	autoOrch := upgrade.NewOrchestrator(&upgrade.OrchestratorArgs{
 		Enabled:    cfg.AutoUpgrade.Enabled,
-		Env:        upgrade.ApplyEnv{Homebrew: isHomebrewInstall(), GOOS: ""},
+		Env:        upgrade.ApplyEnv{Homebrew: homebrewInstall, GOOS: ""},
 		Quiescence: orchQuiescence,
 		Detector:   upgradeDetector,
 		LastActivity: func() time.Time {
@@ -929,6 +930,17 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 			}
 		},
 	})
+	if cfg.AutoUpgrade.Enabled {
+		mode := "notify_only"
+		if homebrewInstall {
+			mode = "brew_upgrade+services_restart"
+			if homeForLease != "" && upgrade.RouteConfigured(homeForLease) {
+				mode = "edge_affinity_drain"
+			}
+		}
+		slog.Info("auto-upgrade: armed",
+			"quiescence", orchQuiescence, "mode", mode, "phase", autoOrch.Phase())
+	}
 	go runAutoApplyLoop(ctx, autoOrch)
 
 	// Determine the default username — used when a request arrives
@@ -1089,7 +1101,7 @@ func runServe(ctx context.Context, addr, federatedAddr string) error {
 	// no daemon restart.
 	shimSup := newShimSupervisor()
 	shimSup.SetEnabled(cfg.MenuBarApp)
-	handler.SetConfigController(configController{reg: reg, shim: shimSup})
+	handler.SetConfigController(configController{reg: reg, shim: shimSup, autoOrch: autoOrch})
 
 	// Wire the self-diagnostics registry into mnemo_doctor (🎯T83) — the
 	// same registry that backs the /health endpoint and the scheduler.
@@ -1470,8 +1482,9 @@ func (a compactorAdapter) Health() tools.CompactorHealth {
 // importing the tools package (a cycle we already avoid for
 // dependency hygiene).
 type configController struct {
-	reg  *registry.Registry
-	shim *shimSupervisor
+	reg      *registry.Registry
+	shim     *shimSupervisor
+	autoOrch *upgrade.Orchestrator
 }
 
 func (c configController) Get() store.Config {
@@ -1479,6 +1492,7 @@ func (c configController) Get() store.Config {
 }
 
 func (c configController) Put(newCfg store.Config) (tools.ConfigReport, error) {
+	old := c.reg.CurrentConfig()
 	if err := store.WriteConfig(newCfg); err != nil {
 		return tools.ConfigReport{}, err
 	}
@@ -1487,6 +1501,20 @@ func (c configController) Put(newCfg store.Config) (tools.ConfigReport, error) {
 	// without a daemon restart (🎯T85.5).
 	if c.shim != nil {
 		c.shim.SetEnabled(newCfg.MenuBarApp)
+	}
+	// Adopt auto_upgrade live (enabled + quiescence). Apply still only
+	// runs on Homebrew non-Windows installs (orchestrator NotifyOnly).
+	if c.autoOrch != nil {
+		auChanged := old.AutoUpgrade.Enabled != newCfg.AutoUpgrade.Enabled ||
+			old.AutoUpgrade.Quiescence != newCfg.AutoUpgrade.Quiescence
+		if auChanged {
+			rep.Changed = append(rep.Changed, "auto_upgrade")
+			c.autoOrch.SetEnabled(newCfg.AutoUpgrade.Enabled)
+			if q, err := newCfg.AutoUpgrade.EffectiveQuiescence(); err == nil {
+				c.autoOrch.SetQuiescence(q)
+			}
+			rep.Adopted = append(rep.Adopted, "auto_upgrade")
+		}
 	}
 	return tools.ConfigReport{
 		Changed:         rep.Changed,


### PR DESCRIPTION
## Summary
- Hot-reload `auto_upgrade.enabled` / `quiescence` via `mnemo_config`; log `auto-upgrade: armed` at startup.
- Drop default auto-upgrade MCP idle window from 30m → **5m**.
- Fix Windows flake in `TestWriteRouteFileAtomicReadable`.
- gofmt `internal/store/store.go`.
- Bump version to **0.63.0** for release.

## Gates
- [x] Ubuntu CI green
- [x] `scripts/win-validate.sh` PASS (windows/arm64) on `ee254e9`

## Test plan
- [x] `go test -tags sqlite_fts5 ./internal/upgrade/`
- [x] `make bullseye`
- [x] win-validate