### PR TITLE
🎯T112: Codex transcript fidelity (model, usage, parent chains)

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -542,6 +542,29 @@ targets:
     origin: 'conversation: deepen Grok beyond MVP; keep Codex in mind; prefer Grok-beyond-Claude signals'
     discovered: 2026-07-11
     achieved: 2026-07-11
+  T112:
+    name: Codex transcript fidelity matches Grok's searchable metadata density where the format allows
+    status: achieved
+    value: 8.0
+    cost: 3.0
+    acceptance:
+    - turn_context.model is stamped on subsequent entries so entries.model is populated
+    - event_msg/token_count produces a synthetic usage entry with input/output tokens and searchable [codex tokens] text
+    - session_meta.parent_thread_id (or forked_from_id) yields a session_chains edge with mechanism codex_parent or codex_fork
+    - session_meta.source.subagent yields session_type=subagent via project=subagents
+    - normalizeAgentToolInput maps cmd→command and flattens command arrays; used from Codex tool path
+    - docs/design/codex-ingest.md documents the fidelity layer; unit + e2e tests cover model, usage, chains, tool_command
+    context: Parallel to Grok 🎯T111. Codex MVP (T99) only indexed conversation+tools; this adds model/usage/parent-chain density without inventing Grok-only streams.
+    depends_on:
+    - T99
+    tags:
+    - ingest
+    - codex
+    - multi-source
+    - transcripts
+    origin: manual
+    discovered: 2026-07-14
+    achieved: 2026-07-14
   T12:
     name: GitHub activity (PRs, issues, reviews) indexed cross-repo with FTS and session correlation
     status: achieved

--- a/docs/design/codex-ingest.md
+++ b/docs/design/codex-ingest.md
@@ -1,12 +1,11 @@
-# Codex Transcript Ingest (MVP)
+# Codex Transcript Ingest
 
-*Status: design note — 2026-06-30. Anchors 🎯T99. Scope is deliberately
-narrow: capture Codex CLI session transcripts into the existing index,
-and not much else.*
+*Status: design note — 2026-06-30 (MVP 🎯T99); fidelity layer 2026-07-14
+(🎯T112, parallel to Grok 🎯T111).*
 
-**Tracking.** Design source for 🎯T99. Grounded in real rollout files on
-disk (`~/.codex`, `cli_version 0.140`) and source-verified against
-`openai/codex` at `codex-rs` HEAD (`rust-v0.142.4`, 2026-06-29).
+**Tracking.** Design source for 🎯T99 + 🎯T112. Grounded in real rollout
+files on disk (`~/.codex`) and source-verified against `openai/codex`
+`codex-rs` rollouts.
 
 ---
 
@@ -107,16 +106,29 @@ map the envelope + the handful of core `response_item` inner types and
 modelling every variant. Unknown → skip-and-continue, never fail the
 file. (Aligns with the external-input defensive-coding rules.)
 
-## Explicitly out of scope (MVP)
+## Fidelity layer (🎯T112)
+
+Parallel to Grok's T111: map Codex-native metadata into the same
+columns/tables Claude already uses where the format allows.
+
+| Codex signal | Mapping |
+|--------------|---------|
+| `turn_context.model` | Current model stamp on subsequent entries (`raw.message.model` → `entries.model`) |
+| `session_meta.parent_thread_id` | `session_chains` edge, `mechanism=codex_parent` |
+| `session_meta.forked_from_id` | `session_chains` edge, `mechanism=codex_fork` (if parent empty) |
+| `session_meta.source.subagent` | `project=subagents` → `session_type=subagent` |
+| `event_msg/token_count` | Synthetic assistant entry with usage + `[codex tokens]` text (noise); `last_token_usage` preferred over total |
+| tool `cmd` / `command` array | `normalizeAgentToolInput` → Claude `command` string for `tool_command` |
+
+### Still out of scope
 
 The four `~/.codex/*.sqlite` DBs (logs/memories/state/goals — the state
 DB is itself backfilled from the JSONL, which stays canonical);
 `~/.codex/history.jsonl` (global *input* keystroke history, not a
-transcript); decrypting `reasoning`; modelling Codex compaction /
-fork / `parent_thread_id` as chains; `event_msg` richness beyond
-optional `token_count`; any Codex-specific MCP / threads / decisions /
-images plumbing. **Just text + tool calls + tool results, attributed to
-a session / repo / timestamp, searchable.**
+transcript); decrypting `reasoning` beyond summary placeholders;
+`event_msg` UI echoes of `response_item` (would double-index);
+`compacted` / `world_state` / `inter_agent_*` bookkeeping; image
+pipeline; Codex-specific MCP / threads / decisions plumbing.
 
 ## Cross-check references
 

--- a/docs/design/grok-ingest.md
+++ b/docs/design/grok-ingest.md
@@ -150,8 +150,9 @@ as searchable text.
 | `task_completed` | tool_result-shaped text with exit/cmd/output | bg task completion |
 | `auto_compact_*` | thinking noise with token before/after | Grok-native compact markers |
 
-Codex reuses tool-input normalisation; session_type/model/usage adapters
-are the same extension points when Codex corpus grows.
+Codex reuses tool-input normalisation and, as of 🎯T112, the same
+session_type / model / usage / parent-chain extension points
+(`docs/design/codex-ingest.md` fidelity layer).
 
 ## Still out of scope
 

--- a/internal/store/codex.go
+++ b/internal/store/codex.go
@@ -1,11 +1,12 @@
-// Codex transcript ingest (🎯T99). OpenAI's Codex CLI records sessions
-// as "rollout" JSONL under ~/.codex/sessions/<YYYY>/<MM>/<DD>/ (and
-// ~/.codex/archived_sessions/). The format is the OpenAI Responses API
-// item stream wrapped in a thin {timestamp, type, payload} envelope —
-// structurally unlike Claude Code's schema. This file transforms each
-// rollout into the same parsedFile intermediate the Claude path
-// produces, so the shared writer (writeParsedFile) and the entire
-// search/session machinery are reused. See docs/design/codex-ingest.md.
+// Codex transcript ingest (🎯T99 MVP + 🎯T112 fidelity). OpenAI's Codex
+// CLI records sessions as "rollout" JSONL under ~/.codex/sessions/
+// <YYYY>/<MM>/<DD>/ (and ~/.codex/archived_sessions/). The format is the
+// OpenAI Responses API item stream wrapped in a thin
+// {timestamp, type, payload} envelope — structurally unlike Claude Code's
+// schema. This file transforms each rollout into the same parsedFile
+// intermediate the Claude path produces, so the shared writer
+// (writeParsedFile) and the entire search/session machinery are reused.
+// See docs/design/codex-ingest.md.
 package store
 
 import (
@@ -34,6 +35,7 @@ type codexLine struct {
 // subset and skip what we don't recognise.
 type codexPayload struct {
 	Type string `json:"type"` // for response_item: message | function_call | reasoning | ...
+	// for event_msg: token_count | user_message | agent_message | ...
 
 	// message
 	Role    string         `json:"role"`
@@ -53,9 +55,32 @@ type codexPayload struct {
 	EncryptedContent string         `json:"encrypted_content"`
 
 	// session_meta / turn_context
-	ID  string    `json:"id"`
-	Cwd string    `json:"cwd"`
-	Git *codexGit `json:"git"`
+	ID             string          `json:"id"`
+	SessionID      string          `json:"session_id"` // sometimes present alongside id
+	Cwd            string          `json:"cwd"`
+	Git            *codexGit       `json:"git"`
+	Model          string          `json:"model"`            // turn_context
+	ParentThreadID string          `json:"parent_thread_id"` // session_meta
+	ForkedFromID   string          `json:"forked_from_id"`   // session_meta
+	Source         json.RawMessage `json:"source"`           // string or {subagent:…}
+
+	// event_msg / token_count
+	Info *codexTokenInfo `json:"info"`
+}
+
+// codexTokenInfo is the subset of event_msg token_count we map into usage.
+type codexTokenInfo struct {
+	TotalTokenUsage    *codexTokenUsage `json:"total_token_usage"`
+	LastTokenUsage     *codexTokenUsage `json:"last_token_usage"`
+	ModelContextWindow int              `json:"model_context_window"`
+}
+
+type codexTokenUsage struct {
+	InputTokens           int `json:"input_tokens"`
+	CachedInputTokens     int `json:"cached_input_tokens"`
+	OutputTokens          int `json:"output_tokens"`
+	ReasoningOutputTokens int `json:"reasoning_output_tokens"`
+	TotalTokens           int `json:"total_tokens"`
 }
 
 type codexContent struct {
@@ -140,6 +165,9 @@ func parseCodexFile(path string, offset int64) (parsedFile, error) {
 	}
 
 	reader := bufio.NewReader(f)
+	// currentModel tracks the latest turn_context.model (🎯T112).
+	var currentModel string
+	var isSubagent bool
 
 	// handleLine parses one rollout envelope into pf. Guard clauses skip a
 	// line by returning rather than a loop `continue`, so the EOF / read-
@@ -151,24 +179,118 @@ func parseCodexFile(path string, offset int64) (parsedFile, error) {
 			return // tolerate junk / unknown lines, never fail the file
 		}
 
+		ts := cl.Timestamp
+		if ts == "" {
+			ts = time.Now().Format(time.RFC3339)
+		}
+
 		switch cl.Type {
-		case "session_meta", "turn_context":
-			// Header / per-turn bookkeeping: harvest session metadata,
-			// emit no entry. cwd and git appear here, nowhere per-record.
+		case "session_meta":
 			var p codexPayload
-			if json.Unmarshal(cl.Payload, &p) == nil {
-				if p.Cwd != "" && pf.cwd == "" {
-					pf.cwd = p.Cwd
-				}
-				if p.Git != nil && p.Git.Branch != "" && pf.branch == "" {
-					pf.branch = p.Git.Branch
+			if json.Unmarshal(cl.Payload, &p) != nil {
+				return
+			}
+			if p.Cwd != "" && pf.cwd == "" {
+				pf.cwd = p.Cwd
+			}
+			if p.Git != nil && p.Git.Branch != "" && pf.branch == "" {
+				pf.branch = p.Git.Branch
+			}
+			// Prefer explicit id; filename already set sessionID as fallback.
+			if p.ID != "" {
+				pf.sessionID = p.ID
+			} else if p.SessionID != "" && pf.sessionID == "" {
+				pf.sessionID = p.SessionID
+			}
+			// Parent/fork chains (🎯T112). parent_thread_id is the common
+			// multi-agent / guardian edge; forked_from_id is a true fork.
+			parent := p.ParentThreadID
+			mech := "codex_parent"
+			if parent == "" && p.ForkedFromID != "" {
+				parent = p.ForkedFromID
+				mech = "codex_fork"
+			}
+			if parent != "" && parent != pf.sessionID {
+				pf.parentSessionID = parent
+				pf.chainMechanism = mech
+			}
+			if codexSourceIsSubagent(p.Source) {
+				isSubagent = true
+			}
+			return
+
+		case "turn_context":
+			var p codexPayload
+			if json.Unmarshal(cl.Payload, &p) != nil {
+				return
+			}
+			if p.Cwd != "" && pf.cwd == "" {
+				pf.cwd = p.Cwd
+			}
+			if p.Model != "" {
+				currentModel = p.Model
+				if pf.model == "" {
+					pf.model = p.Model
 				}
 			}
 			return
+
+		case "event_msg":
+			// token_count → synthetic usage entry (🎯T112). Other event_msg
+			// types are UI echoes of response_item and would double-index.
+			var p codexPayload
+			if json.Unmarshal(cl.Payload, &p) != nil || p.Type != "token_count" || p.Info == nil {
+				return
+			}
+			usage := p.Info.LastTokenUsage
+			if usage == nil {
+				usage = p.Info.TotalTokenUsage
+			}
+			if usage == nil {
+				return
+			}
+			inTok := usage.InputTokens
+			outTok := usage.OutputTokens + usage.ReasoningOutputTokens
+			if inTok == 0 && outTok == 0 && usage.TotalTokens == 0 {
+				return
+			}
+			uuid := fmt.Sprintf("codex-%s-%d", pf.sessionID, thisStart)
+			text := fmt.Sprintf(
+				"[codex tokens] model=%s input=%d cached=%d output=%d reasoning=%d total=%d context_window=%d",
+				currentModel, usage.InputTokens, usage.CachedInputTokens,
+				usage.OutputTokens, usage.ReasoningOutputTokens, usage.TotalTokens,
+				p.Info.ModelContextWindow,
+			)
+			raw, _ := json.Marshal(map[string]any{
+				"uuid":      uuid,
+				"type":      "assistant",
+				"timestamp": ts,
+				"message": map[string]any{
+					"model": currentModel,
+					"usage": map[string]any{
+						"input_tokens":  inTok,
+						"output_tokens": outTok,
+					},
+				},
+				"source": "codex_token_count",
+				"text":   text,
+			})
+			entryIdx := len(pf.entries)
+			pf.entries = append(pf.entries, parsedRawEntry{
+				entryType: "assistant",
+				timestamp: ts,
+				raw:       raw,
+			})
+			pf.messages = append(pf.messages, parsedMessage{
+				entryIdx: entryIdx, role: "assistant", typ: "assistant",
+				text: text, timestamp: ts, contentType: "text", isNoise: 1,
+			})
+			return
+
 		case "response_item":
 			// conversation content — handled below
 		default:
-			return // event_msg, compacted, world_state, inter_agent_* …
+			return // compacted, world_state, inter_agent_* …
 		}
 
 		var p codexPayload
@@ -181,22 +303,18 @@ func parseCodexFile(path string, offset int64) (parsedFile, error) {
 			return
 		}
 
-		ts := cl.Timestamp
-		if ts == "" {
-			ts = time.Now().Format(time.RFC3339)
-		}
-
 		// Store the original envelope plus an injected synthetic uuid —
 		// Codex records carry none, and the entries.uuid generated
 		// column (raw->>'$.uuid') drives (session_id, uuid) dedup. The
 		// line's byte offset is a stable, content-independent
-		// discriminator, so re-ingest is idempotent.
+		// discriminator, so re-ingest is idempotent. Stamp model so
+		// entries.model is populated (🎯T112).
 		uuid := fmt.Sprintf("codex-%s-%d", pf.sessionID, thisStart)
 		entryIdx := len(pf.entries)
 		pf.entries = append(pf.entries, parsedRawEntry{
 			entryType: entryType,
 			timestamp: ts,
-			raw:       injectCodexUUID(line, uuid),
+			raw:       enrichCodexRaw(line, uuid, currentModel, 0, 0),
 		})
 
 		for _, m := range msgs {
@@ -235,8 +353,95 @@ func parseCodexFile(path string, offset int64) (parsedFile, error) {
 	}
 
 	pf.newOffset = consumed
-	pf.project = codexProject(pf.cwd)
+	// Subagent sessions keep project=subagents so session_summary.session_type
+	// classifies them (same SQL trigger path as Claude/Grok). Repo still
+	// comes from cwd via extractRepo on the meta write.
+	if isSubagent {
+		pf.project = "subagents"
+	} else {
+		pf.project = codexProject(pf.cwd)
+	}
+	if pf.model == "" {
+		pf.model = currentModel
+	}
 	return pf, nil
+}
+
+// codexSourceIsSubagent reports whether session_meta.source indicates a
+// subagent/guardian-style thread (object form {"subagent":…} or string
+// containing "subagent").
+func codexSourceIsSubagent(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return strings.Contains(strings.ToLower(s), "subagent")
+	}
+	var m map[string]any
+	if json.Unmarshal(raw, &m) == nil {
+		if _, ok := m["subagent"]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// enrichCodexRaw injects uuid + Claude-shaped message.model/usage so the
+// entries table generated columns (model, input_tokens, …) populate.
+// Mirrors enrichGrokRaw for the Codex envelope shape.
+func enrichCodexRaw(line []byte, uuid, model string, inTok, outTok int) []byte {
+	var m map[string]any
+	if json.Unmarshal(line, &m) != nil {
+		return injectCodexUUID(line, uuid)
+	}
+	m["uuid"] = uuid
+	// Prefer nesting under payload.message if present; else top-level message
+	// (Claude shape) so generated columns still find $.message.model.
+	var msg map[string]any
+	if payload, ok := m["payload"].(map[string]any); ok {
+		if existing, ok := payload["message"].(map[string]any); ok {
+			msg = existing
+		} else {
+			msg = map[string]any{}
+		}
+		if model != "" {
+			msg["model"] = model
+		}
+		if inTok > 0 || outTok > 0 {
+			msg["usage"] = map[string]any{
+				"input_tokens":  inTok,
+				"output_tokens": outTok,
+			}
+		}
+		if len(msg) > 0 {
+			payload["message"] = msg
+			m["payload"] = payload
+		}
+	}
+	// Also stamp top-level message for generated-column paths that expect
+	// Claude layout (entries.model is typically raw->>'$.message.model').
+	top, _ := m["message"].(map[string]any)
+	if top == nil {
+		top = map[string]any{}
+	}
+	if model != "" {
+		top["model"] = model
+	}
+	if inTok > 0 || outTok > 0 {
+		top["usage"] = map[string]any{
+			"input_tokens":  inTok,
+			"output_tokens": outTok,
+		}
+	}
+	if len(top) > 0 {
+		m["message"] = top
+	}
+	out, err := json.Marshal(m)
+	if err != nil {
+		return injectCodexUUID(line, uuid)
+	}
+	return out
 }
 
 // codexRecord maps one response_item payload to an entry type and its

--- a/internal/store/codex_test.go
+++ b/internal/store/codex_test.go
@@ -12,11 +12,12 @@ import (
 )
 
 const codexSessUUID = "019ee2a8-189f-7540-a035-1cc6ee7bd02f"
+const codexParentUUID = "019ee2a8-0000-0000-0000-0000000000aa"
 
 // codexFixtureLines returns a representative Codex rollout: header,
 // per-turn context, user/assistant messages, a function call + output,
-// an apply_patch custom tool call, encrypted reasoning, plus records we
-// must skip (a developer instruction message and an event_msg).
+// an apply_patch custom tool call, encrypted reasoning, token_count usage
+// (🎯T112), plus records we must skip (a developer instruction message).
 func codexFixtureLines(t *testing.T, cwd string) []byte {
 	t.Helper()
 	line := func(typ string, payload map[string]any) map[string]any {
@@ -24,9 +25,10 @@ func codexFixtureLines(t *testing.T, cwd string) []byte {
 	}
 	records := []map[string]any{
 		line("session_meta", map[string]any{
-			"id":  codexSessUUID,
-			"cwd": cwd,
-			"git": map[string]any{"branch": "main", "repository_url": "https://github.com/acme/webapp"},
+			"id":               codexSessUUID,
+			"cwd":              cwd,
+			"parent_thread_id": codexParentUUID,
+			"git":              map[string]any{"branch": "main", "repository_url": "https://github.com/acme/webapp"},
 		}),
 		line("turn_context", map[string]any{"cwd": cwd, "model": "gpt-5.5"}),
 		line("response_item", map[string]any{
@@ -41,10 +43,23 @@ func codexFixtureLines(t *testing.T, cwd string) []byte {
 			"type": "reasoning", "summary": []map[string]any{}, "encrypted_content": "gAAAAABopaque",
 		}),
 		line("response_item", map[string]any{
-			"type": "function_call", "name": "shell",
-			"arguments": `{"command":["go","build"]}`, "call_id": "call_1",
+			// Real Codex uses exec_command with cmd=string; also cover array form.
+			"type": "function_call", "name": "exec_command",
+			"arguments": `{"cmd":"go build ./...","workdir":"/tmp/webapp"}`, "call_id": "call_1",
 		}),
-		line("event_msg", map[string]any{"type": "token_count", "info": map[string]any{"total_tokens": 1234}}),
+		line("event_msg", map[string]any{
+			"type": "token_count",
+			"info": map[string]any{
+				"last_token_usage": map[string]any{
+					"input_tokens": 100, "cached_input_tokens": 40,
+					"output_tokens": 20, "reasoning_output_tokens": 5, "total_tokens": 125,
+				},
+				"total_token_usage": map[string]any{
+					"input_tokens": 100, "output_tokens": 25, "total_tokens": 125,
+				},
+				"model_context_window": 258400,
+			},
+		}),
 		line("response_item", map[string]any{
 			"type": "function_call_output", "call_id": "call_1", "output": "build succeeded",
 		}),
@@ -67,6 +82,13 @@ func codexFixtureLines(t *testing.T, cwd string) []byte {
 		b.WriteByte('\n')
 	}
 	return []byte(b.String())
+}
+
+func shellToolInput(m *parsedMessage) string {
+	if m == nil {
+		return ""
+	}
+	return string(m.toolInput)
 }
 
 func writeCodexRollout(t *testing.T, dir, cwd string) string {
@@ -111,13 +133,48 @@ func TestParseCodexFile(t *testing.T) {
 		t.Errorf("topic = %q, want first user message", pf.topic)
 	}
 
-	// 6 response_items map to entries; developer message, event_msg,
-	// session_meta and turn_context are dropped.
-	if len(pf.entries) != 6 {
-		t.Fatalf("entries = %d, want 6", len(pf.entries))
+	// 6 response_items + 1 token_count usage entry; developer message,
+	// session_meta and turn_context are not conversation entries.
+	if len(pf.entries) != 7 {
+		t.Fatalf("entries = %d, want 7", len(pf.entries))
 	}
-	if len(pf.messages) != 6 {
-		t.Fatalf("messages = %d, want 6", len(pf.messages))
+	if len(pf.messages) != 7 {
+		t.Fatalf("messages = %d, want 7", len(pf.messages))
+	}
+	if pf.parentSessionID != codexParentUUID {
+		t.Errorf("parentSessionID = %q, want %q", pf.parentSessionID, codexParentUUID)
+	}
+	if pf.chainMechanism != "codex_parent" {
+		t.Errorf("chainMechanism = %q, want codex_parent", pf.chainMechanism)
+	}
+	if pf.model != "gpt-5.5" {
+		t.Errorf("model = %q, want gpt-5.5", pf.model)
+	}
+	// Model stamped on conversation entries.
+	var sawModel bool
+	for _, e := range pf.entries {
+		var raw map[string]any
+		if json.Unmarshal(e.raw, &raw) != nil {
+			continue
+		}
+		if msg, _ := raw["message"].(map[string]any); msg != nil && msg["model"] == "gpt-5.5" {
+			sawModel = true
+			break
+		}
+	}
+	if !sawModel {
+		t.Error("expected message.model=gpt-5.5 on at least one entry")
+	}
+	// token_count → searchable usage note
+	var sawUsage bool
+	for _, m := range pf.messages {
+		if strings.Contains(m.text, "[codex tokens]") && strings.Contains(m.text, "input=100") {
+			sawUsage = true
+			break
+		}
+	}
+	if !sawUsage {
+		t.Error("expected [codex tokens] usage message from token_count")
 	}
 
 	// The first entry's raw must carry the injected synthetic uuid so
@@ -150,20 +207,21 @@ func TestParseCodexFile(t *testing.T) {
 		t.Errorf("missing user/assistant text messages (user=%v assistant=%v)", sawUser, sawAssistant)
 	}
 
-	// tool_use: shell with JSON args, and apply_patch with text input.
+	// tool_use: exec_command with cmd normalised to command, apply_patch text.
 	var shell, patch *parsedMessage
 	for i := range byType["tool_use"] {
 		m := &byType["tool_use"][i]
 		switch m.toolName {
-		case "shell":
+		case "exec_command", "shell":
 			shell = m
 		case "apply_patch":
 			patch = m
 		}
 	}
 	if shell == nil || shell.toolUseID != "call_1" || !json.Valid(shell.toolInput) ||
-		!strings.Contains(string(shell.toolInput), "command") {
-		t.Errorf("shell tool_use malformed: %+v", shell)
+		!strings.Contains(string(shell.toolInput), "command") ||
+		!strings.Contains(string(shell.toolInput), "go build") {
+		t.Errorf("shell tool_use malformed: %+v input=%s", shell, shellToolInput(shell))
 	}
 	if patch == nil || patch.toolUseID != "call_2" || patch.toolInput != nil ||
 		!strings.Contains(patch.text, "Begin Patch") {
@@ -222,8 +280,39 @@ func TestCodexIngestEndToEnd(t *testing.T) {
 		}
 		return n
 	}
-	if got := entryCount(); got != 6 {
-		t.Fatalf("entries after ingest = %d, want 6", got)
+	if got := entryCount(); got != 7 {
+		t.Fatalf("entries after ingest = %d, want 7 (incl. token_count)", got)
+	}
+
+	// Model + usage + parent chain (🎯T112).
+	var model string
+	if err := s.readDB.QueryRow(
+		`SELECT model FROM entries WHERE session_id = ? AND type = 'assistant' AND model IS NOT NULL AND model != '' LIMIT 1`,
+		codexSessUUID,
+	).Scan(&model); err != nil || model != "gpt-5.5" {
+		t.Errorf("model = %q err=%v", model, err)
+	}
+	var usageN int
+	if err := s.readDB.QueryRow(
+		`SELECT count(*) FROM messages WHERE session_id = ? AND text LIKE '%[codex tokens]%'`,
+		codexSessUUID,
+	).Scan(&usageN); err != nil || usageN < 1 {
+		t.Errorf("usage messages = %d err=%v", usageN, err)
+	}
+	var pred, mech string
+	if err := s.readDB.QueryRow(
+		`SELECT predecessor_id, mechanism FROM session_chains WHERE successor_id = ?`,
+		codexSessUUID,
+	).Scan(&pred, &mech); err != nil || pred != codexParentUUID || mech != "codex_parent" {
+		t.Errorf("chain pred=%q mech=%q err=%v", pred, mech, err)
+	}
+	// cmd → command normalisation surfaces in tool_command.
+	var cmd string
+	if err := s.readDB.QueryRow(
+		`SELECT tool_command FROM messages WHERE session_id = ? AND tool_name = 'exec_command' LIMIT 1`,
+		codexSessUUID,
+	).Scan(&cmd); err != nil || !strings.Contains(cmd, "go build") {
+		t.Errorf("tool_command = %q err=%v", cmd, err)
 	}
 
 	// Idempotency: re-ingesting the same rollout from offset 0 must not
@@ -237,7 +326,7 @@ func TestCodexIngestEndToEnd(t *testing.T) {
 	if err := s.ingestCodexFile(path); err != nil {
 		t.Fatal(err)
 	}
-	if got := entryCount(); got != 6 {
-		t.Errorf("entries after re-ingest = %d, want 6 (dedup)", got)
+	if got := entryCount(); got != 7 {
+		t.Errorf("entries after re-ingest = %d, want 7 (dedup)", got)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3209,11 +3209,11 @@ func (s *Store) writeParsedFile(ws *writerState, pf parsedFile) {
 				source = CASE WHEN excluded.source != '' THEN excluded.source ELSE session_meta.source END`,
 			pf.sessionID, repo, pf.cwd, pf.branch, workType, pf.topic, compactorInternal, source)
 
-		// Parent/fork and subagent edges (Grok summary + spawn events, 🎯T111).
+		// Parent/fork and subagent edges (Grok 🎯T111, Codex 🎯T112).
 		if pf.parentSessionID != "" && pf.sessionID != "" {
 			mech := pf.chainMechanism
 			if mech == "" {
-				mech = "grok_parent"
+				mech = "parent"
 			}
 			_, _ = ws.tx.Exec(`
 			INSERT OR IGNORE INTO session_chains

--- a/internal/store/tool_input.go
+++ b/internal/store/tool_input.go
@@ -5,11 +5,18 @@
 // file-path queries work across sources.
 package store
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // normalizeAgentToolInput rewrites common alias keys onto the Claude
 // vocabulary expected by messages.tool_* generated columns. Unknown
 // keys are preserved. Non-object inputs pass through unchanged.
+//
+// Also flattens command/cmd when the value is a JSON array of strings
+// (Codex shell often uses {"cmd":"…"} or {"command":["go","test"]}) so
+// tool_command is a single searchable string.
 func normalizeAgentToolInput(raw []byte) []byte {
 	if len(raw) == 0 || !isJSONObject(raw) {
 		return raw
@@ -31,11 +38,14 @@ func normalizeAgentToolInput(raw []byte) []byte {
 	if _, ok := m["command"]; !ok {
 		for _, alias := range []string{"cmd", "shell_command"} {
 			if v, ok := m[alias]; ok && v != nil && v != "" {
-				m["command"] = v
+				m["command"] = flattenStringOrArray(v)
 				changed = true
 				break
 			}
 		}
+	} else if flat := flattenStringOrArray(m["command"]); flat != m["command"] {
+		m["command"] = flat
+		changed = true
 	}
 	if !changed {
 		return raw
@@ -45,4 +55,24 @@ func normalizeAgentToolInput(raw []byte) []byte {
 		return raw
 	}
 	return out
+}
+
+// flattenStringOrArray joins a string-array command into a single string;
+// strings pass through. Other types return as-is.
+func flattenStringOrArray(v any) any {
+	switch x := v.(type) {
+	case string:
+		return x
+	case []any:
+		parts := make([]string, 0, len(x))
+		for _, el := range x {
+			if s, ok := el.(string); ok {
+				parts = append(parts, s)
+			}
+		}
+		if len(parts) == len(x) {
+			return strings.Join(parts, " ")
+		}
+	}
+	return v
 }

--- a/internal/store/tool_input_test.go
+++ b/internal/store/tool_input_test.go
@@ -39,4 +39,13 @@ func TestNormalizeAgentToolInput(t *testing.T) {
 	if m3["file_path"] != "/a" {
 		t.Errorf("should keep existing file_path, got %v", m3["file_path"])
 	}
+
+	// Codex-style command array → space-joined string
+	in4 := []byte(`{"command":["go","test","./..."]}`)
+	out4 := normalizeAgentToolInput(in4)
+	var m4 map[string]any
+	_ = json.Unmarshal(out4, &m4)
+	if m4["command"] != "go test ./..." {
+		t.Errorf("command array flatten = %v", m4["command"])
+	}
 }


### PR DESCRIPTION
## Summary

**🎯T112** — Codex transcript fidelity (parallel to Grok T111):

- Stamp `turn_context.model` onto entries (`entries.model`)
- Map `event_msg/token_count` → synthetic usage entry + `[codex tokens]` text
- `parent_thread_id` / `forked_from_id` → `session_chains` (`codex_parent` / `codex_fork`)
- Subagent `source` → `project=subagents`
- `cmd` / command-array → `tool_command` via shared `normalizeAgentToolInput`
- Design: `docs/design/codex-ingest.md` fidelity section

## Test plan

- [x] `go test -tags sqlite_fts5 ./internal/store/ -run Codex`
- [x] `make bullseye`
- [ ] win-validate / Ubuntu CI
