### PR TITLE
Codex transcript fidelity (version bump)

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ var agentsGuide string
 var dashboardHTML []byte
 
 const (
-	version              = "0.65.0"
+	version              = "0.66.0"
 	defaultAddr          = ":19419"
 	defaultFederatedAddr = ":19420"
 


### PR DESCRIPTION
## Summary
Version **0.66.0** for Codex transcript fidelity (🎯T112, already on master via #153).

## Test plan
- [x] version string only
- [ ] Ubuntu CI + win-validate
