### PR TITLE
🎯T64.5+T64.6: PKM profile detection + vault bridges

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -2270,7 +2270,6 @@ targets:
     status: achieved
     value: 2.0
     cost: 0.0
-    set_aside_reason: 'NOT parked, NOT won''t-fix, NOT an achievement judgement — this is an OWNERSHIP EXCLUSION only. T64.2 is driven externally on open PR #112 (branch t64.2-mnemo-namespace-vault-layout, +1959/−46, both CI checks green at 2026-06-14 but 29 commits behind master; lineage from navnita''s now-closed #105). Excluded from Marcelo''s frontier so /cv stops recommending work that already exists on an open PR. bullseye has no dedicated owner/not-mine disposition (feature filed as bullseye 🎯T43), so set_aside is a stand-in here — the reason carries the nuance the status enum can''t. REVIVE by clearing status back to identified (bullseye_put id=T64.2 status=identified) when ownership returns to Marcelo or #112 lands/closes.'
     acceptance:
     - vault_layout config key accepts "v2", "both", or "v1"; default is "both" for existing vaults, "v2" for new.
     - _mnemo/index.md and _mnemo/README.md exist with the standard fence contract.
@@ -2289,7 +2288,6 @@ targets:
     status: achieved
     value: 2.0
     cost: 0.0
-    set_aside_reason: 'Leak-containment for the T64.2 ownership exclusion. Downstream of 🎯T64.2 (externally-owned, open PR #112). T64.2''s _mnemo/ namespace foundation is NOT on master, so this is not actually actionable — bullseye mechanically unblocked it only because set_aside(T64.2) is treated like achievement. Excluded to keep Marcelo''s frontier honest. REVIVE together with T64.2 (status→identified) when ownership returns / #112 lands.'
     acceptance:
     - decisions/ and memories/ pages render under _mnemo/decisions/ and _mnemo/memories/ with the design's new frontmatter shape and
     - Old v1 decision/memory files still written when vault_layout="both".
@@ -2321,7 +2319,6 @@ targets:
     status: identified
     value: 2.0
     cost: 0.0
-    set_aside_reason: 'Leak-containment for the T64.2 ownership exclusion. Downstream of 🎯T64.2 (externally-owned, open PR #112). T64.2''s _mnemo/ namespace foundation is NOT on master, so this is not actually actionable — bullseye mechanically unblocked it only because set_aside(T64.2) is treated like achievement. Excluded to keep Marcelo''s frontier honest. REVIVE together with T64.2 (status→identified) when ownership returns / #112 lands.'
     acceptance:
     - vault_profile config key accepts "obsidian", "logseq", "foam", or "generic".
     - 'Per-profile renderer hooks plumbed for link syntax + properties differences (Obsidian alias links, Logseq prop:: syntax, etc.).'
@@ -2337,7 +2334,6 @@ targets:
     status: identified
     value: 2.0
     cost: 0.0
-    set_aside_reason: 'Leak-containment for the T64.2 ownership exclusion. Downstream of 🎯T64.2 (externally-owned, open PR #112). T64.2''s _mnemo/ namespace foundation is NOT on master, so this is not actually actionable — bullseye mechanically unblocked it only because set_aside(T64.2) is treated like achievement. Excluded to keep Marcelo''s frontier honest. REVIVE together with T64.2 (status→identified) when ownership returns / #112 lands.'
     acceptance:
     - vault_bridges config maps collection name (themes / patterns / cross-repo / lessons / decisions / memories) to an anchor-file path anywhere in the vault.
     - Whole-file atomic write inserts a fenced block ('<!-- mnemo:bridge:<name> --> ... <!-- /mnemo:bridge:<name> -->') into the named anchor file.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -181,8 +181,11 @@ func (r *Registry) ForUser(username string) (*store.Store, error) {
 		s.RegisterExcludedPath(vaultPath, "vault_path")
 		s.SetVaultPath(vaultPath) // 🎯T68.6: vault divergence + GC machinery needs the path
 		exp, err := vault.New(s, vaultPath, vault.Options{
-			Layout:        r.cfg.ResolvedVaultLayout(vaultPath),
-			SoakWarnAfter: r.cfg.ResolvedVaultLayoutSoakWarnAfter(),
+			Layout:          r.cfg.ResolvedVaultLayout(vaultPath),
+			SoakWarnAfter:   r.cfg.ResolvedVaultLayoutSoakWarnAfter(),
+			Profile:         r.cfg.ResolvedVaultProfile(vaultPath),
+			Bridges:         r.cfg.VaultBridges,
+			BridgesMaxLinks: r.cfg.ResolvedVaultBridgesMaxLinks(),
 		})
 		if err != nil {
 			slog.Warn("vault: exporter creation failed", "path", vaultPath, "err", err)
@@ -966,8 +969,11 @@ func (r *Registry) swapVault(username string, e *userEntry, newPath string) erro
 	}
 
 	exp, err := vault.New(e.store, newPath, vault.Options{
-		Layout:        r.cfg.ResolvedVaultLayout(newPath),
-		SoakWarnAfter: r.cfg.ResolvedVaultLayoutSoakWarnAfter(),
+		Layout:          r.cfg.ResolvedVaultLayout(newPath),
+		SoakWarnAfter:   r.cfg.ResolvedVaultLayoutSoakWarnAfter(),
+		Profile:         r.cfg.ResolvedVaultProfile(newPath),
+		Bridges:         r.cfg.VaultBridges,
+		BridgesMaxLinks: r.cfg.ResolvedVaultBridgesMaxLinks(),
 	})
 	if err != nil {
 		logger.Warn("vault: exporter creation failed on reload", "path", newPath, "err", err)

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 )
@@ -102,6 +103,34 @@ type Config struct {
 	// under "Configuration surface" → "Soak-time TTL" in
 	// docs/design/vault-library-wing.md.
 	VaultLayout string `json:"vault_layout,omitempty"`
+
+	// VaultProfile selects the PKM tool dialect the vault exporter
+	// renders for (🎯T64.5). One of "obsidian", "logseq", "foam", or
+	// "generic". Controls link syntax (alias wikilinks vs. plain
+	// wikilinks vs. Markdown links) and other tool-specific quirks.
+	//
+	// Empty resolves via ResolvedVaultProfile at runtime: auto-detected
+	// from the recency of each tool's canonical signal file, falling
+	// back to "generic" when none is present. A user-set value always
+	// wins over auto-detect. See "PKM profile" in
+	// docs/design/vault-library-wing.md.
+	VaultProfile string `json:"vault_profile,omitempty"`
+
+	// VaultBridges maps a vault entity collection name (one of
+	// vaultBridgeCollections — "themes", "patterns", "cross-repo",
+	// "lessons", "decisions", "memories") to a vault-relative anchor
+	// file path anywhere in the vault (🎯T64.6). On each sync mnemo
+	// writes a fenced block of links to that collection into the named
+	// file, letting users pull mnemo content into their own MOCs
+	// without mnemo owning the file. Unknown collection names are
+	// skipped with a warning (fail-soft). Empty disables bridges.
+	VaultBridges map[string]string `json:"vault_bridges,omitempty"`
+
+	// VaultBridgesMaxLinks caps how many links a single bridge block
+	// emits (per source project for the memories bridge) so a bridge
+	// never becomes its own hairball (🎯T64.6). Zero resolves to the
+	// default (defaultVaultBridgesMaxLinks).
+	VaultBridgesMaxLinks int `json:"vault_bridges_max_links,omitempty"`
 
 	// VaultLayoutSoakWarnAfter is the duration (Go time.ParseDuration
 	// format) that vault_layout="both" may sit before mnemo emits the
@@ -513,8 +542,24 @@ func WriteConfig(cfg Config) error {
 	if err := cfg.validateVaultLayout(); err != nil {
 		return err
 	}
+	if err := cfg.validateVaultProfile(); err != nil {
+		return err
+	}
 	path := filepath.Join(home, ".mnemo", "config.json")
 	return writeConfigTo(path, cfg)
+}
+
+// validateVaultProfile rejects unknown vault_profile values so a typo
+// (e.g. "obsidan", "Logseq") never persists into config.json. Empty is
+// permitted — ResolvedVaultProfile auto-detects at runtime. (🎯T64.5)
+func (c Config) validateVaultProfile() error {
+	switch c.VaultProfile {
+	case "", VaultProfileObsidian, VaultProfileLogseq, VaultProfileFoam, VaultProfileGeneric:
+		return nil
+	default:
+		return fmt.Errorf("vault_profile %q is invalid; must be one of %q, %q, %q, %q",
+			c.VaultProfile, VaultProfileObsidian, VaultProfileLogseq, VaultProfileFoam, VaultProfileGeneric)
+	}
 }
 
 // validateVaultLayout rejects unknown vault_layout values so a typo
@@ -750,6 +795,74 @@ const (
 	VaultLayoutV2   = "v2"
 )
 
+// Vault PKM profile constants (🎯T64.5). Select the tool-specific
+// rendering dialect for the vault. Use these instead of bare strings.
+const (
+	VaultProfileObsidian = "obsidian"
+	VaultProfileLogseq   = "logseq"
+	VaultProfileFoam     = "foam"
+	VaultProfileGeneric  = "generic"
+)
+
+// vaultProfileSignalFiles maps a PKM profile to the canonical file
+// whose modification time signals that the tool is actively used
+// against this vault (🎯T64.5). Auto-detect stats these — recency of
+// mtime, not mere presence, decides the profile, because a stale
+// `.obsidian/` can linger for months after one exploratory open while
+// a multi-tool user's real editor keeps touching its own config.
+//
+// generic has no signal file: it is the fallback when none of these
+// exist.
+var vaultProfileSignalFiles = map[string]string{
+	VaultProfileObsidian: filepath.Join(".obsidian", "workspace.json"),
+	VaultProfileLogseq:   filepath.Join("logseq", "config", "config.edn"),
+	VaultProfileFoam:     filepath.Join(".foam", "settings.json"),
+}
+
+// vaultProfileTieBreak is the deterministic preference order applied
+// when two signal files' mtimes are within vaultProfileTieWindow of
+// each other: obsidian (most common) → logseq → foam. (🎯T64.5)
+var vaultProfileTieBreak = []string{
+	VaultProfileObsidian, VaultProfileLogseq, VaultProfileFoam,
+}
+
+// vaultProfileTieWindow is the mtime proximity within which two signal
+// files are considered "simultaneously touched" and the deterministic
+// tie-break order applies rather than raw most-recent-wins. (🎯T64.5)
+const vaultProfileTieWindow = time.Hour
+
+// vaultBridgeCollections is the closed set of entity collection names a
+// bridge may target (🎯T64.6). A vault_bridges entry keyed outside this
+// set is a typo or a future/unknown collection and is skipped fail-soft.
+var vaultBridgeCollections = []string{
+	"themes", "patterns", "cross-repo", "lessons", "decisions", "memories",
+}
+
+// defaultVaultBridgesMaxLinks caps a bridge block's link count when the
+// user has not set vault_bridges_max_links. (🎯T64.6)
+const defaultVaultBridgesMaxLinks = 50
+
+// IsVaultBridgeCollection reports whether name is a recognised bridge
+// target collection. (🎯T64.6)
+func IsVaultBridgeCollection(name string) bool {
+	for _, c := range vaultBridgeCollections {
+		if c == name {
+			return true
+		}
+	}
+	return false
+}
+
+// ResolvedVaultBridgesMaxLinks returns the effective per-bridge link cap:
+// the configured value when positive, else defaultVaultBridgesMaxLinks.
+// (🎯T64.6)
+func (c Config) ResolvedVaultBridgesMaxLinks() int {
+	if c.VaultBridgesMaxLinks > 0 {
+		return c.VaultBridgesMaxLinks
+	}
+	return defaultVaultBridgesMaxLinks
+}
+
 // defaultVaultLayoutSoakWarnAfter is the soak window before the
 // "both"-layout warning fires. 30 days, hours-based per the design's
 // state-machine spec.
@@ -842,6 +955,115 @@ func (c Config) ResolvedVaultLayout(resolvedVaultPath string) string {
 		}
 	}
 	return VaultLayoutV2
+}
+
+// VaultProfileDetection is the outcome of profile resolution, carrying
+// enough provenance for mnemo_vault_status to explain *why* a profile
+// was chosen (🎯T64.5).
+type VaultProfileDetection struct {
+	// Profile is the resolved profile ("obsidian" | "logseq" | "foam"
+	// | "generic").
+	Profile string
+	// Source is how Profile was decided: "config" (user override),
+	// "auto" (a signal file was found), or "default" (no signal →
+	// generic).
+	Source string
+	// SignalFile is the vault-relative signal path that won auto-detect;
+	// empty for config/default sources.
+	SignalFile string
+	// SignalMtime is the modification time of SignalFile; zero when
+	// SignalFile is empty.
+	SignalMtime time.Time
+	// Alternatives lists the other profiles whose signal files also
+	// exist (sorted by descending mtime), so the user can spot a
+	// mis-detection. Empty for config/default sources.
+	Alternatives []string
+}
+
+// DetectVaultProfile resolves the effective PKM profile for the vault at
+// resolvedVaultPath and returns the full provenance (🎯T64.5).
+//
+// A user-set VaultProfile always wins (Source "config"). Otherwise the
+// signal files are stat'd and the rule from docs/design/vault-library-wing.md
+// applies:
+//
+//  1. drop signal files that do not exist;
+//  2. exactly one present → that profile;
+//  3. multiple present → most-recent mtime wins; ties within
+//     vaultProfileTieWindow break by vaultProfileTieBreak order;
+//  4. none present → "generic".
+//
+// An empty resolvedVaultPath yields generic (the caller is responsible
+// for not exporting when the vault is disabled).
+func (c Config) DetectVaultProfile(resolvedVaultPath string) VaultProfileDetection {
+	if p := c.VaultProfile; p != "" {
+		return VaultProfileDetection{Profile: p, Source: "config"}
+	}
+	if resolvedVaultPath == "" {
+		return VaultProfileDetection{Profile: VaultProfileGeneric, Source: "default"}
+	}
+
+	type sig struct {
+		profile string
+		rel     string
+		mtime   time.Time
+	}
+	var found []sig
+	for profile, rel := range vaultProfileSignalFiles {
+		fi, err := os.Stat(filepath.Join(resolvedVaultPath, rel))
+		if err != nil || fi.IsDir() {
+			continue
+		}
+		found = append(found, sig{profile: profile, rel: rel, mtime: fi.ModTime()})
+	}
+	if len(found) == 0 {
+		return VaultProfileDetection{Profile: VaultProfileGeneric, Source: "default"}
+	}
+
+	// Sort most-recent first; within the tie window, order by the
+	// deterministic tie-break preference so the result is stable across
+	// runs and filesystems regardless of map iteration order.
+	sort.SliceStable(found, func(i, j int) bool {
+		di := found[i].mtime.Sub(found[j].mtime)
+		if di > vaultProfileTieWindow {
+			return true
+		}
+		if di < -vaultProfileTieWindow {
+			return false
+		}
+		return tieBreakRank(found[i].profile) < tieBreakRank(found[j].profile)
+	})
+
+	winner := found[0]
+	alts := make([]string, 0, len(found)-1)
+	for _, s := range found[1:] {
+		alts = append(alts, s.profile)
+	}
+	return VaultProfileDetection{
+		Profile:      winner.profile,
+		Source:       "auto",
+		SignalFile:   winner.rel,
+		SignalMtime:  winner.mtime,
+		Alternatives: alts,
+	}
+}
+
+// tieBreakRank returns the index of profile in vaultProfileTieBreak, or
+// a large sentinel for anything unlisted so it sorts last. (🎯T64.5)
+func tieBreakRank(profile string) int {
+	for i, p := range vaultProfileTieBreak {
+		if p == profile {
+			return i
+		}
+	}
+	return len(vaultProfileTieBreak)
+}
+
+// ResolvedVaultProfile returns just the effective profile string for the
+// vault at resolvedVaultPath. Convenience wrapper over DetectVaultProfile
+// for call sites that do not need the detection provenance. (🎯T64.5)
+func (c Config) ResolvedVaultProfile(resolvedVaultPath string) string {
+	return c.DetectVaultProfile(resolvedVaultPath).Profile
 }
 
 // ResolvedVaultLayoutSoakWarnAfter returns the configured soak duration

--- a/internal/store/state.go
+++ b/internal/store/state.go
@@ -42,6 +42,14 @@ type State struct {
 	BrokenTemplates        []BrokenTemplate       `json:"broken_templates"`
 	BridgeErrors           []BridgeError          `json:"bridge_errors"`
 
+	// WrittenBridges maps each bridge collection name to the
+	// vault-relative anchor file its fenced block was last written into
+	// (🎯T64.6). Persisted so that when a bridge is removed from
+	// config, the next sync knows which anchor file to strip its block
+	// from — the anchor path is no longer in config at that point.
+	// nil/absent means no bridges have been written yet.
+	WrittenBridges map[string]string `json:"written_bridges,omitempty"`
+
 	// LastSoakWarnAt is the timestamp of the most recent soak-window
 	// warning emit. The exporter consults this to enforce a weekly
 	// cadence: a warning fires at most every 7 days, never on every
@@ -128,6 +136,7 @@ var knownStateKeys = map[string]struct{}{
 	"last_cluster_run_id":       {},
 	"broken_templates":          {},
 	"bridge_errors":             {},
+	"written_bridges":           {},
 	"last_soak_warn_at":         {},
 	"migration_doc_written_at":  {},
 }

--- a/internal/store/vault_profile_test.go
+++ b/internal/store/vault_profile_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeSignal creates a profile signal file at rel under root with the
+// given mtime.
+func writeSignal(t *testing.T, root, rel string, mtime time.Time) {
+	t.Helper()
+	abs := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(abs, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+	if err := os.Chtimes(abs, mtime, mtime); err != nil {
+		t.Fatalf("chtimes %s: %v", rel, err)
+	}
+}
+
+func TestDetectVaultProfile(t *testing.T) {
+	obsSig := filepath.Join(".obsidian", "workspace.json")
+	logSig := filepath.Join("logseq", "config", "config.edn")
+	foamSig := filepath.Join(".foam", "settings.json")
+
+	t.Run("config override wins", func(t *testing.T) {
+		root := t.TempDir()
+		writeSignal(t, root, logSig, time.Now())
+		c := Config{VaultProfile: VaultProfileObsidian}
+		d := c.DetectVaultProfile(root)
+		if d.Profile != VaultProfileObsidian || d.Source != "config" {
+			t.Fatalf("got %+v, want obsidian/config", d)
+		}
+	})
+
+	t.Run("no signals -> generic default", func(t *testing.T) {
+		d := Config{}.DetectVaultProfile(t.TempDir())
+		if d.Profile != VaultProfileGeneric || d.Source != "default" {
+			t.Fatalf("got %+v, want generic/default", d)
+		}
+	})
+
+	t.Run("empty path -> generic default", func(t *testing.T) {
+		d := Config{}.DetectVaultProfile("")
+		if d.Profile != VaultProfileGeneric || d.Source != "default" {
+			t.Fatalf("got %+v, want generic/default", d)
+		}
+	})
+
+	t.Run("single signal -> that profile", func(t *testing.T) {
+		root := t.TempDir()
+		writeSignal(t, root, foamSig, time.Now())
+		d := Config{}.DetectVaultProfile(root)
+		if d.Profile != VaultProfileFoam || d.Source != "auto" || d.SignalFile != foamSig {
+			t.Fatalf("got %+v, want foam/auto/%s", d, foamSig)
+		}
+	})
+
+	t.Run("most recent mtime wins beyond tie window", func(t *testing.T) {
+		root := t.TempDir()
+		now := time.Now()
+		writeSignal(t, root, obsSig, now.Add(-48*time.Hour))
+		writeSignal(t, root, logSig, now) // clearly newer
+		d := Config{}.DetectVaultProfile(root)
+		if d.Profile != VaultProfileLogseq {
+			t.Fatalf("got %q, want logseq (newest)", d.Profile)
+		}
+		if len(d.Alternatives) != 1 || d.Alternatives[0] != VaultProfileObsidian {
+			t.Fatalf("alternatives = %v, want [obsidian]", d.Alternatives)
+		}
+	})
+
+	t.Run("within tie window -> obsidian preferred over logseq", func(t *testing.T) {
+		root := t.TempDir()
+		now := time.Now()
+		// logseq slightly newer but inside the 1h tie window.
+		writeSignal(t, root, obsSig, now.Add(-10*time.Minute))
+		writeSignal(t, root, logSig, now)
+		d := Config{}.DetectVaultProfile(root)
+		if d.Profile != VaultProfileObsidian {
+			t.Fatalf("got %q, want obsidian (tie-break)", d.Profile)
+		}
+	})
+
+	t.Run("within tie window -> logseq preferred over foam", func(t *testing.T) {
+		root := t.TempDir()
+		now := time.Now()
+		writeSignal(t, root, foamSig, now)
+		writeSignal(t, root, logSig, now.Add(-5*time.Minute))
+		d := Config{}.DetectVaultProfile(root)
+		if d.Profile != VaultProfileLogseq {
+			t.Fatalf("got %q, want logseq (tie-break over foam)", d.Profile)
+		}
+	})
+}
+
+func TestValidateVaultProfile(t *testing.T) {
+	for _, p := range []string{"", "obsidian", "logseq", "foam", "generic"} {
+		if err := (Config{VaultProfile: p}).validateVaultProfile(); err != nil {
+			t.Errorf("profile %q rejected: %v", p, err)
+		}
+	}
+	if err := (Config{VaultProfile: "notion"}).validateVaultProfile(); err == nil {
+		t.Error("expected invalid profile to be rejected")
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -708,6 +708,17 @@ Modes:
 Requires vault to be configured (vault_path set in ~/.mnemo/config.json).`),
 			mcp.WithBoolean("write", mcp.Description("If true, write the snapshot to _mnemo/MIGRATION.md, overwriting any existing file. Default false (preview only).")),
 		),
+		mcp.NewTool("mnemo_vault_bridge_list",
+			mcp.WithDescription(`List the vault bridges mnemo maintains (🎯T64.6).
+
+A bridge injects a fenced block of links to a mnemo collection (themes, patterns, cross-repo, lessons, decisions, memories) into a user-owned anchor file anywhere in the vault, so mnemo content is navigable from the user's own MOCs without mnemo owning the file.
+
+Returns, for the configured vault:
+  - active bridges: each collection → anchor file path, and whether its block has been written to disk yet;
+  - any bridge errors from the last sync (unknown collection, duplicate fence, unwritable anchor, etc.) with the reason and detail.
+
+Configured via the vault_bridges map (and vault_bridges_max_links) in ~/.mnemo/config.json. Requires vault to be enabled.`),
+		),
 		mcp.NewTool("mnemo_doctor",
 			mcp.WithDescription(`Run mnemo's self-diagnostics and report health (🎯T83). Returns a per-check report — name, severity (ok/warn/fail), tier (fast/full), detail, and a remediation hint — covering the summariser working directory, claude on PATH, configured roots, the compaction circuit-breaker (a tripped breaker means every compaction is failing systemically), whether the indexer has backfilled since startup, and database responsiveness. The single "is mnemo healthy, and what do I do about it" call; the same data backs the dashboard health page (http://localhost:19419/#health) and opt-out OS notifications.`),
 		),
@@ -947,6 +958,8 @@ func (h *Handler) Call(ctx context.Context, cc CallContext, name string, args ma
 		return ch.vaultStatus(h.cfgCtl)
 	case "mnemo_vault_migration_doc":
 		return ch.vaultMigrationDoc(args)
+	case "mnemo_vault_bridge_list":
+		return ch.vaultBridgeList(h.cfgCtl)
 	case "mnemo_compactor_status":
 		return ch.compactorStatus(h.resolveCompactor)
 	case "mnemo_doctor":
@@ -2771,6 +2784,53 @@ func (h *callHandler) vaultStatus(ctl ConfigController) (string, bool, error) {
 	}
 	b.WriteString("\n")
 
+	// PKM profile block (🎯T64.5): which tool dialect the exporter
+	// renders for, and — when auto-detected — the signal file + mtime
+	// that decided it, so the user can spot a mis-detection.
+	prof := cfg.DetectVaultProfile(vaultPath)
+	b.WriteString("PKM profile:\n")
+	fmt.Fprintf(&b, "  active:      %s", prof.Profile)
+	switch prof.Source {
+	case "config":
+		b.WriteString("  (configured)")
+	case "auto":
+		b.WriteString("  (auto-detected)")
+	case "default":
+		b.WriteString("  (default; no signal file found)")
+	}
+	b.WriteString("\n")
+	if prof.SignalFile != "" {
+		fmt.Fprintf(&b, "  signal:      %s (mtime %s)\n",
+			prof.SignalFile, prof.SignalMtime.UTC().Format(time.RFC3339))
+	}
+	if len(prof.Alternatives) > 0 {
+		fmt.Fprintf(&b, "  alternates:  %s\n", strings.Join(prof.Alternatives, ", "))
+	}
+	b.WriteString("\n")
+
+	// Bridges block (🎯T64.6): configured collection→anchor mappings and
+	// any errors from the last sync.
+	if len(cfg.VaultBridges) > 0 {
+		b.WriteString("Bridges:\n")
+		names := make([]string, 0, len(cfg.VaultBridges))
+		for n := range cfg.VaultBridges {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			fmt.Fprintf(&b, "  %-12s → %s\n", n, cfg.VaultBridges[n])
+		}
+		if sp, perr := h.vault.StatePath(); perr == nil {
+			if st, err := store.LoadState(sp); err == nil && len(st.BridgeErrors) > 0 {
+				b.WriteString("  errors:\n")
+				for _, be := range st.BridgeErrors {
+					fmt.Fprintf(&b, "    %s (%s): %s\n", be.Name, be.AnchorPath, be.Reason)
+				}
+			}
+		}
+		b.WriteString("\n")
+	}
+
 	b.WriteString("Notes on disk:\n")
 	total := 0
 	for _, sec := range sections {
@@ -2780,6 +2840,70 @@ func (h *callHandler) vaultStatus(ctl ConfigController) (string, bool, error) {
 	}
 	fmt.Fprintf(&b, "  %-12s %d\n", "total", total)
 	return b.String(), false, nil
+}
+
+// vaultBridgeList implements mnemo_vault_bridge_list (🎯T64.6): the
+// configured collection→anchor bridges, whether each has been written to
+// disk yet (from the state.json written-bridge record), and any errors
+// recorded on the last sync.
+func (h *callHandler) vaultBridgeList(ctl ConfigController) (string, bool, error) {
+	if h.vault == nil {
+		return vaultNotConfigured, false, nil
+	}
+	var cfg store.Config
+	if ctl != nil {
+		cfg = ctl.Get()
+	}
+
+	// Load the written-bridge record + errors from state.json.
+	var written map[string]string
+	var bridgeErrs []store.BridgeError
+	if sp, perr := h.vault.StatePath(); perr == nil {
+		if st, err := store.LoadState(sp); err == nil {
+			written = st.WrittenBridges
+			bridgeErrs = st.BridgeErrors
+		}
+	}
+
+	type bridgeView struct {
+		Collection string `json:"collection"`
+		Anchor     string `json:"anchor"`
+		Written    bool   `json:"written"`
+		Known      bool   `json:"known_collection"`
+	}
+	out := struct {
+		VaultPath string              `json:"vault_path"`
+		MaxLinks  int                 `json:"max_links"`
+		Bridges   []bridgeView        `json:"bridges"`
+		Errors    []store.BridgeError `json:"errors"`
+	}{
+		VaultPath: h.vault.Path(),
+		MaxLinks:  cfg.ResolvedVaultBridgesMaxLinks(),
+		Bridges:   []bridgeView{},
+		Errors:    bridgeErrs,
+	}
+	names := make([]string, 0, len(cfg.VaultBridges))
+	for n := range cfg.VaultBridges {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		_, isWritten := written[n]
+		out.Bridges = append(out.Bridges, bridgeView{
+			Collection: n,
+			Anchor:     cfg.VaultBridges[n],
+			Written:    isWritten,
+			Known:      store.IsVaultBridgeCollection(n),
+		})
+	}
+	if out.Errors == nil {
+		out.Errors = []store.BridgeError{}
+	}
+	buf, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("marshal failed: %v", err), true, nil
+	}
+	return string(buf), false, nil
 }
 
 // doctor implements mnemo_doctor (🎯T83): it runs the full self-

--- a/internal/vault/bridges.go
+++ b/internal/vault/bridges.go
@@ -1,0 +1,341 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package vault
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/marcelocantos/mnemo/internal/store"
+)
+
+// errDuplicateFence signals that an anchor file already contains two or
+// more blocks with the same bridge name — an ambiguous state the writer
+// refuses to resolve, leaving the file untouched (🎯T64.6 edge case).
+var errDuplicateFence = errors.New("duplicate bridge fence")
+
+// bridgeStartDelim / bridgeEndDelim are the HTML-comment sentinels that
+// fence a bridge's managed block inside a user-owned anchor file. The
+// writer locates blocks by these delimiters — never by line offset — so
+// a user may freely relocate the block within the file (🎯T64.6).
+func bridgeStartDelim(name string) string { return "<!-- mnemo:bridge:" + name + " -->" }
+func bridgeEndDelim(name string) string   { return "<!-- /mnemo:bridge:" + name + " -->" }
+
+// syncBridges reconciles the configured bridges against the anchor files
+// on disk and the written-bridge record in st (🎯T64.6). It:
+//
+//   - strips blocks for bridges that were previously written but have
+//     since been removed from config (or whose collection is now
+//     unknown), using st.WrittenBridges to find the anchor file;
+//   - relocates a bridge whose anchor path changed (strip old, write new);
+//   - writes/updates the block for each currently-configured, recognised
+//     bridge;
+//   - records per-bridge failures in st.BridgeErrors and the surviving
+//     name→anchor map in st.WrittenBridges.
+//
+// It never returns an error: bridges are auxiliary and a single bad
+// anchor must not fail the sync. All problems are surfaced via
+// st.BridgeErrors (→ mnemo_vault_status / mnemo_vault_bridge_list) and
+// warn-level logs. st is mutated in place; the caller persists it.
+func (e *Exporter) syncBridges(st *store.State) {
+	var errs []store.BridgeError
+	fail := func(name, anchor, reason, detail string) {
+		errs = append(errs, store.BridgeError{Name: name, AnchorPath: anchor, Reason: reason, Detail: detail})
+	}
+
+	// Current, recognised bridges (skip unknown collections fail-soft).
+	current := map[string]string{}
+	for name, anchor := range e.bridges {
+		if !store.IsVaultBridgeCollection(name) {
+			fail(name, anchor, "unknown collection", "not one of themes/patterns/cross-repo/lessons/decisions/memories")
+			slog.Warn("vault: bridge skipped, unknown collection", "name", name, "anchor", anchor)
+			continue
+		}
+		if strings.TrimSpace(anchor) == "" {
+			fail(name, anchor, "empty anchor path", "")
+			continue
+		}
+		current[name] = anchor
+	}
+
+	written := st.WrittenBridges
+	if written == nil {
+		written = map[string]string{}
+	}
+
+	// Strip blocks for bridges no longer configured, or whose anchor
+	// path changed (strip the old location before writing the new one).
+	for name, oldAnchor := range written {
+		newAnchor, stillWanted := current[name]
+		if stillWanted && newAnchor == oldAnchor {
+			continue
+		}
+		if err := stripBridgeBlock(filepath.Join(e.path, oldAnchor), name); err != nil {
+			slog.Warn("vault: strip removed bridge failed", "name", name, "anchor", oldAnchor, "err", err)
+			// Leave the record so a later sync can retry the strip.
+			if !stillWanted {
+				fail(name, oldAnchor, "strip failed", err.Error())
+			}
+			continue
+		}
+		delete(written, name)
+	}
+
+	// Write/update each current bridge.
+	for name, anchor := range current {
+		body, err := e.renderBridgeBody(name)
+		if err != nil {
+			fail(name, anchor, "render failed", err.Error())
+			slog.Warn("vault: render bridge body failed", "name", name, "err", err)
+			continue
+		}
+		if err := upsertBridgeBlock(filepath.Join(e.path, anchor), name, body); err != nil {
+			reason := "write failed"
+			if errors.Is(err, errDuplicateFence) {
+				reason = "duplicate fence"
+			}
+			fail(name, anchor, reason, err.Error())
+			slog.Warn("vault: write bridge failed", "name", name, "anchor", anchor, "reason", reason, "err", err)
+			continue
+		}
+		written[name] = anchor
+	}
+
+	if len(written) == 0 {
+		written = nil
+	}
+	st.WrittenBridges = written
+	st.BridgeErrors = errs
+	if st.BridgeErrors == nil {
+		st.BridgeErrors = []store.BridgeError{}
+	}
+}
+
+// renderBridgeBody produces the body lines (no fence delimiters) for a
+// bridge collection, honouring the profile's link syntax and the
+// per-bridge link cap (🎯T64.6). Collections whose pages do not exist
+// yet (themes, patterns, cross-repo, lessons — future slices) render an
+// empty body; the empty fenced block is written so the bridge lights up
+// automatically once those slices land.
+func (e *Exporter) renderBridgeBody(name string) ([]string, error) {
+	max := e.bridgesMaxLinks
+	if max <= 0 {
+		max = 50
+	}
+	switch name {
+	case "decisions":
+		return e.bridgeDecisionLines(max)
+	case "memories":
+		return e.bridgeMemoryLines(max)
+	default:
+		// themes / patterns / cross-repo / lessons — not materialised yet.
+		return nil, nil
+	}
+}
+
+// bridgeDecisionLines returns a flat, most-recent-first bulleted list of
+// links to the wing's decision pages, capped at max.
+func (e *Exporter) bridgeDecisionLines(max int) ([]string, error) {
+	decisions, err := e.backend.SearchDecisions("", "", 36500, 100000)
+	if err != nil {
+		return nil, fmt.Errorf("search decisions: %w", err)
+	}
+	sort.SliceStable(decisions, func(i, j int) bool {
+		return decisions[i].Timestamp > decisions[j].Timestamp // RFC3339 sorts lexically
+	})
+	lines := make([]string, 0, max)
+	for _, d := range decisions {
+		if len(lines) >= max {
+			break
+		}
+		target := bridgeTarget(decisionPathV2(d))
+		alias := "Decision · " + dateOf(d.Timestamp)
+		if d.Repo != "" {
+			alias += " · " + shortProjectName(d.Repo)
+		}
+		lines = append(lines, "- "+e.profile.Link(target, alias))
+	}
+	return lines, nil
+}
+
+// bridgeMemoryLines returns memory links grouped by source project, each
+// project a `### <project>` subsection capped at max links, per the
+// design's memories-bridge shape.
+func (e *Exporter) bridgeMemoryLines(max int) ([]string, error) {
+	memories, err := e.backend.SearchMemories("", "", "", 100000)
+	if err != nil {
+		return nil, fmt.Errorf("search memories: %w", err)
+	}
+	byProject := map[string][]store.MemoryInfo{}
+	var order []string
+	for _, m := range memories {
+		proj := shortProjectName(m.Project)
+		if proj == "" {
+			proj = "unknown"
+		}
+		if _, seen := byProject[proj]; !seen {
+			order = append(order, proj)
+		}
+		byProject[proj] = append(byProject[proj], m)
+	}
+	sort.Strings(order)
+
+	var lines []string
+	for _, proj := range order {
+		if len(lines) > 0 {
+			lines = append(lines, "")
+		}
+		lines = append(lines, "### "+proj)
+		n := 0
+		for _, m := range byProject[proj] {
+			if n >= max {
+				break
+			}
+			alias := m.Name
+			if alias == "" {
+				alias = "memory"
+			}
+			lines = append(lines, "- "+e.profile.Link(bridgeTarget(memoryPathV2(m)), alias))
+			n++
+		}
+	}
+	return lines, nil
+}
+
+// bridgeTarget converts a vault-relative note path to the link target
+// form expected by Profile.Link: forward slashes, no ".md" suffix.
+func bridgeTarget(relPath string) string {
+	return strings.TrimSuffix(filepath.ToSlash(relPath), ".md")
+}
+
+// upsertBridgeBlock writes the fenced bridge block for name into the
+// anchor file at absPath, handling every edge case from the design:
+//
+//   - anchor missing → create it (with parent dirs) holding a one-line
+//     header derived from the filename plus the block;
+//   - fence absent → append the block after a blank-line separator;
+//   - fence present → replace it in place, located by delimiter;
+//   - duplicate fences → return errDuplicateFence, file left untouched;
+//   - unwritable anchor → the atomic write returns an error, surfaced up.
+func upsertBridgeBlock(absPath, name string, body []string) error {
+	block := renderBridgeBlock(name, body)
+
+	// atomicWriteFile writes into a sibling tempfile and does not create
+	// parent directories; ensure the anchor's directory exists first.
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		return fmt.Errorf("mkdir anchor dir: %w", err)
+	}
+
+	data, err := os.ReadFile(absPath)
+	if errors.Is(err, os.ErrNotExist) {
+		header := "# " + bridgeAnchorTitle(absPath) + "\n\n"
+		return atomicWriteFile(absPath, []byte(header+block+"\n"))
+	}
+	if err != nil {
+		return fmt.Errorf("read anchor: %w", err)
+	}
+
+	content := string(data)
+	start, end, count, err := locateBridgeBlock(content, name)
+	if err != nil {
+		return err
+	}
+	var out string
+	switch count {
+	case 0:
+		sep := "\n"
+		if !strings.HasSuffix(content, "\n") {
+			sep = "\n\n"
+		} else if !strings.HasSuffix(content, "\n\n") {
+			sep = "\n"
+		}
+		out = content + sep + block + "\n"
+	case 1:
+		out = content[:start] + block + content[end:]
+	}
+	return atomicWriteFile(absPath, []byte(out))
+}
+
+// stripBridgeBlock removes the named bridge block from absPath. A missing
+// file or absent fence is a no-op. Duplicate fences are left untouched
+// (returns errDuplicateFence) so an ambiguous file is never mangled.
+func stripBridgeBlock(absPath, name string) error {
+	data, err := os.ReadFile(absPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read anchor: %w", err)
+	}
+	content := string(data)
+	start, end, count, err := locateBridgeBlock(content, name)
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		return nil
+	}
+	// Drop the block plus one trailing newline and a preceding blank-line
+	// separator if present, so removing a bridge doesn't leave a widening
+	// gap of blank lines across syncs.
+	for end < len(content) && content[end] == '\n' {
+		end++
+	}
+	for start > 0 && content[start-1] == '\n' {
+		start--
+	}
+	out := content[:start] + content[end:]
+	if out != "" && !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
+	return atomicWriteFile(absPath, []byte(out))
+}
+
+// renderBridgeBlock assembles the full fenced block text (delimiters +
+// body) with no trailing newline.
+func renderBridgeBlock(name string, body []string) string {
+	var b strings.Builder
+	b.WriteString(bridgeStartDelim(name))
+	b.WriteString("\n")
+	if len(body) > 0 {
+		b.WriteString(strings.Join(body, "\n"))
+		b.WriteString("\n")
+	}
+	b.WriteString(bridgeEndDelim(name))
+	return b.String()
+}
+
+// locateBridgeBlock finds the named bridge block within content. It
+// returns the byte offset of the start delimiter, the offset just past
+// the end delimiter, and the number of well-formed blocks found (0 or
+// 1). More than one start delimiter, or a start without a matching end
+// after it, yields errDuplicateFence / a malformed error so the caller
+// leaves the file alone.
+func locateBridgeBlock(content, name string) (start, end, count int, err error) {
+	sd, ed := bridgeStartDelim(name), bridgeEndDelim(name)
+	if strings.Count(content, sd) > 1 || strings.Count(content, ed) > 1 {
+		return 0, 0, 0, errDuplicateFence
+	}
+	s := strings.Index(content, sd)
+	if s < 0 {
+		return 0, 0, 0, nil
+	}
+	eIdx := strings.Index(content[s:], ed)
+	if eIdx < 0 {
+		return 0, 0, 0, fmt.Errorf("bridge %q: start fence without matching end", name)
+	}
+	return s, s + eIdx + len(ed), 1, nil
+}
+
+// bridgeAnchorTitle derives a human-facing header for a freshly-created
+// anchor file from its filename (drops the extension).
+func bridgeAnchorTitle(absPath string) string {
+	base := filepath.Base(absPath)
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}

--- a/internal/vault/bridges_test.go
+++ b/internal/vault/bridges_test.go
@@ -1,0 +1,294 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package vault
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/marcelocantos/mnemo/internal/store"
+	"github.com/marcelocantos/mnemo/internal/storetest"
+)
+
+func TestLocateBridgeBlock(t *testing.T) {
+	sd := bridgeStartDelim("themes")
+	ed := bridgeEndDelim("themes")
+
+	t.Run("absent", func(t *testing.T) {
+		_, _, count, err := locateBridgeBlock("no fence here", "themes")
+		if err != nil || count != 0 {
+			t.Fatalf("count=%d err=%v, want 0/nil", count, err)
+		}
+	})
+	t.Run("single", func(t *testing.T) {
+		content := "top\n" + sd + "\n- x\n" + ed + "\nbottom\n"
+		start, end, count, err := locateBridgeBlock(content, "themes")
+		if err != nil || count != 1 {
+			t.Fatalf("count=%d err=%v, want 1/nil", count, err)
+		}
+		if content[start:end] != sd+"\n- x\n"+ed {
+			t.Errorf("located block = %q", content[start:end])
+		}
+	})
+	t.Run("duplicate start", func(t *testing.T) {
+		content := sd + "\n" + ed + "\n" + sd + "\n" + ed + "\n"
+		if _, _, _, err := locateBridgeBlock(content, "themes"); err != errDuplicateFence {
+			t.Fatalf("err=%v, want errDuplicateFence", err)
+		}
+	})
+}
+
+func TestRenderBridgeBlock(t *testing.T) {
+	got := renderBridgeBlock("decisions", []string{"- a", "- b"})
+	want := bridgeStartDelim("decisions") + "\n- a\n- b\n" + bridgeEndDelim("decisions")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	// Empty body → just the two delimiters, no interior blank line.
+	empty := renderBridgeBlock("themes", nil)
+	if empty != bridgeStartDelim("themes")+"\n"+bridgeEndDelim("themes") {
+		t.Errorf("empty body render = %q", empty)
+	}
+}
+
+func TestUpsertBridgeBlockCreatesMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	anchor := filepath.Join(dir, "sub", "Themes MOC.md")
+	if err := upsertBridgeBlock(anchor, "themes", []string{"- [[x]]"}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	raw, err := os.ReadFile(anchor)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	got := string(raw)
+	if !strings.HasPrefix(got, "# Themes MOC\n") {
+		t.Errorf("missing derived header, got:\n%s", got)
+	}
+	if !strings.Contains(got, bridgeStartDelim("themes")) || !strings.Contains(got, "- [[x]]") {
+		t.Errorf("missing block/body:\n%s", got)
+	}
+}
+
+func TestUpsertBridgeBlockAppendsPreservingUserContent(t *testing.T) {
+	dir := t.TempDir()
+	anchor := filepath.Join(dir, "notes.md")
+	user := "# My Notes\n\nSome important user text.\n"
+	if err := os.WriteFile(anchor, []byte(user), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertBridgeBlock(anchor, "patterns", []string{"- [[p]]"}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	raw, _ := os.ReadFile(anchor)
+	got := string(raw)
+	if !strings.HasPrefix(got, user) {
+		t.Errorf("user content not preserved at top:\n%s", got)
+	}
+	if !strings.Contains(got, bridgeStartDelim("patterns")) {
+		t.Errorf("block not appended:\n%s", got)
+	}
+}
+
+func TestUpsertBridgeBlockReplacesInPlaceHonouringMovedBlock(t *testing.T) {
+	dir := t.TempDir()
+	anchor := filepath.Join(dir, "moc.md")
+	// User has relocated the block into the middle of the file.
+	initial := "# MOC\n\n" +
+		bridgeStartDelim("decisions") + "\nold link\n" + bridgeEndDelim("decisions") + "\n\n" +
+		"## User section below\ntext\n"
+	if err := os.WriteFile(anchor, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertBridgeBlock(anchor, "decisions", []string{"- new link"}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	got := string(mustRead(t, anchor))
+	if strings.Contains(got, "old link") {
+		t.Error("old block content survived")
+	}
+	if !strings.Contains(got, "- new link") {
+		t.Error("new block content missing")
+	}
+	// User content on both sides is untouched, block stays in the middle.
+	if !strings.HasPrefix(got, "# MOC\n") || !strings.Contains(got, "## User section below") {
+		t.Errorf("surrounding user content disturbed:\n%s", got)
+	}
+	if strings.Index(got, bridgeStartDelim("decisions")) > strings.Index(got, "## User section below") {
+		t.Errorf("block should remain above the user section:\n%s", got)
+	}
+	// Exactly one fence pair after replace.
+	if strings.Count(got, bridgeStartDelim("decisions")) != 1 {
+		t.Errorf("expected exactly one fence, got:\n%s", got)
+	}
+}
+
+func TestUpsertBridgeBlockDuplicateFenceLeavesFileAlone(t *testing.T) {
+	dir := t.TempDir()
+	anchor := filepath.Join(dir, "dup.md")
+	dupe := bridgeStartDelim("themes") + "\na\n" + bridgeEndDelim("themes") + "\n" +
+		bridgeStartDelim("themes") + "\nb\n" + bridgeEndDelim("themes") + "\n"
+	if err := os.WriteFile(anchor, []byte(dupe), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := upsertBridgeBlock(anchor, "themes", []string{"- x"})
+	if err != errDuplicateFence {
+		t.Fatalf("err=%v, want errDuplicateFence", err)
+	}
+	// File is byte-for-byte unchanged.
+	if string(mustRead(t, anchor)) != dupe {
+		t.Error("file was modified despite duplicate fence")
+	}
+}
+
+func TestStripBridgeBlock(t *testing.T) {
+	t.Run("removes block, keeps user content", func(t *testing.T) {
+		dir := t.TempDir()
+		anchor := filepath.Join(dir, "a.md")
+		content := "# Head\n\nbefore\n\n" +
+			bridgeStartDelim("memories") + "\n### proj\n- [[m]]\n" + bridgeEndDelim("memories") + "\n\nafter\n"
+		os.WriteFile(anchor, []byte(content), 0o644)
+		if err := stripBridgeBlock(anchor, "memories"); err != nil {
+			t.Fatalf("strip: %v", err)
+		}
+		got := string(mustRead(t, anchor))
+		if strings.Contains(got, "mnemo:bridge:memories") {
+			t.Errorf("fence not stripped:\n%s", got)
+		}
+		if !strings.Contains(got, "before") || !strings.Contains(got, "after") {
+			t.Errorf("user content lost:\n%s", got)
+		}
+	})
+	t.Run("no-op when fence absent", func(t *testing.T) {
+		dir := t.TempDir()
+		anchor := filepath.Join(dir, "b.md")
+		os.WriteFile(anchor, []byte("just user content\n"), 0o644)
+		if err := stripBridgeBlock(anchor, "themes"); err != nil {
+			t.Fatalf("strip: %v", err)
+		}
+		if string(mustRead(t, anchor)) != "just user content\n" {
+			t.Error("file changed on no-op strip")
+		}
+	})
+	t.Run("missing file is nil", func(t *testing.T) {
+		if err := stripBridgeBlock(filepath.Join(t.TempDir(), "nope.md"), "themes"); err != nil {
+			t.Fatalf("strip missing: %v", err)
+		}
+	})
+}
+
+// ---- syncBridges integration (through Sync) --------------------------------
+
+// newBridgeExporter builds an Exporter over an empty store with a
+// tempdir state.json, ready to exercise bridge reconciliation.
+func newBridgeExporter(t *testing.T, bridges map[string]string) (*Exporter, string, string) {
+	t.Helper()
+	s := storetest.NewStore(t, t.TempDir())
+	if err := s.IngestAll(); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	vaultDir := t.TempDir()
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	exp, err := New(s, vaultDir, Options{
+		Layout:    store.VaultLayoutV2,
+		StatePath: statePath,
+		Bridges:   bridges,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return exp, vaultDir, statePath
+}
+
+func TestSyncBridgesWritesBlockAndTracksState(t *testing.T) {
+	exp, vaultDir, statePath := newBridgeExporter(t, map[string]string{
+		"decisions": "MOCs/Decisions.md",
+	})
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	anchor := filepath.Join(vaultDir, "MOCs", "Decisions.md")
+	got := string(mustRead(t, anchor))
+	if !strings.Contains(got, bridgeStartDelim("decisions")) {
+		t.Errorf("decisions bridge block not written:\n%s", got)
+	}
+	st, err := store.LoadState(statePath)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if st.WrittenBridges["decisions"] != "MOCs/Decisions.md" {
+		t.Errorf("WrittenBridges = %v, want decisions→MOCs/Decisions.md", st.WrittenBridges)
+	}
+}
+
+func TestSyncBridgesUnknownCollectionRecordsError(t *testing.T) {
+	exp, _, statePath := newBridgeExporter(t, map[string]string{
+		"notacollection": "X.md",
+	})
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	st, _ := store.LoadState(statePath)
+	if len(st.BridgeErrors) == 0 {
+		t.Fatal("expected a bridge error for unknown collection")
+	}
+	if st.BridgeErrors[0].Name != "notacollection" {
+		t.Errorf("error name = %q, want notacollection", st.BridgeErrors[0].Name)
+	}
+	if _, ok := st.WrittenBridges["notacollection"]; ok {
+		t.Error("unknown collection should not be recorded as written")
+	}
+}
+
+func TestSyncBridgesRemovedBridgeStripsBlock(t *testing.T) {
+	// First sync: bridge present.
+	exp, vaultDir, statePath := newBridgeExporter(t, map[string]string{
+		"decisions": "MOCs/Decisions.md",
+	})
+	if err := exp.Sync(context.Background()); err != nil {
+		t.Fatalf("first Sync: %v", err)
+	}
+	anchor := filepath.Join(vaultDir, "MOCs", "Decisions.md")
+	// Add user content below the block to prove it survives the strip.
+	prev := string(mustRead(t, anchor))
+	os.WriteFile(anchor, []byte(prev+"\nuser tail\n"), 0o644)
+
+	// Second exporter over the SAME vault + state, bridge removed.
+	s := storetest.NewStore(t, t.TempDir())
+	s.IngestAll()
+	exp2, err := New(s, vaultDir, Options{
+		Layout:    store.VaultLayoutV2,
+		StatePath: statePath,
+		Bridges:   nil, // removed
+	})
+	if err != nil {
+		t.Fatalf("New2: %v", err)
+	}
+	if err := exp2.Sync(context.Background()); err != nil {
+		t.Fatalf("second Sync: %v", err)
+	}
+	got := string(mustRead(t, anchor))
+	if strings.Contains(got, "mnemo:bridge:decisions") {
+		t.Errorf("removed bridge block not stripped:\n%s", got)
+	}
+	if !strings.Contains(got, "user tail") {
+		t.Errorf("user content lost during strip:\n%s", got)
+	}
+	st, _ := store.LoadState(statePath)
+	if _, ok := st.WrittenBridges["decisions"]; ok {
+		t.Error("removed bridge still tracked in WrittenBridges")
+	}
+}
+
+func mustRead(t *testing.T, path string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return b
+}

--- a/internal/vault/profile.go
+++ b/internal/vault/profile.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package vault
+
+import (
+	"strings"
+
+	"github.com/marcelocantos/mnemo/internal/store"
+)
+
+// Profile is the PKM-tool dialect the vault exporter renders for
+// (🎯T64.5). It governs tool-specific syntax — chiefly link form — so
+// every entity renderer can stay dialect-agnostic and call through the
+// profile instead of hard-coding Obsidian wikilinks.
+//
+// The zero value renders as generic (safe Markdown that every editor
+// understands).
+type Profile string
+
+const (
+	ProfileObsidian = Profile(store.VaultProfileObsidian)
+	ProfileLogseq   = Profile(store.VaultProfileLogseq)
+	ProfileFoam     = Profile(store.VaultProfileFoam)
+	ProfileGeneric  = Profile(store.VaultProfileGeneric)
+)
+
+// profileFrom maps a resolved config profile string to a Profile,
+// defaulting unknown/empty to generic. Config validation already
+// rejects typos, so the default only fires for the empty case.
+func profileFrom(s string) Profile {
+	switch s {
+	case store.VaultProfileObsidian:
+		return ProfileObsidian
+	case store.VaultProfileLogseq:
+		return ProfileLogseq
+	case store.VaultProfileFoam:
+		return ProfileFoam
+	default:
+		return ProfileGeneric
+	}
+}
+
+// Link renders a link to a vault page.
+//
+//   - target is the vault-relative page path WITHOUT the ".md"
+//     extension, using forward slashes (e.g. "_mnemo/themes/auth-redesign").
+//   - alias is the human-facing display text. It may be empty, in which
+//     case the link shows the target's own title/basename.
+//
+// The rendering differs per PKM dialect (see the design's profile
+// table):
+//
+//	| profile  | with alias        | without alias |
+//	|----------|-------------------|---------------|
+//	| obsidian | [[target|alias]]  | [[target]]    |
+//	| logseq   | [[target]]        | [[target]]    |
+//	| foam     | [[target]]        | [[target]]    |
+//	| generic  | [alias](target.md)| [target](target.md) |
+//
+// Logseq and Foam have no in-link alias syntax, so a meaningful alias is
+// dropped there — the linked page's own title carries the name. Obsidian
+// keeps the alias only when it adds information (differs from the target
+// basename), so graph view isn't cluttered with redundant [[x|x]].
+func (p Profile) Link(target, alias string) string {
+	target = strings.TrimSuffix(target, ".md")
+	switch p {
+	case ProfileObsidian:
+		if alias == "" || alias == pageBasename(target) {
+			return "[[" + target + "]]"
+		}
+		return "[[" + target + "|" + alias + "]]"
+	case ProfileLogseq, ProfileFoam:
+		// Bare wikilink; no in-link alias in these dialects.
+		return "[[" + target + "]]"
+	default: // ProfileGeneric — portable Markdown link.
+		display := alias
+		if display == "" {
+			display = target
+		}
+		return "[" + display + "](" + target + ".md)"
+	}
+}
+
+// pageBasename returns the final path segment of a forward-slash vault
+// page path, used to decide whether an Obsidian alias is redundant.
+func pageBasename(target string) string {
+	if i := strings.LastIndex(target, "/"); i >= 0 {
+		return target[i+1:]
+	}
+	return target
+}

--- a/internal/vault/profile_test.go
+++ b/internal/vault/profile_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Marcelo Cantos
+// SPDX-License-Identifier: Apache-2.0
+
+package vault
+
+import "testing"
+
+func TestProfileLink(t *testing.T) {
+	cases := []struct {
+		name    string
+		profile Profile
+		target  string
+		alias   string
+		want    string
+	}{
+		{"obsidian aliased", ProfileObsidian, "_mnemo/themes/auth-redesign", "Auth redesign", "[[_mnemo/themes/auth-redesign|Auth redesign]]"},
+		{"obsidian empty alias", ProfileObsidian, "_mnemo/themes/auth-redesign", "", "[[_mnemo/themes/auth-redesign]]"},
+		{"obsidian redundant alias == basename", ProfileObsidian, "_mnemo/themes/auth-redesign", "auth-redesign", "[[_mnemo/themes/auth-redesign]]"},
+		{"obsidian strips md suffix", ProfileObsidian, "decisions/x.md", "", "[[decisions/x]]"},
+		{"logseq drops alias", ProfileLogseq, "_mnemo/themes/auth-redesign", "Auth redesign", "[[_mnemo/themes/auth-redesign]]"},
+		{"foam drops alias", ProfileFoam, "_mnemo/themes/auth-redesign", "Auth redesign", "[[_mnemo/themes/auth-redesign]]"},
+		{"generic aliased markdown", ProfileGeneric, "_mnemo/themes/auth-redesign", "Auth redesign", "[Auth redesign](_mnemo/themes/auth-redesign.md)"},
+		{"generic no alias falls back to target", ProfileGeneric, "_mnemo/themes/auth-redesign", "", "[_mnemo/themes/auth-redesign](_mnemo/themes/auth-redesign.md)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.profile.Link(tc.target, tc.alias); got != tc.want {
+				t.Errorf("%s.Link(%q, %q) = %q, want %q", tc.profile, tc.target, tc.alias, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProfileFrom(t *testing.T) {
+	cases := map[string]Profile{
+		"obsidian": ProfileObsidian,
+		"logseq":   ProfileLogseq,
+		"foam":     ProfileFoam,
+		"generic":  ProfileGeneric,
+		"":         ProfileGeneric,
+		"bogus":    ProfileGeneric,
+	}
+	for in, want := range cases {
+		if got := profileFrom(in); got != want {
+			t.Errorf("profileFrom(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -109,6 +109,19 @@ type Exporter struct {
 	// state.json sidecar. Empty falls back to ~/.mnemo/state.json.
 	// Injectable for tests. (🎯T64.2)
 	statePath string
+
+	// profile is the resolved PKM dialect the exporter renders for
+	// (🎯T64.5). Empty (zero value) renders as generic. Governs link
+	// syntax via Profile.Link.
+	profile Profile
+
+	// bridges maps a bridge collection name to its vault-relative
+	// anchor file (🎯T64.6). Empty disables bridge writing.
+	bridges map[string]string
+
+	// bridgesMaxLinks caps the links a single bridge block emits.
+	// Zero renders as the store default.
+	bridgesMaxLinks int
 }
 
 // Options carries optional Exporter wiring. Each zero-valued field
@@ -127,6 +140,19 @@ type Options struct {
 	// StatePath overrides the ~/.mnemo/state.json sidecar location.
 	// Tests pass a tempdir path; production wiring leaves this empty.
 	StatePath string
+
+	// Profile selects the PKM dialect the exporter renders for (🎯T64.5).
+	// Empty defaults to generic. Use store.ResolvedVaultProfile to
+	// compute the value from the current Config + on-disk vault shape.
+	Profile string
+
+	// Bridges maps a bridge collection name to a vault-relative anchor
+	// file (🎯T64.6). Empty disables bridges. Pass cfg.VaultBridges.
+	Bridges map[string]string
+
+	// BridgesMaxLinks caps a bridge block's link count. Zero uses the
+	// store default. Pass cfg.ResolvedVaultBridgesMaxLinks().
+	BridgesMaxLinks int
 }
 
 // New creates a new Exporter rooted at path. The directory is created if
@@ -137,11 +163,14 @@ func New(backend store.Backend, path string, opts Options) (*Exporter, error) {
 		return nil, fmt.Errorf("vault: create root %s: %w", path, err)
 	}
 	return &Exporter{
-		backend:   backend,
-		path:      path,
-		layout:    opts.Layout,
-		soakWarn:  opts.SoakWarnAfter,
-		statePath: opts.StatePath,
+		backend:         backend,
+		path:            path,
+		layout:          opts.Layout,
+		soakWarn:        opts.SoakWarnAfter,
+		statePath:       opts.StatePath,
+		profile:         profileFrom(opts.Profile),
+		bridges:         opts.Bridges,
+		bridgesMaxLinks: opts.BridgesMaxLinks,
 	}, nil
 }
 

--- a/internal/vault/wing.go
+++ b/internal/vault/wing.go
@@ -102,6 +102,12 @@ func (e *Exporter) syncMnemoWing(ctx context.Context, now time.Time) {
 				st.MigrationDocWrittenAt = now.UTC()
 			}
 		}
+
+		// Bridges (🎯T64.6): reconcile configured bridges against anchor
+		// files + the written-bridge record. Runs even when no bridges
+		// are configured so a removed bridge's block is stripped. Mutates
+		// st (WrittenBridges + BridgeErrors); persisted by st.Write below.
+		e.syncBridges(st)
 	}
 
 	soak := e.effectiveSoakWarn()


### PR DESCRIPTION
## 🎯T64.5 + T64.6 — PKM profile detection + vault bridges

Builds on the merged vault wing MVP (#150/#151). Two orthogonal slices, both depending only on the already-shipped `vault_layout` machinery.

### T64.5 — PKM profile
- Detects the vault's PKM dialect (`obsidian` / `logseq` / `foam` / `generic`) from **canonical signal files** (`.obsidian/workspace.json`, `logseq/config/config.edn`, `.foam/settings.json`) — not mere directory presence.
- mtime-based auto-detect with a 1h tie-break window (obsidian → logseq → foam); `vault_profile` config override wins.
- `Profile.Link(target, alias)` emits the right wikilink/markdown syntax per dialect (Obsidian aliased `[[t|a]]`, Logseq/Foam bare `[[t]]`, generic `[a](t.md)`).
- Surfaced in `mnemo_vault_status` (profile + source + signal file).

### T64.6 — Bridges
- Injects fenced `<!-- mnemo:bridge:<name> -->` blocks into user-owned anchor files (MOCs), reconciled every sync.
- Collections: `themes`/`patterns`/`cross-repo`/`lessons`/`decisions`/`memories`. `decisions` + `memories` render live links now; the rest write empty blocks that light up when future slices land.
- All 7 design edge cases covered: missing file (create w/ header), fence absent (append), fence present (replace in place, honours user relocation), duplicate fences (leave untouched), removed-from-config (strip via `state.json` `written_bridges` tracking), relocated anchor (strip old + write new), unwritable anchor (soft-fail into `BridgeErrors`).
- Atomic writes (tempfile + fsync + rename). Per-bridge link cap (`vault_bridges_max_links`, default 50).
- New `mnemo_vault_bridge_list` tool + Bridges block in `mnemo_vault_status`.

### Schema / compatibility
- **No SQLite schema change.** Config is JSON; `state.json` gains one additive `written_bridges` field. Append-only contract intact.

### Tests
- `internal/vault/{profile,bridges}_test.go`, `internal/store/vault_profile_test.go` — all green.
- Full suite passes **except** pre-existing `TestQuery` (`sqldeep transpile: unmatched ')'`), unrelated to this branch (fails on clean master too).

### Deferred follow-ups (documented in commit)
- Logseq `prop::` properties hook.
- Route decision/memory note renderers through `Profile.Link`.
- Bridge `.tmpl` overrides (belongs to the template subsystem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
