### PR TITLE
🎯T64.3+T64.4: vault wing MVP (decisions/memories + quiet v2)

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2286,7 +2286,7 @@ targets:
     achieved: 2026-07-13
   T64.3:
     name: Move decisions + memories under _mnemo/
-    status: identified
+    status: achieved
     value: 2.0
     cost: 0.0
     set_aside_reason: 'Leak-containment for the T64.2 ownership exclusion. Downstream of 🎯T64.2 (externally-owned, open PR #112). T64.2''s _mnemo/ namespace foundation is NOT on master, so this is not actually actionable — bullseye mechanically unblocked it only because set_aside(T64.2) is treated like achievement. Excluded to keep Marcelo''s frontier honest. REVIVE together with T64.2 (status→identified) when ownership returns / #112 lands.'
@@ -2300,9 +2300,10 @@ targets:
     - T64.2
     origin: PR
     discovered: 2026-05-22
+    achieved: 2026-07-13
   T64.4:
     name: Drop session/CI/PR/repo writers from _mnemo/
-    status: identified
+    status: achieved
     value: 1.0
     cost: 0.0
     acceptance:
@@ -2314,6 +2315,7 @@ targets:
     - T64.3
     origin: PR
     discovered: 2026-05-22
+    achieved: 2026-07-13
   T64.5:
     name: PKM profile + auto-detect (mtime-based)
     status: identified

--- a/internal/vault/layout_mvp_test.go
+++ b/internal/vault/layout_mvp_test.go
@@ -1,0 +1,303 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package vault
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marcelocantos/mnemo/internal/store"
+	"github.com/marcelocantos/mnemo/internal/storetest"
+)
+
+// seedLayoutMVPStore builds a store with one session and one memory so
+// Sync exercises memory dual-write and raw-signal layout policy for real.
+func seedLayoutMVPStore(t *testing.T) *store.Store {
+	t.Helper()
+	projDir := t.TempDir()
+	storetest.WriteJSONL(t, projDir, "-Users-alice-dev-myapp", "sess-layout-mvp-01", []map[string]any{
+		storetest.MetaMsg("user",
+			"I propose we move decisions under _mnemo/decisions for the vault wing.",
+			"2026-05-10T10:00:00Z", "/Users/alice/dev/myapp", "main"),
+		storetest.Msg("assistant",
+			"Agreed — I'll put decisions under _mnemo/decisions.",
+			"2026-05-10T10:00:05Z"),
+		storetest.Msg("user",
+			"Yes, go ahead with that approach.",
+			"2026-05-10T10:00:10Z"),
+	})
+	memDir := filepath.Join(projDir, "-Users-alice-dev-myapp", "memory")
+	if err := os.MkdirAll(memDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	memBody := "---\nname: wing-layout\ndescription: vault wing layout note\n---\n\nKeep raw signal out of the wing.\n"
+	if err := os.WriteFile(filepath.Join(memDir, "wing-layout.md"), []byte(memBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := storetest.NewStore(t, projDir)
+	if err := s.IngestAll(); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if err := s.IngestMemories(); err != nil {
+		t.Fatalf("IngestMemories: %v", err)
+	}
+	return s
+}
+
+func syncWithLayout(t *testing.T, layout string) string {
+	t.Helper()
+	s := seedLayoutMVPStore(t)
+	vaultDir := t.TempDir()
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	exp, err := New(s, vaultDir, Options{
+		Layout:    layout,
+		StatePath: statePath,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	return vaultDir
+}
+
+func mustFindUnder(t *testing.T, root, prefix string) []string {
+	t.Helper()
+	var hits []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		rel, _ := filepath.Rel(root, path)
+		sl := filepath.ToSlash(rel)
+		if strings.HasPrefix(sl, prefix) && strings.HasSuffix(sl, ".md") {
+			hits = append(hits, sl)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hits
+}
+
+func TestDecisionPathsForLayout(t *testing.T) {
+	d := store.DecisionInfo{SessionID: "abcdef012345", Repo: "myapp", Timestamp: "2026-05-10T10:00:00Z"}
+	v1 := filepath.ToSlash(decisionPath(d))
+	v2 := filepath.ToSlash(decisionPathV2(d))
+	if !strings.HasPrefix(v1, "decisions/") {
+		t.Fatalf("v1 path: %s", v1)
+	}
+	if !strings.HasPrefix(v2, "_mnemo/decisions/") {
+		t.Fatalf("v2 path: %s", v2)
+	}
+	cases := []struct {
+		layout string
+		want   []string
+	}{
+		{store.VaultLayoutV1, []string{v1}},
+		{store.VaultLayoutBoth, []string{v1, v2}},
+		{store.VaultLayoutV2, []string{v2}},
+		{"", []string{v2}},
+	}
+	for _, tc := range cases {
+		got := decisionPathsForLayout(tc.layout, d)
+		if len(got) != len(tc.want) {
+			t.Fatalf("layout %q: got %v want %v", tc.layout, got, tc.want)
+		}
+		for i := range got {
+			if filepath.ToSlash(got[i]) != tc.want[i] {
+				t.Errorf("layout %q [%d]: got %q want %q", tc.layout, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+func TestMemoryPathsForLayout(t *testing.T) {
+	m := store.MemoryInfo{Project: "myapp", Name: "wing-layout"}
+	got := memoryPathsForLayout(store.VaultLayoutBoth, m)
+	if len(got) != 2 {
+		t.Fatalf("both: got %v", got)
+	}
+	if !strings.HasPrefix(filepath.ToSlash(got[0]), "memories/") {
+		t.Errorf("v1 path: %s", got[0])
+	}
+	if !strings.HasPrefix(filepath.ToSlash(got[1]), "_mnemo/memories/") {
+		t.Errorf("v2 path: %s", got[1])
+	}
+}
+
+func TestSyncV2WritesWingMemoriesSuppressesRawSignal(t *testing.T) {
+	vaultDir := syncWithLayout(t, store.VaultLayoutV2)
+
+	if _, err := os.Stat(filepath.Join(vaultDir, "_mnemo", "index.md")); err != nil {
+		t.Fatalf("expected _mnemo/index.md: %v", err)
+	}
+
+	for _, prefix := range []string{"sessions/", "ci/", "prs/", "repos/"} {
+		if hits := mustFindUnder(t, vaultDir, prefix); len(hits) > 0 {
+			t.Errorf("v2 must not write %s: %v", prefix, hits)
+		}
+	}
+	// v1 roots must stay empty.
+	if hits := mustFindUnder(t, vaultDir, "decisions/"); len(hits) > 0 {
+		t.Errorf("v2 leaked v1 decisions/: %v", hits)
+	}
+	if hits := mustFindUnder(t, vaultDir, "memories/"); len(hits) > 0 {
+		t.Errorf("v2 leaked v1 memories/: %v", hits)
+	}
+
+	memHits := mustFindUnder(t, vaultDir, "_mnemo/memories/")
+	if len(memHits) == 0 {
+		t.Fatal("expected at least one _mnemo/memories note")
+	}
+	body, err := os.ReadFile(filepath.Join(vaultDir, memHits[0]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(body)
+	for _, needle := range []string{"type: memory", "mnemo/memory"} {
+		if !strings.Contains(text, needle) {
+			t.Errorf("memory frontmatter missing %q in %s:\n%s", needle, memHits[0], text[:min(400, len(text))])
+		}
+	}
+}
+
+func TestSyncBothDualWritesMemoriesAndKeepsSessions(t *testing.T) {
+	vaultDir := syncWithLayout(t, store.VaultLayoutBoth)
+
+	if hits := mustFindUnder(t, vaultDir, "sessions/"); len(hits) == 0 {
+		t.Error("both: expected sessions/")
+	}
+	if hits := mustFindUnder(t, vaultDir, "memories/"); len(hits) == 0 {
+		t.Error("both: expected v1 memories/")
+	}
+	if hits := mustFindUnder(t, vaultDir, "_mnemo/memories/"); len(hits) == 0 {
+		t.Error("both: expected _mnemo/memories/")
+	}
+}
+
+// TestSyncWritesDecisionPaths exercises writeNote + path selection for a
+// concrete decision under both layouts via the same code path Sync uses
+// (renderDecision → writeNote at decisionPathsForLayout targets).
+func TestSyncWritesDecisionPaths(t *testing.T) {
+	d := store.DecisionInfo{
+		SessionID:        "decpath01deadbeef",
+		Repo:             "myapp",
+		Timestamp:        "2026-05-10T11:00:00Z",
+		ProposalText:     "Use _mnemo/decisions for wing pages.",
+		ConfirmationText: "Confirmed.",
+	}
+	for _, layout := range []string{store.VaultLayoutV2, store.VaultLayoutBoth, store.VaultLayoutV1} {
+		t.Run(layout, func(t *testing.T) {
+			dir := t.TempDir()
+			content := renderDecision(d, "")
+			for _, rel := range decisionPathsForLayout(layout, d) {
+				abs := filepath.Join(dir, rel)
+				if err := writeNote(abs, content, d.Timestamp); err != nil {
+					t.Fatalf("writeNote %s: %v", rel, err)
+				}
+				raw, err := os.ReadFile(abs)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !strings.Contains(string(raw), "type: decision") {
+					t.Errorf("%s missing type frontmatter", rel)
+				}
+			}
+			// Pure v2 must not create v1 decision root.
+			if layout == store.VaultLayoutV2 {
+				if _, err := os.Stat(filepath.Join(dir, "decisions")); !os.IsNotExist(err) {
+					t.Errorf("v2 should not create v1 decisions/ dir")
+				}
+			}
+		})
+	}
+}
+
+func TestSyncV1KeepsLegacyPathsOnly(t *testing.T) {
+	vaultDir := syncWithLayout(t, store.VaultLayoutV1)
+
+	if hits := mustFindUnder(t, vaultDir, "_mnemo/"); len(hits) > 0 {
+		t.Errorf("v1 must not write _mnemo/: %v", hits)
+	}
+	if hits := mustFindUnder(t, vaultDir, "sessions/"); len(hits) == 0 {
+		t.Error("v1: expected sessions/")
+	}
+	if hits := mustFindUnder(t, vaultDir, "memories/"); len(hits) == 0 {
+		t.Error("v1: expected memories/")
+	}
+}
+
+func TestAtomicWriteFileReplacesAtomically(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "note.md")
+	if err := os.WriteFile(dst, []byte("old content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicWriteFile(dst, []byte("new content\n")); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new content\n" {
+		t.Fatalf("got %q", got)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".mnemo-") || strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("leftover temp file: %s", e.Name())
+		}
+	}
+}
+
+func TestWriteNoteUsesAtomicPath(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "sub", "note.md")
+	if err := writeNote(dst, "# Hello\n\nbody\n", time.Now().UTC().Format(time.RFC3339)); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), generatedFence) {
+		t.Fatalf("missing fence: %s", raw)
+	}
+	if !strings.Contains(string(raw), "# Hello") {
+		t.Fatalf("missing body: %s", raw)
+	}
+}
+
+func TestRenderDecisionFrontmatterShape(t *testing.T) {
+	d := store.DecisionInfo{
+		SessionID:        "sess12345678",
+		Repo:             "mnemo",
+		Timestamp:        "2026-05-10T12:00:00Z",
+		ProposalText:     "Ship the wing.",
+		ConfirmationText: "Yes.",
+	}
+	out := renderDecision(d, "")
+	for _, needle := range []string{
+		"type: decision",
+		"mnemo/decision",
+		"first-seen:",
+		"## Proposal",
+		"## Outcome",
+	} {
+		if !strings.Contains(out, needle) {
+			t.Errorf("missing %q in:\n%s", needle, out)
+		}
+	}
+}

--- a/internal/vault/names.go
+++ b/internal/vault/names.go
@@ -122,7 +122,7 @@ func sessionPath(info store.SessionInfo) string {
 	return filepath.Join("sessions", repo, name+".md")
 }
 
-// decisionPath returns the vault-relative file path for a decision note.
+// decisionPath returns the v1 vault-relative path for a decision note.
 // Format: decisions/<short-repo>/YYYY-MM-DD-<session-id8>.md
 func decisionPath(d store.DecisionInfo) string {
 	repo := decisionRepoSlug(d.Repo)
@@ -130,7 +130,30 @@ func decisionPath(d store.DecisionInfo) string {
 	return filepath.Join("decisions", repo, date+"-"+shortID(d.SessionID)+".md")
 }
 
-// memoryPath returns the vault-relative path for a memory note.
+// decisionPathV2 returns the library-wing path for a decision note (🎯T64.3).
+// Format: _mnemo/decisions/<short-repo>/YYYY-MM-DD-<session-id8>.md
+func decisionPathV2(d store.DecisionInfo) string {
+	return filepath.Join(mnemoWingDir, decisionPath(d))
+}
+
+// decisionPathsForLayout returns the set of relative paths a decision
+// should be written to under the active vault_layout.
+//
+//	v1   → decisions/...
+//	both → decisions/... and _mnemo/decisions/...
+//	v2   → _mnemo/decisions/... only
+func decisionPathsForLayout(layout string, d store.DecisionInfo) []string {
+	switch layout {
+	case store.VaultLayoutV1:
+		return []string{decisionPath(d)}
+	case store.VaultLayoutBoth:
+		return []string{decisionPath(d), decisionPathV2(d)}
+	default: // v2 or empty (New defaults empty → v2 wing content)
+		return []string{decisionPathV2(d)}
+	}
+}
+
+// memoryPath returns the v1 vault-relative path for a memory note.
 // Format: memories/<short-project>-<name-slug>.md
 //
 // Flat (no subdirectory) so that every file in the vault has a globally
@@ -146,6 +169,36 @@ func memoryPath(m store.MemoryInfo) string {
 		name = "memory"
 	}
 	return filepath.Join("memories", proj+"-"+name+".md")
+}
+
+// memoryPathV2 returns the library-wing path for a memory note (🎯T64.3).
+// Format: _mnemo/memories/<short-project>-<name-slug>.md
+func memoryPathV2(m store.MemoryInfo) string {
+	return filepath.Join(mnemoWingDir, memoryPath(m))
+}
+
+// memoryPathsForLayout mirrors decisionPathsForLayout for memories.
+func memoryPathsForLayout(layout string, m store.MemoryInfo) []string {
+	switch layout {
+	case store.VaultLayoutV1:
+		return []string{memoryPath(m)}
+	case store.VaultLayoutBoth:
+		return []string{memoryPath(m), memoryPathV2(m)}
+	default:
+		return []string{memoryPathV2(m)}
+	}
+}
+
+// writesRawSignalReports whether layout still materialises v1 raw-signal
+// pages (sessions, CI, PRs, repo indices). False for pure v2 / empty
+// (empty defaults to v2). (🎯T64.4)
+func writesRawSignalReports(layout string) bool {
+	switch layout {
+	case store.VaultLayoutV1, store.VaultLayoutBoth:
+		return true
+	default: // v2 or empty
+		return false
+	}
 }
 
 // planPath returns the vault-relative path for a plan note.

--- a/internal/vault/note.go
+++ b/internal/vault/note.go
@@ -103,15 +103,22 @@ func renderSession(info store.SessionInfo, msgs []store.SessionMessage) string {
 }
 
 // renderDecision produces a Markdown note for a detected decision.
+// Frontmatter follows the library-wing page shape (🎯T64.3 / design):
+// type + mnemo/* tags plus provenance keys.
 func renderDecision(d store.DecisionInfo, sessionRelPath string) string {
 	var b strings.Builder
 
 	b.WriteString("---\n")
+	writeYAML(&b, "type", "decision")
 	writeYAML(&b, "session_id", d.SessionID)
 	writeYAML(&b, "repo", d.Repo)
 	writeYAML(&b, "date", dateOf(d.Timestamp))
 	writeYAML(&b, "timestamp", d.Timestamp)
+	writeYAML(&b, "first-seen", dateOf(d.Timestamp))
+	writeYAML(&b, "last-touched", dateOf(d.Timestamp))
 	b.WriteString("tags:\n")
+	b.WriteString("  - mnemo\n")
+	b.WriteString("  - mnemo/decision\n")
 	b.WriteString("  - decision\n")
 	if r := shortProjectName(d.Repo); r != "" && r != "untitled" && r != "unknown" {
 		fmt.Fprintf(&b, "  - %s\n", r)
@@ -139,18 +146,25 @@ func renderDecision(d store.DecisionInfo, sessionRelPath string) string {
 }
 
 // renderMemory produces a Markdown note for an indexed memory file.
+// Frontmatter follows the library-wing page shape (🎯T64.3).
 func renderMemory(m store.MemoryInfo) string {
 	var b strings.Builder
 
 	b.WriteString("---\n")
+	writeYAML(&b, "type", "memory")
 	writeYAML(&b, "project", m.Project)
 	writeYAML(&b, "name", m.Name)
 	writeYAML(&b, "memory_type", m.MemoryType)
 	writeYAML(&b, "updated_at", m.UpdatedAt)
+	if m.UpdatedAt != "" {
+		writeYAML(&b, "last-touched", dateOf(m.UpdatedAt))
+	}
 	if m.Description != "" {
 		writeYAML(&b, "description", m.Description)
 	}
 	b.WriteString("tags:\n")
+	b.WriteString("  - mnemo\n")
+	b.WriteString("  - mnemo/memory\n")
 	b.WriteString("  - memory\n")
 	if r := shortProjectName(m.Project); r != "" && r != "untitled" {
 		fmt.Fprintf(&b, "  - %s\n", r)
@@ -167,7 +181,9 @@ func renderMemory(m store.MemoryInfo) string {
 	fmt.Fprintf(&b, "# %s\n\n", name)
 
 	if m.Project != "" {
-		fmt.Fprintf(&b, "*Project: `%s` · [[repos/%s]]*\n\n", m.Project, shortProjectName(m.Project))
+		// Under pure v2, repos/ pages are not written; keep the project
+		// label but only link when the raw-signal index path would exist.
+		fmt.Fprintf(&b, "*Project: `%s`*\n\n", m.Project)
 	}
 
 	b.WriteString(strings.TrimSpace(m.Content))

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -18,20 +18,15 @@
 // Human edits are preserved across re-syncs: generated content lives
 // above the fence, human notes live below and are never overwritten.
 //
-// Vault structure:
+// Vault structure (layout-dependent; vault_layout = v1 | both | v2):
 //
-//	<vault_path>/
-//	├── index.md               — root index (all repos, total sessions)
-//	├── repos/<repo>.md        — per-repo index with recent sessions + decisions
-//	├── sessions/<repo>/       — one note per session (full conversation)
-//	├── decisions/<repo>/      — one note per extracted decision
-//	├── memories/              — project memory notes (flat, globally unique names)
-//	├── skills/                — skill procedure notes from ~/.claude/skills/
-//	├── configs/               — CLAUDE.md project instruction notes
-//	├── plans/<repo>/          — planning documents
-//	├── targets/<repo>/        — convergence targets
-//	├── ci/<repo>/             — CI run summaries
-//	└── prs/<repo>/            — PR and issue notes
+//	v1 / both root (raw signal; suppressed under pure v2 — 🎯T64.4):
+//	  sessions/, repos/, ci/, prs/, decisions/, memories/
+//	v2 / both wing (🎯T64.2–T64.3):
+//	  _mnemo/{index,README,MIGRATION}.md
+//	  _mnemo/decisions/, _mnemo/memories/  (+ later: patterns, themes, …)
+//	Always (all layouts):
+//	  index.md, plans/, targets/, skills/, configs/
 package vault
 
 import (
@@ -182,43 +177,56 @@ func (e *Exporter) Sync(ctx context.Context) error {
 	slog.Info("vault: sync starting", "path", e.path)
 	start := time.Now()
 
-	// Sessions must be synced first: the path map they produce is needed
-	// by decisions (for back-links) and repo indices (for forward-links).
-	sessionPaths, err := e.syncSessions(ctx)
+	layout := e.effectiveLayout()
+	rawSignal := writesRawSignalReports(layout)
+
 	var firstErr error
-	setErr := func(e error) {
-		if e != nil && firstErr == nil {
-			firstErr = e
+	setErr := func(err error) {
+		if err != nil && firstErr == nil {
+			firstErr = err
 		}
 	}
-	setErr(err)
-	layout := e.effectiveLayout()
-	// v1 decision/memory writers run under "v1" and "both" layouts.
-	// Under "v2" they are suppressed; the wing writers handle those. (🎯T64.3)
-	if layout != store.VaultLayoutV2 {
-		setErr(e.syncDecisions(ctx, sessionPaths))
-		setErr(e.syncMemories(ctx))
+
+	// Sessions (raw signal) first when layout allows: the path map is
+	// used for decision back-links and repo indices. Under pure v2 the
+	// pages are not written (🎯T64.4); decision notes then cite session
+	// IDs only.
+	var sessionPaths map[string]string
+	if rawSignal {
+		paths, err := e.syncSessions(ctx)
+		setErr(err)
+		sessionPaths = paths
+	} else {
+		sessionPaths = map[string]string{}
 	}
+
+	// Decisions + memories: layout-selected paths (v1 and/or _mnemo/). (🎯T64.3)
+	setErr(e.syncDecisions(ctx, sessionPaths, layout))
+	setErr(e.syncMemories(ctx, layout))
+
 	setErr(e.syncPlans(ctx))
 	setErr(e.syncTargets(ctx))
-	setErr(e.syncCI(ctx))
-	setErr(e.syncPRs(ctx))
+	// CI / PR / repo indices are raw signal — suppress under pure v2. (🎯T64.4)
+	if rawSignal {
+		setErr(e.syncCI(ctx))
+		setErr(e.syncPRs(ctx))
+	}
 	setErr(e.syncSkills(ctx))
 	setErr(e.syncConfigs(ctx))
-	// Repo indices and root index are written last so they reflect the
-	// session paths already materialised above. Fetch repos once and
-	// pass to both so we avoid two identical ListRepos queries.
 	repos, err := e.backend.ListRepos("")
 	setErr(err)
-	setErr(e.syncRepoIndices(ctx, repos, sessionPaths))
+	if rawSignal {
+		setErr(e.syncRepoIndices(ctx, repos, sessionPaths))
+	}
+	// Root index is a thin rollup (not listed as raw-signal noise in T64.4);
+	// keep writing under every layout so the vault always has an entry point.
 	setErr(e.syncRootIndex(repos))
-	// 🎯T64.2/T64.3: library-wing (_mnemo/) writers + state.json bookkeeping
-	// + soak warning. Auxiliary to the v1 writers above; failures are
-	// logged inside and never block the rest of the sync.
+	// Library-wing (_mnemo/) index/README/MIGRATION + state.json + soak. (🎯T64.2)
 	e.syncMnemoWing(ctx, time.Now())
 
 	slog.Info("vault: sync complete",
 		"elapsed", time.Since(start).Round(time.Millisecond),
+		"layout", layout,
 		"err", firstErr)
 	return firstErr
 }
@@ -277,8 +285,9 @@ func (e *Exporter) syncSessions(ctx context.Context) (map[string]string, error) 
 	return pathMap, nil
 }
 
-// syncDecisions writes a vault note for every detected decision.
-func (e *Exporter) syncDecisions(ctx context.Context, sessionPaths map[string]string) error {
+// syncDecisions writes vault notes for every detected decision. Paths
+// depend on layout: v1 root, _mnemo/ wing, or both (🎯T64.3 dual-write).
+func (e *Exporter) syncDecisions(ctx context.Context, sessionPaths map[string]string, layout string) error {
 	// days=36500 effectively means "all time".
 	decisions, err := e.backend.SearchDecisions("", "", 36500, 100000)
 	if err != nil {
@@ -290,27 +299,29 @@ func (e *Exporter) syncDecisions(ctx context.Context, sessionPaths map[string]st
 		if ctx.Err() != nil {
 			break
 		}
-		relPath := decisionPath(d)
-		absPath := filepath.Join(e.path, relPath)
-		if !needsUpdate(absPath, d.Timestamp) {
-			skipped++
-			continue
-		}
 		content := renderDecision(d, sessionPaths[d.SessionID])
-		if err := writeNote(absPath, content, d.Timestamp); err != nil {
-			slog.Warn("vault: write decision note failed", "path", absPath, "err", err)
-			continue
+		for _, relPath := range decisionPathsForLayout(layout, d) {
+			absPath := filepath.Join(e.path, relPath)
+			if !needsUpdate(absPath, d.Timestamp) {
+				skipped++
+				continue
+			}
+			if err := writeNote(absPath, content, d.Timestamp); err != nil {
+				slog.Warn("vault: write decision note failed", "path", absPath, "err", err)
+				continue
+			}
+			e.recordOutput(relPath, "decision", d.SessionID+":"+d.Timestamp, content)
+			written++
 		}
-		e.recordOutput(relPath, "decision", d.SessionID+":"+d.Timestamp, content)
-		written++
 	}
 
-	slog.Info("vault: decisions synced", "written", written, "skipped", skipped)
+	slog.Info("vault: decisions synced", "written", written, "skipped", skipped, "layout", layout)
 	return nil
 }
 
-// syncMemories writes a vault note for every indexed memory file.
-func (e *Exporter) syncMemories(ctx context.Context) error {
+// syncMemories writes vault notes for every indexed memory file.
+// Paths depend on layout (🎯T64.3 dual-write under "both").
+func (e *Exporter) syncMemories(ctx context.Context, layout string) error {
 	memories, err := e.backend.SearchMemories("", "", "", 100000)
 	if err != nil {
 		return fmt.Errorf("vault: search memories: %w", err)
@@ -321,22 +332,23 @@ func (e *Exporter) syncMemories(ctx context.Context) error {
 		if ctx.Err() != nil {
 			break
 		}
-		relPath := memoryPath(m)
-		absPath := filepath.Join(e.path, relPath)
-		if !needsUpdate(absPath, m.UpdatedAt) {
-			skipped++
-			continue
-		}
 		content := renderMemory(m)
-		if err := writeNote(absPath, content, m.UpdatedAt); err != nil {
-			slog.Warn("vault: write memory note failed", "path", absPath, "err", err)
-			continue
+		for _, relPath := range memoryPathsForLayout(layout, m) {
+			absPath := filepath.Join(e.path, relPath)
+			if !needsUpdate(absPath, m.UpdatedAt) {
+				skipped++
+				continue
+			}
+			if err := writeNote(absPath, content, m.UpdatedAt); err != nil {
+				slog.Warn("vault: write memory note failed", "path", absPath, "err", err)
+				continue
+			}
+			e.recordOutput(relPath, "memory", m.Project+":"+m.Name, content)
+			written++
 		}
-		e.recordOutput(relPath, "memory", m.Project+":"+m.Name, content)
-		written++
 	}
 
-	slog.Info("vault: memories synced", "written", written, "skipped", skipped)
+	slog.Info("vault: memories synced", "written", written, "skipped", skipped, "layout", layout)
 	return nil
 }
 

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -843,7 +843,7 @@ func TestExporterSyncCreatesFiles(t *testing.T) {
 	}
 
 	vaultDir := t.TempDir()
-	exp, err := New(s, vaultDir, Options{})
+	exp, err := New(s, vaultDir, Options{Layout: store.VaultLayoutBoth})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -895,7 +895,7 @@ func TestBidirectionalSync(t *testing.T) {
 	}
 
 	vaultDir := t.TempDir()
-	exp, err := New(s, vaultDir, Options{})
+	exp, err := New(s, vaultDir, Options{Layout: store.VaultLayoutBoth})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -985,7 +985,7 @@ func TestVaultOnlySearch(t *testing.T) {
 		t.Fatalf("ingest: %v", err)
 	}
 	vaultDir := t.TempDir()
-	exp, err := New(s, vaultDir, Options{})
+	exp, err := New(s, vaultDir, Options{Layout: store.VaultLayoutBoth})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -1194,7 +1194,7 @@ func TestVaultSyncCoalescesConcurrentCalls(t *testing.T) {
 		t.Fatalf("ingest: %v", err)
 	}
 	vaultDir := t.TempDir()
-	exp, err := New(s, vaultDir, Options{})
+	exp, err := New(s, vaultDir, Options{Layout: store.VaultLayoutBoth})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}


### PR DESCRIPTION
## Summary

Completes the vault library wing **MVP boundary** (🎯T64.1–T64.4):

- **🎯T64.3**: Decisions and memories write under `_mnemo/decisions/` and `_mnemo/memories/` with design frontmatter (`type`, `mnemo/*` tags). Under `vault_layout="both"`, dual-write to v1 root paths continues. Notes go through `writeNote` → `atomicWriteFile` (temp + fsync + rename).
- **🎯T64.4**: Under pure `vault_layout="v2"`, session / CI / PR / repo-index pages are not written (raw signal stays in SQLite).

Parent 🎯T64 stays open (T64.5–T64.9 still pending).

## Test plan

- [x] `go test -tags sqlite_fts5 ./internal/vault/`
- [x] `make bullseye`
- [ ] `scripts/win-validate.sh`
- [ ] Ubuntu CI
