### PR TITLE
Bump version to 0.64.0 (T64.2 vault_layout)

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.63.0"
+	version              = "0.64.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 


### PR DESCRIPTION
## Summary
Version bump to **0.64.0** for the T64.2 vault_layout / `_mnemo/` namespace release (already on master via #148).

## Test plan
- [x] version string only
