### PR TITLE
Bump version to 0.65.0 (vault wing MVP)

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.64.0"
+	version              = "0.65.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 


### PR DESCRIPTION
## Summary
Version **0.65.0** for the vault wing MVP (T64.3+T64.4) already on master via #150.
